### PR TITLE
Integrate shipping calculator with graphql resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Change _ProductPrice_'s installments logic.
-
-### Changed
 - Merge _TechnicalSpecifications_ Component with _ProductDescription_.
+- Integration of the `ShippingComponent` with graphql.
 
 ## [1.2.0] - 2018-05-24
 ### Added

--- a/react/components/ShippingSimulator/README.md
+++ b/react/components/ShippingSimulator/README.md
@@ -8,12 +8,17 @@ import ShippingSimulator from 'vtex.store-components/ShippingSimulator'
 
 ## Usage
 You can use it in your code like a React component with the jsx tag: `<ShippingSimulator />`. 
-```html
-<ShippingSimulator />
+
+```jsx
+<ShippingSimulator
+  skuId="3"
+  seller="1"
+/>
 ```
 
-| Prop name          | Type      | Description                                                          |
-| ------------------ | --------- | -------------------------------------------------------------------- |
-| `label`            | `Object`  | Shows input title of component                                       |
+| Prop name          | Type      | Description                   |
+| ------------------ | --------- | ----------------------------- |
+| `skuId`            | `String!` | Id of the current product SKU |
+| `seller`           | `String!` | Id of the product seller      |
 
 See an example at [Product Details](https://github.com/vtex-apps/product-details/blob/master/react/ProductDetails.js#L71) app

--- a/react/components/ShippingSimulator/components/ShippingTable.js
+++ b/react/components/ShippingSimulator/components/ShippingTable.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
 
 import ShippingTableRow from './ShippingTableRow'
 
@@ -30,6 +31,16 @@ export default class ShippingTable extends Component {
       (slas, info) => [...slas, ...info.slas],
       []
     )
+
+    if (slaList.length === 0) {
+      return (
+        <FormattedMessage id="shipping.empty-sla">
+          {text => (
+            <span className="vtex-shipping__no-shipping-message">{text}</span>
+          )}
+        </FormattedMessage>
+      )
+    }
 
     return (
       <table className="vtex-shipping-table">

--- a/react/components/ShippingSimulator/components/ShippingTable.js
+++ b/react/components/ShippingSimulator/components/ShippingTable.js
@@ -6,21 +6,36 @@ import ShippingTableRow from './ShippingTableRow'
 export default class ShippingTable extends Component {
   static propTypes = {
     /** Placeholder */
-    shippingOptionList: PropTypes.any,
+    shipping: PropTypes.shape({
+      logisticsInfo: PropTypes.arrayOf(PropTypes.shape({
+        itemIndex: PropTypes.string,
+        slas: PropTypes.arrayOf(PropTypes.shape({
+          id: PropTypes.string,
+          name: PropTypes.string,
+          price: PropTypes.number,
+          shippingEstimate: PropTypes.string,
+        })),
+      })),
+    }),
   }
 
   render() {
-    const { shippingOptionList } = this.props
+    const { shipping } = this.props
 
-    if (shippingOptionList.length === 0) {
+    if (!shipping || !shipping.logisticsInfo || shipping.logisticsInfo.length === 0) {
       return null
     }
+
+    const slaList = shipping.logisticsInfo.reduce(
+      (slas, info) => [...slas, ...info.slas],
+      []
+    )
 
     return (
       <table className="vtex-shipping-table">
         <tbody>
-          {shippingOptionList.map(shipping => (
-            <ShippingTableRow key={shipping.name} {...shipping} />
+          {slaList.map(shipping => (
+            <ShippingTableRow key={shipping.id} {...shipping} />
           ))}
         </tbody>
       </table>

--- a/react/components/ShippingSimulator/components/ShippingTable.js
+++ b/react/components/ShippingSimulator/components/ShippingTable.js
@@ -6,7 +6,7 @@ import ShippingTableRow from './ShippingTableRow'
 
 export default class ShippingTable extends Component {
   static propTypes = {
-    /** Placeholder */
+    /** Shipping informations */
     shipping: PropTypes.shape({
       logisticsInfo: PropTypes.arrayOf(PropTypes.shape({
         itemIndex: PropTypes.string,

--- a/react/components/ShippingSimulator/components/ShippingTableRow.js
+++ b/react/components/ShippingSimulator/components/ShippingTableRow.js
@@ -31,7 +31,7 @@ const ShippingTableRow = ({ name, shippingEstimate, price, intl }) => {
   return (
     <tr key={name}>
       <td className="vtex-shipping-table__cell">
-        <label>
+        <label className="vtex-shipping-table__shipping-name-label">
           <input
             className="vtex-shipping-table__radio-input"
             name="shipping-option"

--- a/react/components/ShippingSimulator/components/ShippingTableRow.js
+++ b/react/components/ShippingSimulator/components/ShippingTableRow.js
@@ -3,29 +3,29 @@ import PropTypes from 'prop-types'
 import { intlShape, injectIntl } from 'react-intl'
 import classNames from 'classnames'
 
-const ShippingTableRow = ({ name, eta, value, intl }) => {
+const ShippingTableRow = ({ name, shippingEstimate, price, intl }) => {
   const etaClassName = classNames('vtex-shipping-table__cell', {
-    'vtex-shipping-table__cell--center': eta === undefined,
+    'vtex-shipping-table__cell--center': shippingEstimate === undefined,
   })
 
   const valueClassName = classNames('vtex-shipping-table__cell', {
-    'vtex-shipping-table__cell--center': value === undefined,
+    'vtex-shipping-table__cell--center': price === undefined,
   })
 
   let etaText, valueText
 
-  if (eta === undefined) {
+  if (shippingEstimate === undefined) {
     etaText = '-'
   } else {
-    etaText = intl.formatMessage({ id: 'shipping.eta' }, { eta })
+    etaText = intl.formatMessage({ id: 'shipping.eta' }, { eta: shippingEstimate })
   }
 
-  if (value === undefined) {
+  if (price === undefined) {
     valueText = '-'
-  } else if (value === 0) {
+  } else if (price === 0) {
     valueText = intl.formatMessage({ id: 'shipping.free' })
   } else {
-    valueText = intl.formatNumber(value, { style: 'currency', currency: 'BRL' })
+    valueText = intl.formatNumber(price, { style: 'currency', currency: 'BRL' })
   }
 
   return (
@@ -54,8 +54,8 @@ const ShippingTableRow = ({ name, eta, value, intl }) => {
 
 ShippingTableRow.propTypes = {
   name: PropTypes.string,
-  eta: PropTypes.number,
-  value: PropTypes.number,
+  shippingEstimate: PropTypes.number,
+  price: PropTypes.number,
   intl: intlShape.isRequired,
 }
 

--- a/react/components/ShippingSimulator/components/ShippingTableRow.js
+++ b/react/components/ShippingSimulator/components/ShippingTableRow.js
@@ -54,7 +54,7 @@ const ShippingTableRow = ({ name, shippingEstimate, price, intl }) => {
 
 ShippingTableRow.propTypes = {
   name: PropTypes.string,
-  shippingEstimate: PropTypes.number,
+  shippingEstimate: PropTypes.string,
   price: PropTypes.number,
   intl: intlShape.isRequired,
 }

--- a/react/components/ShippingSimulator/global.css
+++ b/react/components/ShippingSimulator/global.css
@@ -3,30 +3,30 @@
   display: flex;
   align-items: center;
   color: #828282;
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
-.vtex-shipping-simulator__input {
+.vtex-shipping-simulator .vtex-input {
   height: 100%;
   margin-left: 10px;
-  padding: 2px 5px;
-  font-size: 12px;
-  color: #4f4f4f;
+}
 
+.vtex-shipping-simulator .vtex-input input {
+  padding: 2px 5px;
+  color: #4f4f4f;
   border: 1px solid #bdbdbd;
   border-radius: 2px;
+  height: 100%;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.vtex-shipping-simulator__cta {
+.vtex-shipping-simulator .vtex-button {
   height: 100%;
   width: 26px;
+  font-size: inherit;
   background-color: #e0e0e0;
   padding: 6px 2px;
-  color: inherit;
-  font-size: inherit;
-
   border: 1px solid #bdbdbd;
   border-left: none;
   border-radius: 2px;
@@ -35,16 +35,17 @@
 }
 
 .vtex-shipping-table {
-  border-top: 1px solid #828282;
-  border-bottom: 1px solid #828282;
+  width: 100%;
+  border-bottom: 1px solid #bdbdbd;
+  background-color: rgba(0, 0, 0, 0.05);
   color: #828282;
-  font-size: 12px;
-  margin: 15px 0;
+  margin-top: 7px;
   padding: 5px 0;
 }
 
 .vtex-shipping-table__cell {
   padding: 2px 10px;
+  font-size: 0.75rem;
 }
 
 .vtex-shipping-table__cell--center {

--- a/react/components/ShippingSimulator/global.css
+++ b/react/components/ShippingSimulator/global.css
@@ -2,8 +2,14 @@
   height: 26px;
   display: flex;
   align-items: center;
-  color: #828282;
-  font-size: 0.75rem;
+  color: #4F4F4F;
+  font-size: 0.875rem;
+}
+
+.vtex-shipping-simulator__zipcode-label {
+  display: flex;
+  align-items: center;
+  height: 100%;
 }
 
 .vtex-shipping-simulator .vtex-input {
@@ -35,21 +41,24 @@
 }
 
 .vtex-shipping-table {
-  width: 100%;
+  border-top: 1px solid #bdbdbd;
   border-bottom: 1px solid #bdbdbd;
-  background-color: rgba(0, 0, 0, 0.05);
-  color: #828282;
+  color: #4F4F4F;
   margin-top: 7px;
   padding: 5px 0;
 }
 
 .vtex-shipping-table__cell {
   padding: 2px 10px;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
 }
 
 .vtex-shipping-table__cell--center {
   text-align: center;
+}
+
+.vtex-shipping-table__shipping-name-label {
+  font-weight: bold;
 }
 
 .vtex-shipping-table__radio-input {
@@ -58,6 +67,6 @@
 
 .vtex-shipping__no-shipping-message {
   display: inline-block;
-  font-size: 12px;
+  font-size: 0.875rem;
   margin-top: 7px;
 }

--- a/react/components/ShippingSimulator/global.css
+++ b/react/components/ShippingSimulator/global.css
@@ -56,3 +56,8 @@
   margin-right: 15px; 
 }
 
+.vtex-shipping__no-shipping-message {
+  display: inline-block;
+  font-size: 12px;
+  margin-top: 7px;
+}

--- a/react/components/ShippingSimulator/index.js
+++ b/react/components/ShippingSimulator/index.js
@@ -1,3 +1,4 @@
+/* global __RUNTIME__ */
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
@@ -60,7 +61,7 @@ class ShippingSimulator extends Component {
     this.props.client.query({
       query: getShippingEstimates,
       variables: {
-        country: 'BRA', // TODO @lucasecdb: get country of user instead of hard-coding
+        country: __RUNTIME__.hints.country,
         postalCode: this.state.zipcodeValue,
         items: [
           {

--- a/react/components/ShippingSimulator/index.js
+++ b/react/components/ShippingSimulator/index.js
@@ -21,7 +21,7 @@ class ShippingSimulator extends Component {
     intl: intlShape.isRequired,
     client: PropTypes.object,
     skuId: PropTypes.string.isRequired,
-    sellerId: PropTypes.string.isRequired,
+    seller: PropTypes.string.isRequired,
   }
 
   state = {
@@ -51,7 +51,7 @@ class ShippingSimulator extends Component {
   handleClick = e => {
     e.preventDefault()
 
-    const { skuId, sellerId } = this.props
+    const { skuId, seller } = this.props
 
     this.setState({
       loading: true,
@@ -66,7 +66,7 @@ class ShippingSimulator extends Component {
           {
             quantity: '1',
             id: skuId,
-            seller: sellerId,
+            seller,
           },
         ],
       },

--- a/react/components/ShippingSimulator/index.js
+++ b/react/components/ShippingSimulator/index.js
@@ -1,4 +1,3 @@
-/* global __RUNTIME__ */
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
@@ -22,7 +21,8 @@ class ShippingSimulator extends Component {
     intl: intlShape.isRequired,
     client: PropTypes.object,
     skuId: PropTypes.string.isRequired,
-    seller: PropTypes.string.isRequired,
+    seller: PropTypes.number.isRequired,
+    country: PropTypes.string.isRequired,
   }
 
   state = {
@@ -52,7 +52,7 @@ class ShippingSimulator extends Component {
   handleClick = e => {
     e.preventDefault()
 
-    const { skuId, seller } = this.props
+    const { skuId, seller, country } = this.props
 
     this.setState({
       loading: true,
@@ -61,7 +61,7 @@ class ShippingSimulator extends Component {
     this.props.client.query({
       query: getShippingEstimates,
       variables: {
-        country: __RUNTIME__.hints.country,
+        country,
         postalCode: this.state.zipcodeValue,
         items: [
           {
@@ -93,15 +93,17 @@ class ShippingSimulator extends Component {
 
     return (
       <Fragment>
-        <label className="vtex-shipping-simulator f7">
-          {this.formatMessage('shipping.label')}
-          <Input
-            className="vtex-shipping-simulator__input"
-            name="zipcode"
-            type="text"
-            onChange={this.handleChange}
-            value={zipcodeValue}
-          />
+        <form className="vtex-shipping-simulator">
+          <label className="vtex-shipping-simulator__zipcode-label">
+            {this.formatMessage('shipping.label')}
+            <Input
+              className="vtex-shipping-simulator__input"
+              name="zipcode"
+              type="text"
+              onChange={this.handleChange}
+              value={zipcodeValue}
+            />
+          </label>
           <Button
             className="vtex-shipping-simulator__cta"
             onClick={this.handleClick}
@@ -110,7 +112,7 @@ class ShippingSimulator extends Component {
           >
             OK
           </Button>
-        </label>
+        </form>
 
         <ShippingTable shipping={shipping} />
       </Fragment>

--- a/react/components/ShippingSimulator/queries/getShippingEstimates.gql
+++ b/react/components/ShippingSimulator/queries/getShippingEstimates.gql
@@ -1,0 +1,15 @@
+query getShippingEstimates($items: [ShippingItem], $postalCode: String, $country: String) {
+  shipping(items: $items, postalCode: $postalCode, country: $country) {
+    logisticsInfo {
+      itemIndex
+      slas {
+        id
+        name
+        price
+        shippingEstimate
+        shippingEstimateDate
+      }
+    }
+  }
+}
+

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -14,6 +14,7 @@
   "shipping.label": "Calculate shipping",
   "shipping.eta": "up to {eta} days",
   "shipping.free": "Free",
+  "shipping.empty-sla": "There's no shipping information available for the informed zip code",
   "buybutton.add-failure":
     "Something went wrong and the item wasn't added to your cart!",
   "technicalspecifications.title": "Technical Specifications",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -14,6 +14,7 @@
   "shipping.label": "Calcular el flete",
   "shipping.eta": "hasta {eta} días",
   "shipping.free": "Gratis",
+  "shipping.empty-sla": "No hay información de envío disponible para el código postal informado",
   "buybutton.add-failure":
     "¡Algo salió mal y el artículo no se agregó a tu carrito!",
   "technicalspecifications.title": "Especificaciones Tecnicas",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -14,6 +14,7 @@
   "shipping.label": "Calcular o frete",
   "shipping.eta": "até {eta} dias",
   "shipping.free": "Grátis",
+  "shipping.empty-sla": "Não existe um frete disponível para o CEP informado",
   "buybutton.add-failure":
     "Algo deu errado e o item não pode ser adicionado ao seu carrinho!",
   "technicalspecifications.title": "Especificações Técnicas",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Integrate the `ShippingSimulator` component with the newest release of `store-graphql` and use real data from the backend.

#### What problem is this solving?
The component was using only mocked data.

#### How should this be manually tested?
Access my [workspace](https://lucas--storecomponents.myvtex.com/porsche-911/p), the id of the product (used for the query) is mocked in the workspace, but not in the pull request.

#### Screenshots or example usage
<img width="693" alt="screen shot 2018-05-29 at 16 14 23" src="https://user-images.githubusercontent.com/10223856/40680116-759c7d68-635b-11e8-919f-81a6877939e6.png">

```jsx
<ShippingCalculator
  skuId="3" // These props are part of the new component api
  seller="1"
/>
```

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
