### PR TITLE
Fix image centralization of SKU Selector Items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- Vertically centralization of SKU Selector Items.
+
 ### Added
 - Inner zoom image to the product image.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Vertically centralization of SKU Selector Items.
+- Vertical centralization of SKU Selector Items.
 
 ### Added
 - Inner zoom image to the product image.

--- a/react/components/SKUSelector/components/SelectorItem.js
+++ b/react/components/SKUSelector/components/SelectorItem.js
@@ -16,7 +16,7 @@ class SelectorItem extends PureComponent {
 
   render() {
     return (
-      <div className={`${VTEXClasses.SELECTOR__ITEM} di ba bw1 pointer ${this.props.isSelected ? 'b--black' : 'b--transparent'}`} onClick={this.handleClick}>
+      <div className={`${VTEXClasses.SELECTOR__ITEM} di ba bw1 pointer flex items-center ${this.props.isSelected ? 'b--blue' : 'b--transparent'}`} onClick={this.handleClick}>
         { this.props.children }
       </div>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix image centralization of SKU Selector Items.

#### What problem is this solving?
Images of SKU Selector Items was not centered vertically.

#### How should this be manually tested?

#### Screenshots or example usage
<a href="https://gustavo--storecomponents.myvtex.com/porsche-911/p">Workspace</a>
![captura de tela de 2018-06-04 16-53-58](https://user-images.githubusercontent.com/9275109/40938315-ebf7d08c-6817-11e8-8e5b-7d0ffe9f2099.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
