### PR TITLE
Logo component integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- Vertically centralization of SKU Selector Items.
+
 ### Added
 - Inner zoom image to the product image.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Inner zoom image to the product image.
+- Max height of the logo image
 
 ## [1.3.2] - 2018-5-31
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Vertically centralization of SKU Selector Items.
+- Vertical centralization of SKU Selector Items.
 
 ### Added
 - Inner zoom image to the product image.

--- a/react/components/Logo/global.css
+++ b/react/components/Logo/global.css
@@ -1,0 +1,3 @@
+.vtex-logo {
+  max-height: 45px;
+}

--- a/react/components/Logo/index.js
+++ b/react/components/Logo/index.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
+import './global.css'
+
 /**
  * Logo of the store
  */
@@ -11,13 +13,14 @@ export default class Logo extends Component {
     /** Title to be displayed as alt text */
     title: PropTypes.string.isRequired,
   }
+
   static defaultProps = {
-    url: 'http://',
+    url: 'http://brand.vtex.com/static/media/logo.2f3fc60b.svg',
     title: 'VTEX logo',
   }
+  
   render() {
     const { url, title } = this.props
-
     return <img className="vtex-logo" src={url} alt={title} />
   }
 }

--- a/react/components/SKUSelector/components/SelectorItem.js
+++ b/react/components/SKUSelector/components/SelectorItem.js
@@ -16,7 +16,7 @@ class SelectorItem extends PureComponent {
 
   render() {
     return (
-      <div className={`${VTEXClasses.SELECTOR__ITEM} di ba bw1 pointer ${this.props.isSelected ? 'b--black' : 'b--transparent'}`} onClick={this.handleClick}>
+      <div className={`${VTEXClasses.SELECTOR__ITEM} di ba bw1 pointer flex items-center ${this.props.isSelected ? 'b--blue' : 'b--transparent'}`} onClick={this.handleClick}>
         { this.props.children }
       </div>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Integrate the logo component to the store.

#### What problem is this solving?
Store was showing the label "storecomponents" instead of the logo.

#### How should this be manually tested?

#### Screenshots or example usage
<a href="https://gustavo--storecomponents.myvtex.com/">Workspace</a>

![captura de tela de 2018-06-05 17-25-01](https://user-images.githubusercontent.com/9275109/41000870-c33415e2-68e5-11e8-9f48-718e512d0360.png)

![captura de tela de 2018-06-05 17-25-32](https://user-images.githubusercontent.com/9275109/41000883-cc1a9de8-68e5-11e8-9443-35bb1c0ff788.png)

![captura de tela de 2018-06-05 17-25-25](https://user-images.githubusercontent.com/9275109/41000882-cacba6ee-68e5-11e8-829f-630e19c328e8.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
