### PR TITLE
Put ProductPrice schema inside the ProductPrice Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a title to the _Share_ Component share url.
 
 ### Fixed
-- `SKU Selector` with a different item selected on entering the product page
+- _SKU Selector_ with a different item selected on entering the product page
+- Put the _ProductPrice_ schema inside it's Component.
 
 ## [1.4.0] - 2018-6-6
 ### Added

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -19,6 +19,7 @@ class Price extends Component {
     showListPrice: true,
     showLabels: true,
     showInstallments: false,
+    showSavings: false,
   }
 
   currencyOptions = {
@@ -158,4 +159,34 @@ class Price extends Component {
   }
 }
 
-export default injectIntl(Price)
+const priceComponent = injectIntl(Price)
+
+priceComponent.schema = {
+  title: 'Price',
+  description: "Product's price Component",
+  type: 'object',
+  properties: {
+    showListPrice: {
+      type: 'boolean',
+      title: "Show product's list price",
+      default: Price.defaultProps.showListPrice,
+    },
+    showLabels: {
+      type: 'boolean',
+      title: "Show product's prices' labels",
+      default: Price.defaultProps.showLabels,
+    },
+    showInstallments: {
+      type: 'boolean',
+      title: "Show product's payment installments",
+      default: Price.defaultProps.showInstallments,
+    },
+    showSavings: {
+      type: 'boolean',
+      title: "Show product's list and selling price difference",
+      default: Price.defaultProps.showSavings,
+    },
+  },
+}
+
+export default priceComponent

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -162,28 +162,28 @@ class Price extends Component {
 const priceComponent = injectIntl(Price)
 
 priceComponent.schema = {
-  title: 'Price',
-  description: "Product's price Component",
+  title: 'editor.product-price.title',
+  description: 'editor.product-price.description',
   type: 'object',
   properties: {
     showListPrice: {
       type: 'boolean',
-      title: "Show product's list price",
+      title: 'editor.product-price.show-list-price',
       default: Price.defaultProps.showListPrice,
     },
     showLabels: {
       type: 'boolean',
-      title: "Show product's prices' labels",
+      title: 'editor.product-price.show-labels',
       default: Price.defaultProps.showLabels,
     },
     showInstallments: {
       type: 'boolean',
-      title: "Show product's payment installments",
+      title: 'editor.product-price.show-installments',
       default: Price.defaultProps.showInstallments,
     },
     showSavings: {
       type: 'boolean',
-      title: "Show product's list and selling price difference",
+      title: 'editor.product-price.show-savings',
       default: Price.defaultProps.showSavings,
     },
   },

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -1,11 +1,16 @@
 {
+  "editor.product-price.title": "Product price",
+  "editor.product-price.description": "Product price Component",
+  "editor.product-price.show-list-price": "Show product's list price",
+  "editor.product-price.show-labels": "Show product's prices' labels",
+  "editor.product-price.show-installments": "Show product's payment installments",
+  "editor.product-price.show-savings": "Show product's list and selling price difference",
   "product-description.title": "Product Description",
   "social-networks": "Social Networks",
   "section-links": "Links",
   "more-information-links": "More Information",
   "payment-form": "Payment Forms",
-  "pricing.installment-display":
-    "Or {installments} {times} of {installmentPrice}",
+  "pricing.installment-display": "Or {installments} {times} of {installmentPrice}",
   "pricing.from": "From",
   "pricing.to": "To",
   "pricing.savings": "Save: {savings}",
@@ -15,8 +20,7 @@
   "shipping.eta": "up to {eta} days",
   "shipping.free": "Free",
   "shipping.empty-sla": "There's no shipping information available for the informed zip code",
-  "buybutton.add-failure":
-    "Something went wrong and the item wasn't added to your cart!",
+  "buybutton.add-failure": "Something went wrong and the item wasn't added to your cart!",
   "technicalspecifications.title": "Technical Specifications",
   "availability-subscriber.title": "This product isn't available right now",
   "availability-subscriber.subscribe-label": "Let me know when this product is available again",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -1,11 +1,16 @@
 {
+  "editor.product-price.title": "Precio del producto",
+  "editor.product-price.description": "Componente del precio del producto",
+  "editor.product-price.show-list-price": "Mostrar precios de tabla",
+  "editor.product-price.show-labels": "Mostrar subtítulos en los precios",
+  "editor.product-price.show-installments": "Mostrar opción de parcelamiento",
+  "editor.product-price.show-savings": "Mostrar diferencia entre el precio tabulado y el de venta",
   "product-description.title": "Descripción del Producto",
   "social-networks": "Redes Sociales",
   "section-links": "Enlaces",
   "more-information-links": "Mas informaciones",
   "payment-form": "Formas de Pago",
-  "pricing.installment-display":
-    "O {installments} {times} de {installmentPrice}",
+  "pricing.installment-display": "O {installments} {times} de {installmentPrice}",
   "pricing.from": "De",
   "pricing.to": "Por",
   "pricing.savings": "Ahorre: {savings}",
@@ -15,8 +20,7 @@
   "shipping.eta": "hasta {eta} días",
   "shipping.free": "Gratis",
   "shipping.empty-sla": "No hay información de envío disponible para el código postal informado",
-  "buybutton.add-failure":
-    "¡Algo salió mal y el artículo no se agregó a tu carrito!",
+  "buybutton.add-failure": "¡Algo salió mal y el artículo no se agregó a tu carrito!",
   "technicalspecifications.title": "Especificaciones Tecnicas",
   "availability-subscriber.title": "Este producto no está disponible actualmente",
   "availability-subscriber.subscribe-label": "Me avisa cuando este producto está disponible",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -1,11 +1,16 @@
 {
+  "editor.product-price.title": "Preço do produto",
+  "editor.product-price.description": "Componente do preço do produto",
+  "editor.product-price.show-list-price": "Mostrar preço de tabela",
+  "editor.product-price.show-labels": "Mostrar legendas nos preços",
+  "editor.product-price.show-installments": "Mostrar opção de parcelamento",
+  "editor.product-price.show-savings": "Mostrar diferença entre o preço tabelado e o de venda",
   "product-description.title": "Descrição do Produto",
   "social-networks": "Redes Sociais",
   "section-links": "Links",
   "more-information-links": "Mais Informações",
   "payment-form": "Formas de Pagamento",
-  "pricing.installment-display":
-    "Ou {installments} {times} de {installmentPrice}",
+  "pricing.installment-display": "Ou {installments} {times} de {installmentPrice}",
   "pricing.from": "De",
   "pricing.to": "Por",
   "pricing.savings": "Economize: {savings}",
@@ -15,8 +20,7 @@
   "shipping.eta": "até {eta} dias",
   "shipping.free": "Grátis",
   "shipping.empty-sla": "Não existe um frete disponível para o CEP informado",
-  "buybutton.add-failure":
-    "Algo deu errado e o item não pode ser adicionado ao seu carrinho!",
+  "buybutton.add-failure": "Algo deu errado e o item não pode ser adicionado ao seu carrinho!",
   "technicalspecifications.title": "Especificações Técnicas",
   "availability-subscriber.title": "Este produto não está disponível no momento",
   "availability-subscriber.subscribe-label": "Avise-me quando estiver disponível",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a schema to the ProductPrice Component

#### What problem is this solving?

The ProductPrice schema was only inside the ProductSummary Component. Now it is inside the ProductPrice Component and internationalized.

#### How should this be manually tested?

[Access the workspace](https://share--storecomponents.myvtex.com/nintendo-switch/p) to see it being used in the ProductDetails schema

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/41102779-04ae1cda-6a3e-11e8-91e9-b665562c1223.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
