### PR TITLE
Fix travis badge image link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - _SKU Selector_ with a different item selected on entering the product page
 - Put the _ProductPrice_ schema inside it's Component.
+- README typos.
 
 ## [1.4.0] - 2018-6-6
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Storecomponents is a collection of components that can be used to create/extend 
 
 ### Travis CI
 
-[![Build Status](https://travis-ci.org/vtex-apps/storecomponents.svg?branch=master)](https://travis-ci.org/vtex-apps/storecomponents)
+[![Build Status](https://travis-ci.org/vtex-apps/store-components.svg?branch=master)](https://travis-ci.org/vtex-apps/store-components)
 
 ## Table of Contents
 - [Usage](#usage)
@@ -61,12 +61,12 @@ Inside your `react/components/<component_name>` you should have:
 
 - index.js
 - README.md
-- components/ [Optional]
-- constants/  [Optional]
-- utils/      [Optional]
-- queries/    [Optional]
-- mutations/  [Optional]
-- global.css  [Optional]
+- [Optional] components/
+- [Optional] constants/
+- [Optional] utils/
+- [Optional] queries/
+- [Optional] mutations/
+- [Optional] global.css
 
 Next, inside of `react/` folder you need to export your component, such as: 
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the repository in the travis badge image from `storecomponents` to `store-components`

#### What problem is this solving?
The badge had the link of the previous repository, thus were broken.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
