### PR TITLE
Add customizable children prop to handle image render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Make `onMaxReached` function not required in `QuantitySelector`
 - Use children prop in `ProductImage` to customize selected image render.
+- Update design of `CollectionBadges`.
 
 ## [1.5.1] - 2018-6-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Make `onMaxReached` function not required in `QuantitySelector`
+- Use children prop in `ProductImage` to customize selected image render.
 
 ## [1.5.1] - 2018-6-18
 ### Added
@@ -28,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.5.0] - 2018-6-11
 ### Added
-- Max height of the logo image
+- Max height of the logo image.
 - Added a title to the _Share_ Component share url.
 - Internationalization of the `Footer` schema.
 - Internationalization of the `Share` schema.

--- a/react/components/CollectionBadges/components/CollectionBadgeItem.js
+++ b/react/components/CollectionBadges/components/CollectionBadgeItem.js
@@ -10,7 +10,7 @@ import VTEXClasses from './CustomClasses'
 export class CollectionBadgeItem extends PureComponent {
   render() {
     return (
-      <div className={`${VTEXClasses.COLLECTION_BADGE_ITEM} w-50 fl ml1 mr1 pa2 bg-blue white fabriga tc`}>
+      <div className={`${VTEXClasses.COLLECTION_BADGE_ITEM} mh1 pa2 bg-blue white tc`}>
         {this.props.children}
       </div>
     )

--- a/react/components/CollectionBadges/index.js
+++ b/react/components/CollectionBadges/index.js
@@ -8,24 +8,18 @@ import VTEXClasses from './components/CustomClasses'
  * Collection Badges component.
  * Encapsulates and displays a responsive list of Collection Badges.
  */
-export default class CollectionBadges extends Component {
-  render() {
-    return (
-      <div className={`${VTEXClasses.COLLECTION_BADGES} relative dib`}>
-        <div className="inline-flex absolute w-100 bottom-0">
-          {
-            this.props.collectionBadgesText.map(collectionBadgeText => (
-              <CollectionBadgeItem key={collectionBadgeText}>
-                {collectionBadgeText}
-              </CollectionBadgeItem>
-            ))
-          }
-        </div>
-        {this.props.children}
-      </div>
-    )
-  }
-}
+const CollectionBadges = ({ collectionBadgesText, children }) => (
+  <div className={`${VTEXClasses.COLLECTION_BADGES} relative dib h-100`}>
+    {children}
+    <div className="inline-flex justify-end absolute w-100 bottom-0 left-0">
+      {collectionBadgesText.map(collectionBadgeText => (
+        <CollectionBadgeItem key={collectionBadgeText}>
+          {collectionBadgeText}
+        </CollectionBadgeItem>
+      ))}
+    </div>
+  </div>
+)
 
 CollectionBadges.propTypes = {
   /** Array of collection badges text */
@@ -37,3 +31,5 @@ CollectionBadges.propTypes = {
 CollectionBadges.defaultProps = {
   collectionBadgesText: [],
 }
+
+export default CollectionBadges

--- a/react/components/ProductImages/README.md
+++ b/react/components/ProductImages/README.md
@@ -12,7 +12,13 @@ You can use it in your code like a React component with the jsx tag: `<ProductIm
 <ProductImages  
     images={selectedItem.images}
     thumbnailSliderOrientation="HORIZONTAL"
-/>
+>
+  {img => (
+    <div className="my-img-container">
+      {img}
+    </div>
+  )}
+</ProductImages>
 ```
 
 | Prop name                    | Type       | Description                                                                 |
@@ -20,5 +26,6 @@ You can use it in your code like a React component with the jsx tag: `<ProductIm
 | `images`                     | `Array!`   | Array of images to be passed for the Thumbnail Slider component as a props  |
 | `thumbnailSliderOrientation` | `Enum!`    | Thumbnail Slider orientation                                                |
 | `thumbnailMaxVisibleItems`   | `Number`   | Maximum number of visible items that should be displayed by the Slider      |
+| `children`                   | `Function` | Selected image renderer                                                     |
 
 See an example at [Product Details](https://github.com/vtex-apps/product-details/blob/master/react/ProductDetails.js#L39) app

--- a/react/components/ProductImages/components/SelectedImage.js
+++ b/react/components/ProductImages/components/SelectedImage.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+
 import ImageZoom from './ImageZoom'
 
 import VTEXClasses from '../constants/productImagesClasses'
@@ -17,6 +18,11 @@ export default class SelectedImage extends Component {
       /** Text that describes the image */
       imageText: PropTypes.string.isRequired,
     }).isRequired,
+    children: PropTypes.func,
+  }
+
+  static defaultProps = {
+    children: img => img,
   }
 
   state = {
@@ -32,7 +38,7 @@ export default class SelectedImage extends Component {
   }
 
   render() {
-    const { imageUrl, imageText } = this.props.image
+    const { children, image: { imageUrl, imageText } } = this.props
     const { showZoom } = this.state
 
     return (
@@ -43,7 +49,7 @@ export default class SelectedImage extends Component {
               VTEXClasses.SELECTED_IMAGE
             } flex-ns justify-center-ns items-center-ns dn`}>
             <div className="flex justify-center items-center">
-              <img onMouseEnter={this.handleMouseEnterImage} src={imageUrl} alt={imageText} />
+              {children(<img onMouseEnter={this.handleMouseEnterImage} src={imageUrl} alt={imageText} />)}
             </div>
           </div>
           <div className="vtex-product-image__image-zoom-container absolute">

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -40,6 +40,7 @@ class ProductImages extends Component {
       images,
       thumbnailSliderOrientation,
       thumbnailMaxVisibleItems,
+      children,
     } = this.props
 
     const thumbnailProps = {
@@ -61,7 +62,9 @@ class ProductImages extends Component {
     return (
       <div className={className}>
         <ThumbnailSlider {...thumbnailProps} />
-        <SelectedImage image={this.state.selectedImage} />
+        <SelectedImage image={this.state.selectedImage}>
+          {children}
+        </SelectedImage>
       </div>
     )
   }
@@ -81,6 +84,8 @@ ProductImages.propTypes = {
   thumbnailSliderOrientation: PropTypes.oneOf([VERTICAL, HORIZONTAL]),
   /** Maximum number of visible items that should be displayed by the Thumbnail Slider at the same time */
   thumbnailMaxVisibleItems: PropTypes.number,
+  /** Function to render selected image */
+  children: PropTypes.func,
 }
 
 ProductImages.defaultProps = {
@@ -117,6 +122,7 @@ ProductImages.defaultProps = {
     },
   ],
   thumbnailSliderOrientation: VERTICAL,
+  children: img => img,
 }
 
 export default ProductImages


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add possibility to pass the `children` prop as a function to customize the image render in the `ProductImage` component.

#### What problem is this solving?
The API defined in the collection badges component is required to have the image as the children of the own component, and we don't have access to it directly on the product details page, only the product image component has.

So, to apply the collection badges in the product details page, it would be possible with this new API on the product images component, like so

```jsx
<ProductImages>
{img =>
  hasCollections
  ? <CollectionBadges>{img}</CollectionBadges>
  : img}
</ProductImages>
```

#### How should this be manually tested?
[Access this workspace](https://collectionbadges--storecomponents.myvtex.com/).

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
