### PR TITLE
Make onMaxReached function not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Debounce function to handle the increase and decrease events in the `QuantitySelector`
 
+### Changed
+- Make `onMaxReached` function not required in `QuantitySelector`
+
 ## [1.5.1] - 2018-6-18
 ### Added
 - Internationalization to `SearchBar`

--- a/react/components/QuantitySelector/index.js
+++ b/react/components/QuantitySelector/index.js
@@ -48,7 +48,7 @@ class QuantitySelector extends Component {
       this.setState({ currentQuantity: currentQuantity + 1 })
       event.persist()
       this.debouncedIncreaseFunction()
-    } else {
+    } else if (onMaxReached) {
       onMaxReached()
     }
   }
@@ -96,7 +96,7 @@ QuantitySelector.propTypes = {
   /** Called when the client set the quantity selector */
   onQuantityChange: PropTypes.func.isRequired,
   /** Define if can buy more items than the maximum limit */
-  onMaxReached: PropTypes.func.isRequired,
+  onMaxReached: PropTypes.func,
 }
 
 QuantitySelector.defaultProps = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make onMaxReached function not required.

#### What problem is this solving?
This function was required, but it isn't always necessary or used.

#### How should this be manually tested?
https://waza--storecomponents.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
