### PR TITLE
Fix className of SKUSelectorItem

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,1 @@
+/usr/lib/node_modules/vtex/.eslintrc

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,1 +1,0 @@
-/usr/local/share/.config/yarn/global/node_modules/vtex/.eslintrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- _SKU Selector_ item with false value as class name.
+
 ## [1.5.0] - 2018-6-11
 ### Added
 - Max height of the logo image
@@ -19,7 +22,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - _SKU Selector_ item's discount badge position
 - Put the _ProductPrice_ schema inside it's Component.
 - README typos.
-- _SKU Selector_ item with false value as class name.
 
 ## [1.4.0] - 2018-6-6
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Fixed
 - _SKU Selector_ item with false value as class name.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - _SKU Selector_ item's discount badge position
 - Put the _ProductPrice_ schema inside it's Component.
 - README typos.
+- _SKU Selector_ item with false value as class name.
 
 ## [1.4.0] - 2018-6-6
 ### Added

--- a/react/components/SKUSelector/components/SelectorItem.js
+++ b/react/components/SKUSelector/components/SelectorItem.js
@@ -24,7 +24,7 @@ export default class SelectorItem extends PureComponent {
         ${isSelected ? 'b--blue' : 'b--transparent'}
         ${!isAvailable && 'bg-light-gray'}`}
         onClick={this.handleClick}>
-        <div className={`${!isAvailable && 'o-50'}`}>
+        <div className={isAvailable ? '' : 'o-50'}>
           {children}
         </div>
         {discount > 0 && <span className={`${VTEXClasses.SKU_BADGE} b`}><FormattedNumber value={discount} style="percent" /></span>}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove false as class name property of SKU Selector Item.

#### What problem is this solving?
SKU Selector item with false as class name property.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
