### PR TITLE
Fix Buybutton default props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Changed _BuyButton_ Component added isOneClickBuy attribute.
+- _BuyButton_ don't wait add to cart to proceed to checkout page.
+- _BuyButton_ Component added isOneClickBuy attribute.
 
 ### Fixed
+- _BuyButton_ default props as static attribute.
 - _SKU Selector_ item with false value as class name.
 
 

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -19,7 +19,7 @@ const CONSTANTS = {
  * BuyButton Component. Adds a list of items to the cart.
  */
 export class BuyButton extends Component {
-  defaultProps = {
+  static defaultProps = {
     isOneClickBuy: false,
     quantity: 1,
     seller: 1,
@@ -73,6 +73,10 @@ export class BuyButton extends Component {
 
           variables.orderFormId = orderFormId
 
+          if (isOneClickBuy) {
+            location.assign(CONSTANTS.CHECKOUT_URL)
+          }
+
           client
             .mutate({
               mutation: ADD_TO_CART_MUTATION,
@@ -83,10 +87,6 @@ export class BuyButton extends Component {
                 const { items } = mutationRes.data.addItem
                 const success = find(items, { id: skuId })
                 this.toastMessage(success)
-
-                if (success && isOneClickBuy) {
-                  location.assign(CONSTANTS.CHECKOUT_URL)
-                }
               },
               mutationErr => {
                 this.toastMessage(false, mutationErr)


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix Buy button default props
- Change buy button to redirect right after the click.

#### What problem is this solving?
- Buy button had its default props as an instance attribute instead of static.
- After the button click the redirect occurred after the action add to cart, generating an unnecessary amount of time.

#### How should this be manually tested?
Access: https://andre--storecomponents.myvtex.com/

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)
