### PR TITLE
Remove HTML escape and update logo link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Unescape HTML in the product description.
 
 ### Fixed
 - Vertical display of `ProductImage`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Unescape HTML in the product description.
+- Logo link to be a `Link` component from `render`.
 
 ### Fixed
 - Vertical display of `ProductImage`.

--- a/react/components/Header/components/TopMenu.js
+++ b/react/components/Header/components/TopMenu.js
@@ -1,11 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { intlShape, injectIntl } from 'react-intl'
+import { ExtensionPoint, Link } from 'render'
 
 import Logo from '../../../Logo'
 import SearchBar from '../../../SearchBar'
-
-import { ExtensionPoint } from 'render'
 
 const TopMenu = ({ logoUrl, logoTitle, intl, fixed, offsetTop }) => {
   const translate = id => intl.formatMessage({ id: `header.${id}` })
@@ -18,12 +17,12 @@ const TopMenu = ({ logoUrl, logoTitle, intl, fixed, offsetTop }) => {
       style={{top: `${offsetTop}px`}}
     >
       <div className="flex w-100 w-auto-ns pa4-ns items-center">
-        <a className="link b f3 near-black tc tl-ns serious-black flex-auto" href="/">
+        <Link className="link b f3 near-black tc tl-ns serious-black flex-auto" to="/">
           <Logo
             url={logoUrl}
             title={logoTitle}
           />
-        </a>
+        </Link>
       </div>
       <div className="flex-auto pr2 pa4">
         <SearchBar

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -20,7 +20,7 @@ class ProductDescription extends Component {
           <FormattedMessage id="product-description.title" />
         </div>
 
-        <span dangerouslySetInnerHTML={{ __html: description }} />
+        <span className="measure-wide" dangerouslySetInnerHTML={{ __html: description }} />
 
         {specifications.length > 0 && (
           <div className="vtex-product-specifications">

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -12,7 +12,7 @@ import './global.css'
  */
 class ProductDescription extends Component {
   render() {
-    const { specifications, skuName } = this.props
+    const { specifications, skuName, description } = this.props
 
     return (
       <div className={`${VTEXClasses.PRODUCT_DESCRIPTION} ma2`}>
@@ -20,7 +20,7 @@ class ProductDescription extends Component {
           <FormattedMessage id="product-description.title" />
         </div>
 
-        <span dangerouslySetInnerHTML={{ __html: this.props.children }} />
+        <span dangerouslySetInnerHTML={{ __html: description }} />
 
         {specifications.length > 0 && (
           <div className="vtex-product-specifications">
@@ -66,12 +66,11 @@ class ProductDescription extends Component {
 
 ProductDescription.defaultProps = {
   specifications: [],
-  children: {},
 }
 
 ProductDescription.propTypes = {
-  /** Children component which contains the product description */
-  children: PropTypes.node.isRequired,
+  /** Product description string */
+  description: PropTypes.string.isRequired,
   /** Intl object to provides internationalization */
   intl: intlShape.isRequired,
   /** Specifications that will be displayed on the table */

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -20,7 +20,7 @@ class ProductDescription extends Component {
           <FormattedMessage id="product-description.title" />
         </div>
 
-        {this.props.children}
+        <span dangerouslySetInnerHTML={{ __html: this.props.children }} />
 
         {specifications.length && (
           <div className="vtex-product-specifications">
@@ -48,7 +48,7 @@ class ProductDescription extends Component {
                     <td className="vtex-product-specifications__specification-values">
                       {specification.values.map((value, i) => (
                         <Fragment key={value}>
-                          {value}{' '}
+                          <span dangerouslySetInnerHTML={{ __html: value }} />{' '}
                           {i !== specification.values.length - 1 && <br />}
                         </Fragment>
                       ))}

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -22,7 +22,7 @@ class ProductDescription extends Component {
 
         <span dangerouslySetInnerHTML={{ __html: this.props.children }} />
 
-        {specifications.length && (
+        {specifications.length > 0 && (
           <div className="vtex-product-specifications">
             <div className="vtex-product-specifications__title">
               <FormattedMessage id="technicalspecifications.title" />


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove HTML escape from `ProductDescription` component, and update the logo to use the `Link` component.

#### What problem is this solving?
Rich description wasn't rendering correctly, and the click on the store logo wasn't using client-side redirection.

#### How should this be manually tested?
[Access this workspace](https://htmlescape--storecomponents.myvtex.com/samsung-s9/p)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
