### PR TITLE
Hide fixed header while in edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.7.2] - 2018-7-9
 ### Changed
 - Hide fixed header while in edit mode.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Hide fixed header while in edit mode.
 
 ## [1.7.1] - 2018-7-6
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/CollectionBadges/index.js
+++ b/react/components/CollectionBadges/index.js
@@ -12,8 +12,8 @@ const CollectionBadges = ({ collectionBadgesText, children }) => (
   <div className={`${VTEXClasses.COLLECTION_BADGES} relative dib h-100`}>
     {children}
     <div className="inline-flex justify-end absolute w-100 bottom-0 left-0">
-      {collectionBadgesText.map(collectionBadgeText => (
-        <CollectionBadgeItem key={collectionBadgeText}>
+      {collectionBadgesText.map((collectionBadgeText, index) => (
+        <CollectionBadgeItem key={collectionBadgeText + index}>
           {collectionBadgeText}
         </CollectionBadgeItem>
       ))}

--- a/react/components/Header/components/Modal.js
+++ b/react/components/Header/components/Modal.js
@@ -8,8 +8,8 @@ const getModalRoot = () => {
   if (typeof _modalRoot === 'undefined') {
     _modalRoot = document.createElement('div')
     _modalRoot.classList.add('vtex-modal-root')
-
-    document.body.appendChild(_modalRoot)
+    const container = document.getElementsByClassName('render-container')[0]
+    container.appendChild(_modalRoot)
   }
 
   return _modalRoot

--- a/react/components/Header/components/Modal.js
+++ b/react/components/Header/components/Modal.js
@@ -8,7 +8,7 @@ const getModalRoot = () => {
   if (typeof _modalRoot === 'undefined') {
     _modalRoot = document.createElement('div')
     _modalRoot.classList.add('vtex-modal-root')
-    const container = document.getElementsByClassName('render-container')[0]
+    const container = document.querySelector('.render-container')
     container.appendChild(_modalRoot)
   }
 

--- a/react/components/Header/components/TopMenu.js
+++ b/react/components/Header/components/TopMenu.js
@@ -13,7 +13,7 @@ const TopMenu = ({ logoUrl, logoTitle, intl, fixed, offsetTop }) => {
     <div
       className={`${
         fixed ? 'fixed shadow-5' : ''
-        } z-999 flex items-center w-100 flex-wrap pa4 pa5-ns bg-white tl`}
+        } vtex-top-menu z-999 flex items-center w-100 flex-wrap pa4 pa5-ns bg-white tl`}
       style={{top: `${offsetTop}px`}}
     >
       <div className="flex w-100 w-auto-ns pa4-ns items-center">

--- a/react/components/Header/global.css
+++ b/react/components/Header/global.css
@@ -1,2 +1,3 @@
-.vtex-header {
+.editor-provider .vtex-modal-root .vtex-top-menu {
+    display: none;
 }

--- a/react/components/Header/index.js
+++ b/react/components/Header/index.js
@@ -8,6 +8,8 @@ import TopMenu from './components/TopMenu'
 import { Alert } from 'vtex.styleguide'
 import { ExtensionPoint } from 'render'
 
+import './global.css'
+
 export const TOAST_TIMEOUT = 3000
 
 class Header extends Component {


### PR DESCRIPTION
#### What is the purpose of this pull request?
In edit mode, fixed elements shouldn't be rendered, except when on full-screen (which effectively disables edit mode)

#### What problem is this solving?
Superposition of top menu and admin controls.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
