### PR TITLE
Fix display of the Header on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `TopMenu` display on mobile screen.
 
 ## [1.7.2] - 2018-7-9
 ### Changed

--- a/react/components/Header/components/TopMenu.js
+++ b/react/components/Header/components/TopMenu.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { intlShape, injectIntl } from 'react-intl'
 import { ExtensionPoint, Link } from 'render'
+import classNames from 'classnames'
 
 import Logo from '../../../Logo'
 import SearchBar from '../../../SearchBar'
@@ -9,28 +10,33 @@ import SearchBar from '../../../SearchBar'
 const TopMenu = ({ logoUrl, logoTitle, intl, fixed, offsetTop }) => {
   const translate = id => intl.formatMessage({ id: `header.${id}` })
 
+  const classes = classNames(
+    'vtex-top-menu',
+    {
+      'vtex-top-menu--fixed': fixed,
+    }
+  )
+
   return (
     <div
-      className={`${
-        fixed ? 'fixed shadow-5' : ''
-        } vtex-top-menu z-999 flex items-center w-100 flex-wrap pa4 pa5-ns bg-white tl`}
-      style={{top: `${offsetTop}px`}}
+      className={classes}
+      style={offsetTop ? {top: `${offsetTop}px`} : null}
     >
-      <div className="flex w-100 w-auto-ns pa4-ns items-center">
-        <Link className="link b f3 near-black tc tl-ns serious-black flex-auto" to="/">
+      <div className="vtex-top-menu__logo">
+        <Link className="link b f3 near-black tc tl-ns serious-black" to="/">
           <Logo
             url={logoUrl}
             title={logoTitle}
           />
         </Link>
       </div>
-      <div className="flex-auto pr2 pa4">
+      <div className="vtex-top-menu__search-bar">
         <SearchBar
           placeholder={translate('search-placeholder')}
           emptyPlaceholder={translate('search-emptyPlaceholder')}
         />
       </div>
-      <div className="pr2 bg-black">
+      <div className="vtex-top-menu__icons">
         <ExtensionPoint id="minicart" />
         <ExtensionPoint id="login" />
       </div>

--- a/react/components/Header/global.css
+++ b/react/components/Header/global.css
@@ -19,7 +19,6 @@
 }
 
 .vtex-top-menu__logo {
-  width: 100%;
   text-align: center;
 }
 
@@ -33,12 +32,23 @@
 }
 
 @media only screen and (max-width: 639px) {
+  .vtex-top-menu__logo {
+    order: 1;
+  }
 
+  .vtex-top-menu__search-bar {
+    order: 3;
+    width: 100%;
+  }
+
+  .vtex-top-menu__icons {
+    order: 2;
+    margin-left: auto;
+  }
 }
 
 @media only screen and (min-width: 640px) {
   .vtex-top-menu__logo {
-    width: auto;
     padding: .75rem;
   }
 }

--- a/react/components/Header/global.css
+++ b/react/components/Header/global.css
@@ -1,3 +1,44 @@
 .editor-provider .vtex-modal-root .vtex-top-menu {
-    display: none;
+  display: none;
+}
+
+.vtex-top-menu {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  z-index: 999;
+  flex-wrap: wrap;
+  background-color: white;
+  text-align: left;
+  padding: .75rem;
+}
+
+.vtex-top-menu--fixed {
+  position: fixed;
+  box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2);
+}
+
+.vtex-top-menu__logo {
+  width: 100%;
+  text-align: center;
+}
+
+.vtex-top-menu__search-bar {
+  flex: 1 1 auto;
+  padding: .75rem;
+}
+
+.vtex-top-menu__icons {
+  padding-right: .25rem;
+}
+
+@media only screen and (max-width: 639px) {
+
+}
+
+@media only screen and (min-width: 640px) {
+  .vtex-top-menu__logo {
+    width: auto;
+    padding: .75rem;
+  }
 }

--- a/react/components/Header/index.js
+++ b/react/components/Header/index.js
@@ -27,6 +27,8 @@ class Header extends Component {
     intl: intlShape.isRequired,
   }
 
+  _root = React.createRef()
+
   componentDidMount() {
     this._timeouts = []
     document.addEventListener('message:error', this.handleError)
@@ -66,12 +68,12 @@ class Header extends Component {
   }
 
   handleScroll = () => {
-    if (!this._el) {
+    if (!this._root.current) {
       return
     }
 
     const scroll = window.scrollY
-    const { scrollHeight } = this._el
+    const { scrollHeight } = this._root.current
 
     if (scroll < scrollHeight && this.state.showMenuPopup) {
       this.setState({
@@ -88,13 +90,13 @@ class Header extends Component {
     const { account } = global.__RUNTIME__
     const { name, logoUrl, logoTitle } = this.props
     const { isAddToCart, hasError, showMenuPopup, error } = this.state
-    const offsetTop = (this._el && this._el.offsetTop) || 0
+
+    const offsetTop = (this._root.current && this._root.current.offsetTop) || 0
+
     return (
       <div
         className="vtex-header relative z-2 w-100 shadow-5"
-        ref={e => {
-          this._el = e
-        }}
+        ref={this._root}
       >
         <div className="z-2 items-center w-100 top-0 bg-white tl">
           <ExtensionPoint id="menu-link" />


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the display on mobile of the header `TopMenu` and it's items, to accommodate the login and minicart icons on top of the search bar.

#### What problem is this solving?
The icons were being rendered bellow the search bar, and was not according to the design specification.

#### How should this be manually tested?
[Workspace](https://login--storecomponents.myvtex.com/)

#### Screenshots or example usage
![screen shot 2018-07-09 at 11 22 38](https://user-images.githubusercontent.com/10223856/42456133-6ec7d404-836a-11e8-90ea-18538ddafb80.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
