### PR TITLE
Fix ProductPrice propTypes warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `ProductPrice` propTypes.
 
 ## [1.8.2] - 2018-07-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `ProductPrice` propTypes.
+- `ProductPrice` propTypes, removed warning from console.
 
 ## [1.8.2] - 2018-07-18
 ### Changed

--- a/react/components/ProductPrice/propTypes.js
+++ b/react/components/ProductPrice/propTypes.js
@@ -5,7 +5,7 @@ export default {
   /** Product selling price */
   sellingPrice: PropTypes.number.isRequired,
   /** Product list price */
-  listPrice: PropTypes.number.isRequired,
+  listPrice: PropTypes.number,
   /** Set visibility of list price */
   showListPrice: PropTypes.bool.isRequired,
   /** Set visibility of labels */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove warning from console

#### What problem is this solving?
The ProductPrice component is able to be rendered without the listPrice

#### How should this be manually tested?

[workspace](https://productresize--storecomponents.myvtex.com/porsche-911/p)

#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
