### PR TITLE
Fix the Footer position to be always at the bottom of the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Footer` positioned always at the bottom of the page.
 
 ## [1.8.2] - 2018-07-18
 ### Changed

--- a/react/components/Footer/global.css
+++ b/react/components/Footer/global.css
@@ -183,3 +183,12 @@
   }
 }
 
+.vtex-store__template > div {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.vtex-store__template > div > div:last-child {
+  margin-top: auto; 
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the Footer position to be always at the bottom of the page.

#### What problem is this solving?
The footer wasn't always at the bottom of the page as you can see in the screenshot above.
![captura de tela de 2018-07-20 16-46-38](https://user-images.githubusercontent.com/12852518/43022117-848ac280-8c3c-11e8-9bb6-ec65572805bc.png)

#### How should this be manually tested?
https://waza--storecomponents.myvtex.com/

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
