### PR TITLE
Add initial implementation of CategoryCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `CategoryCard` component to display an image related to a category.
+
 ### Fixed
 - `Footer` positioned always at the bottom of the page.
 - ImageUrl warning in `SKUSelector` and `ProductImages`.

--- a/react/CategoryCard.js
+++ b/react/CategoryCard.js
@@ -1,0 +1,3 @@
+import CategoryCard from './components/CategoryCard/index'
+
+export default CategoryCard

--- a/react/components/CategoryCard/README.md
+++ b/react/components/CategoryCard/README.md
@@ -1,0 +1,23 @@
+# CategoryCard
+CategoryCard is a canonical component that any VTEX app can import.
+
+To import it into your code: 
+```js
+import CategoryCard from 'vtex.store-components/CategoryCard'
+```
+
+## Usage
+You can use it in your code like a React component with the jsx tag: `<CategoryCard />`. 
+```html
+<CategoryCardCard 
+  categoryName={category.name}
+  categoryImageUrl={category.image.url}
+/>
+```
+
+| Prop name          | Type       | Description                                                                 |
+| ------------------ | ---------- | --------------------------------------------------------------------------- |
+| `categoryName`     | `String!`  | Name of the Category                                                        |
+| `categoryImageUrl` | `String`   | URL of the image that is related to the category                            |
+
+

--- a/react/components/CategoryCard/global.css
+++ b/react/components/CategoryCard/global.css
@@ -1,0 +1,11 @@
+.vtex-category-card {
+  width: 250px;
+  height: 250px;
+  background-color: #555555;
+  overflow: hidden;
+}
+
+.vtex-category-card img {
+  height: 250px;
+  width: auto;
+}

--- a/react/components/CategoryCard/index.js
+++ b/react/components/CategoryCard/index.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+import './global.css'
+
+class CategoryCard extends Component {
+  static propTypes = {
+    /** Name of the Category */
+    categoryName: PropTypes.string.isRequired,
+    /** URL of the image that is related to the category */
+    categoryImageUrl: PropTypes.string,
+  }
+
+  static defaultProps = {
+    categoryName: 'Category Name',
+  }
+
+  render() {
+    const { categoryName, categoryImageUrl } = this.props
+
+    return (
+      <div className="vtex-category-card shadow-1 flex items-center justify-center mv2 mh2">
+        {
+          categoryImageUrl 
+          ? <img src={categoryImageUrl} alt={categoryName}/> 
+          : <span className="f3 white">
+              {categoryName}
+            </span>
+        }
+      </div>
+    )
+  }
+}
+
+export default CategoryCard


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the initial implementation of the CategoryCard which will be displayed into the department page inside a React Slick Slider.

#### What problem is this solving?
Add the initial implementation of the CategoryCard.

#### How should this be manually tested?

#### Screenshots or example usage
<a href="https://gustavo--storecomponents.myvtex.com/veiculos/d">Workspace</a>
![captura de tela de 2018-07-27 16-18-04](https://user-images.githubusercontent.com/9275109/43342314-ace86814-91b8-11e8-845e-25c08fd65b92.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
