### PR TITLE
 Add the ProductDescription Content Loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ProductDescription` content loader.
 
 ## [1.12.0] - 2018-08-02
 ### Added

--- a/react/components/ProductDescription/global.css
+++ b/react/components/ProductDescription/global.css
@@ -16,7 +16,7 @@
 }
 
 .vtex-product-specifications__table-row:nth-child(odd) {
-  background-color: rgba(0, 0, 0, 0.05)
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .vtex-product-specifications__specification-name {
@@ -25,7 +25,7 @@
   text-transform: uppercase;
   font-weight: normal;
   width: 25%;
-  border-right: 1px solid rgba(0, 0, 0, 0.15)
+  border-right: 1px solid rgba(0, 0, 0, 0.15);
 }
 
 .vtex-product-specifications__specification-values {
@@ -51,3 +51,29 @@
   }
 }
 
+.vtex-product-specifications-loader {
+  height: 26em;
+}
+
+.vtex-product-specifications__description-title--loader {
+  width: 15em;
+  height: 2em;
+}
+
+.vtex-product-specifications__description--loader {
+  width: 100%;
+  height: 5em;
+  y: 3em;
+}
+
+.vtex-product-specifications__title--loader {
+  width: 15em;
+  height: 2em;
+  y: 11em;
+}
+
+.vtex-product-specifications__table--loader {
+  width: 100%;
+  height: 12em;
+  y: 14em;
+}

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -1,18 +1,41 @@
-import React, { Component, Fragment } from 'react'
+import './global.css'
+
 import PropTypes from 'prop-types'
-import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
+import React, { Component, Fragment } from 'react'
+import ContentLoader from 'react-content-loader'
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 
 import VTEXClasses from './CustomClasses'
-
-import './global.css'
 
 /**
  * Product Description Component.
  * Render the description and technical specifications of a product
  */
 class ProductDescription extends Component {
+  static Loader = (loaderProps = {}) => (
+    <div className="vtex-product-specifications vtex-product-specifications-loader">
+      <ContentLoader
+        uniquekey="vtex-product-specifications-loader"
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+        height="100%"
+        width="100%"
+        {...loaderProps}>
+        <rect className="vtex-product-specifications__description-title--loader" />
+        <rect className="vtex-product-specifications__description--loader" />
+        <rect className="vtex-product-specifications__title--loader" />
+        <rect className="vtex-product-specifications__table--loader" />
+      </ContentLoader>
+    </div>
+  )
   render() {
     const { specifications, skuName, description } = this.props
+
+    if (!description || !specifications) {
+      return <ProductDescription.Loader />
+    }
 
     return (
       <div className={`${VTEXClasses.PRODUCT_DESCRIPTION} ma2`}>
@@ -20,7 +43,10 @@ class ProductDescription extends Component {
           <FormattedMessage id="product-description.title" />
         </div>
 
-        <span className="measure-wide" dangerouslySetInnerHTML={{ __html: description }} />
+        <span
+          className="measure-wide"
+          dangerouslySetInnerHTML={{ __html: description }}
+        />
 
         {specifications.length > 0 && (
           <div className="vtex-product-specifications">
@@ -40,8 +66,7 @@ class ProductDescription extends Component {
                 {specifications.map(specification => (
                   <tr
                     key={specification.name}
-                    className="vtex-product-specifications__table-row"
-                  >
+                    className="vtex-product-specifications__table-row">
                     <th className="vtex-product-specifications__specification-name">
                       {specification.name}
                     </th>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the ProductDescription Content Loader

#### What problem is this solving?
ProductDescription is not shown when there is no data. Nothing is shown.

#### How should this be manually tested?
[Access the workspace](https://estacio--storecomponents.myvtex.com/porsche-911/p) (this product has no description and no specifications, but it isn't like that in the real stores).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/43653532-bb623d46-971e-11e8-98df-3452c6390478.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
