### PR TITLE
Refact Content Loaders to work on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix all content loaders to work on Firefox.
 
 ## [1.12.4] - 2018-08-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix all content loaders to work on Firefox.
+- All content loaders to work on Firefox.
 
 ## [1.12.4] - 2018-08-10
 ### Added

--- a/react/components/ProductDescription/global.css
+++ b/react/components/ProductDescription/global.css
@@ -54,26 +54,3 @@
 .vtex-product-specifications-loader {
   height: 26em;
 }
-
-.vtex-product-specifications__description-title--loader {
-  width: 15em;
-  height: 2em;
-}
-
-.vtex-product-specifications__description--loader {
-  width: 100%;
-  height: 5em;
-  y: 3em;
-}
-
-.vtex-product-specifications__title--loader {
-  width: 15em;
-  height: 2em;
-  y: 11em;
-}
-
-.vtex-product-specifications__table--loader {
-  width: 100%;
-  height: 12em;
-  y: 14em;
-}

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -1,11 +1,11 @@
-import './global.css';
+import './global.css'
 
-import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-import ContentLoader from 'react-content-loader';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import PropTypes from 'prop-types'
+import React, { Component, Fragment } from 'react'
+import ContentLoader from 'react-content-loader'
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 
-import VTEXClasses from './CustomClasses';
+import VTEXClasses from './CustomClasses'
 
 /**
  * Product Description Component.

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -1,11 +1,11 @@
-import './global.css'
+import './global.css';
 
-import PropTypes from 'prop-types'
-import React, { Component, Fragment } from 'react'
-import ContentLoader from 'react-content-loader'
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import ContentLoader from 'react-content-loader';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 
-import VTEXClasses from './CustomClasses'
+import VTEXClasses from './CustomClasses';
 
 /**
  * Product Description Component.
@@ -22,10 +22,31 @@ class ProductDescription extends Component {
         height="100%"
         width="100%"
         {...loaderProps}>
-        <rect className="vtex-product-specifications__description-title--loader" />
-        <rect className="vtex-product-specifications__description--loader" />
-        <rect className="vtex-product-specifications__title--loader" />
-        <rect className="vtex-product-specifications__table--loader" />
+        <rect
+          width="15em"
+          height="2em"
+          {...loaderProps[
+            'vtex-product-specifications__description-title--loader'
+          ]}
+        />
+        <rect
+          width="100%"
+          height="5em"
+          y="3em"
+          {...loaderProps['vtex-product-specifications__description--loader']}
+        />
+        <rect
+          width="15em"
+          height="2em"
+          y="11em"
+          {...loaderProps['vtex-product-specifications__title--loader']}
+        />
+        <rect
+          width="100%"
+          height="12em"
+          y="14em"
+          {...loaderProps['vtex-product-specifications__table--loader']}
+        />
       </ContentLoader>
     </div>
   )
@@ -33,7 +54,7 @@ class ProductDescription extends Component {
     const { specifications, skuName, description } = this.props
 
     if (!description || !specifications) {
-      return <ProductDescription.Loader />
+      return <ProductDescription.Loader {...this.props.styles} />
     }
 
     return (
@@ -108,6 +129,8 @@ ProductDescription.propTypes = {
   ),
   /** Name of the current SKU */
   skuName: PropTypes.string,
+  /** Component and content loader styles */
+  styles: PropTypes.object,
 }
 
 export default injectIntl(ProductDescription)

--- a/react/components/ProductImages/global.css
+++ b/react/components/ProductImages/global.css
@@ -57,20 +57,8 @@
   height: 31.25em;
 }
 
-.vtex-product-image__selected-image--loader {
-  x: 10%;
-  y: 2%;
-  max-width: 19.782em;
-  width: 80%;
-  height: 17.465em;
-}
-
-.vtex-product-image__thumbnail-slider--loader {
-  x: 10%;
-  y: 19em;
-  max-width: 19.782em;
-  width: 80%;
-  height: 2.785em;
+.vtex-product-image__vertical--loader {
+  height: 31.25em;
 }
 
 @media only screen and (max-width: 27em) {
@@ -108,15 +96,6 @@
   .vtex-product-image__thumbnail-slider-item {
     height: 17em;
     width: inherit;
-  }
-
-  .vtex-product-image__selected-image--loader {
-    height: 12em;
-  }
-
-  .vtex-product-image__thumbnail-slider--loader {
-    y: 13em;
-    height: 2em;
   }
 }
 

--- a/react/components/ProductImages/global.css
+++ b/react/components/ProductImages/global.css
@@ -53,11 +53,7 @@
   background-size: contain;
 }
 
-.vtex-product-image__horizontal--loader {
-  height: 31.25em;
-}
-
-.vtex-product-image__vertical--loader {
+.vtex-product-image-loader {
   height: 31.25em;
 }
 

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -43,7 +43,6 @@ class ProductImages extends Component {
       'vtex-product-image__selected-image--loader': {
         x: '10%',
         y: '5%',
-        'max-width': '19.782em',
         width: '80%',
         height: '75%',
         ...loaderProps['vtex-product-image__selected-image--loader'],
@@ -51,7 +50,6 @@ class ProductImages extends Component {
       'vtex-product-image__thumbnail-slider--loader': {
         x: '10%',
         y: '85%',
-        'max-width': '19.782em',
         width: '80%',
         height: '10%',
         ...loaderProps['vtex-product-image__thumbnail-slider--loader'],
@@ -61,14 +59,12 @@ class ProductImages extends Component {
         y: '5%',
         width: '80%',
         height: '90%',
-        'max-width': '18em',
         ...loaderProps['vtex-product-image__selected-image-vertical--loader'],
       },
       'vtex-product-image__thumbnail-slider-vertical--loader': {
         y: '5%',
         width: '15%',
         height: '90%',
-        'max-width': '2em',
         ...loaderProps['vtex-product-image__thumbnail-slider-vertical--loader'],
       },
     }
@@ -141,7 +137,7 @@ class ProductImages extends Component {
       className += ` ${VTEXClasses.HORIZONTAL_COMPONENT} flex-column-reverse`
     }
 
-    if (!images) {
+    if (!!images) {
       return (
         <ProductImages.Loader {...this.props.styles} isVertical={isVertical} />
       )

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -1,13 +1,13 @@
-import './global.css';
+import './global.css'
 
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import ContentLoader from 'react-content-loader';
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import ContentLoader from 'react-content-loader'
 
-import SelectedImage from './components/SelectedImage';
-import ThumbnailSlider from './components/ThumbnailSlider';
-import { HORIZONTAL, VERTICAL } from './constants/orientation';
-import VTEXClasses from './constants/productImagesClasses';
+import SelectedImage from './components/SelectedImage'
+import ThumbnailSlider from './components/ThumbnailSlider'
+import { HORIZONTAL, VERTICAL } from './constants/orientation'
+import VTEXClasses from './constants/productImagesClasses'
 
 const DEFAULT_SELECTED_IMAGE = 0
 

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -137,7 +137,7 @@ class ProductImages extends Component {
       className += ` ${VTEXClasses.HORIZONTAL_COMPONENT} flex-column-reverse`
     }
 
-    if (!!images) {
+    if (!images) {
       return (
         <ProductImages.Loader {...this.props.styles} isVertical={isVertical} />
       )

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -38,8 +38,42 @@ class ProductImages extends Component {
     return null
   }
 
-  static Loader = props =>
-    props.isVertical ? (
+  static Loader = (loaderProps = {}) => {
+    const styles = {
+      'vtex-product-image__selected-image--loader': {
+        x: '10%',
+        y: '5%',
+        'max-width': '19.782em',
+        width: '80%',
+        height: '75%',
+        ...loaderProps['vtex-product-image__selected-image--loader'],
+      },
+      'vtex-product-image__thumbnail-slider--loader': {
+        x: '10%',
+        y: '85%',
+        'max-width': '19.782em',
+        width: '80%',
+        height: '10%',
+        ...loaderProps['vtex-product-image__thumbnail-slider--loader'],
+      },
+      'vtex-product-image__selected-image-vertical--loader': {
+        x: '20%',
+        y: '5%',
+        width: '80%',
+        height: '90%',
+        'max-width': '18em',
+        ...loaderProps['vtex-product-image__selected-image-vertical--loader'],
+      },
+      'vtex-product-image__thumbnail-slider-vertical--loader': {
+        y: '5%',
+        width: '15%',
+        height: '90%',
+        'max-width': '2em',
+        ...loaderProps['vtex-product-image__thumbnail-slider-vertical--loader'],
+      },
+    }
+
+    return loaderProps.isVertical ? (
       <div className="vtex-product-image vtex-product-image-loader vtex-product-image__vertical vtex-product-image__vertical--loader">
         <ContentLoader
           style={{
@@ -48,8 +82,12 @@ class ProductImages extends Component {
           }}
           height="100%"
           width="100%">
-          <rect className="vtex-product-image__selected-image--loader" />
-          <rect className="vtex-product-image__thumbnail-slider--loader" />
+          <rect
+            {...styles['vtex-product-image__selected-image-vertical--loader']}
+          />
+          <rect
+            {...styles['vtex-product-image__thumbnail-slider-vertical--loader']}
+          />
         </ContentLoader>
       </div>
     ) : (
@@ -61,11 +99,12 @@ class ProductImages extends Component {
           }}
           height="100%"
           width="100%">
-          <rect className="vtex-product-image__selected-image--loader" />
-          <rect className="vtex-product-image__thumbnail-slider--loader" />
+          <rect {...styles['vtex-product-image__selected-image--loader']} />
+          <rect {...styles['vtex-product-image__thumbnail-slider--loader']} />
         </ContentLoader>
       </div>
     )
+  }
 
   /**
    * Function that changes the selected image
@@ -103,7 +142,9 @@ class ProductImages extends Component {
     }
 
     if (!images) {
-      return <ProductImages.Loader isVertical={isVertical} />
+      return (
+        <ProductImages.Loader {...this.props.styles} isVertical={isVertical} />
+      )
     }
 
     return (
@@ -139,6 +180,8 @@ ProductImages.propTypes = {
   thumbnailSliderOrientation: PropTypes.oneOf([VERTICAL, HORIZONTAL]),
   /** Maximum number of visible items that should be displayed by the Thumbnail Slider at the same time */
   thumbnailMaxVisibleItems: PropTypes.number,
+  /** Component and content loader styles */
+  styles: PropTypes.object,
 }
 
 ProductImages.defaultProps = {

--- a/react/components/ProductName/global.css
+++ b/react/components/ProductName/global.css
@@ -17,16 +17,3 @@
 .vtex-product-name-loader {
   padding-top: 1em;
 }
-
-.vtex-product-name__brand--loader {
-  height: 1.125em;
-  width: 75%;
-  x: 15%;
-}
-
-.vtex-product-name__sku--loader {
-  height: 1.125em;
-  width: 50%;
-  x: 25%;
-  y: 1.75em;
-}

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -1,8 +1,8 @@
-import './global.css';
+import './global.css'
 
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import ContentLoader from 'react-content-loader';
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import ContentLoader from 'react-content-loader'
 
 /**
  * Name component. Show name and relevant SKU information of the Product Summary

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -1,8 +1,8 @@
-import './global.css'
+import './global.css';
 
-import PropTypes from 'prop-types'
-import React, { Component } from 'react'
-import ContentLoader from 'react-content-loader'
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import ContentLoader from 'react-content-loader';
 
 /**
  * Name component. Show name and relevant SKU information of the Product Summary
@@ -41,8 +41,19 @@ class ProductName extends Component {
         height="100%"
         width="100%"
         {...loaderProps}>
-        <rect className="vtex-product-name__brand--loader" />
-        <rect className="vtex-product-name__sku--loader" />
+        <rect
+          height="1.125em"
+          width="75%"
+          x="15%"
+          {...loaderProps['vtex-product-name__brand--loader']}
+        />
+        <rect
+          height="1.125em"
+          width="50%"
+          x="25%"
+          y="1.75em"
+          {...loaderProps['vtex-product-name__sku--loader']}
+        />
       </ContentLoader>
     </div>
   )
@@ -83,8 +94,8 @@ class ProductName extends Component {
         <div className={skuClasses}>{skuName}</div>
         {showProductReference &&
           productReference && (
-          <div className="vtex-product-name__product-reference pt3 f7 ttu gray">{`REF: ${productReference}`}</div>
-        )}
+            <div className="vtex-product-name__product-reference pt3 f7 ttu gray">{`REF: ${productReference}`}</div>
+          )}
       </div>
     )
   }

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -23,6 +23,8 @@ class ProductName extends Component {
     showBrandName: PropTypes.bool,
     /** Display large font */
     large: PropTypes.bool,
+    /** Component and content loader styles */
+    styles: PropTypes.object,
   }
 
   static defaultProps = {
@@ -80,6 +82,7 @@ class ProductName extends Component {
     if (!name) {
       return (
         <ProductName.Loader
+          {...this.props.styles}
           brandClasses={brandClasses}
           skuClasses={skuClasses}
         />

--- a/react/components/ProductPrice/global.css
+++ b/react/components/ProductPrice/global.css
@@ -1,23 +1,3 @@
 .vtex-price-loader {
   height: 4.1em;
 }
-
-.vtex-price-list__container--loader {
-  height: 0.75em;
-  width: 50%;
-  x: 25%;
-}
-
-.vtex-price-selling--loader {
-  height: 1em;
-  width: 70%;
-  x: 15%;
-  y: 1.25em;
-}
-
-.vtex-price-installments--loader {
-  height: 0.75em;
-  width: 80%;
-  x: 10%;
-  y: 2.75em;
-}

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -1,12 +1,12 @@
-import './global.css'
+import './global.css';
 
-import PropTypes from 'prop-types'
-import { isEmpty, isNil } from 'ramda'
-import React, { Component } from 'react'
-import ContentLoader from 'react-content-loader'
-import { FormattedMessage, injectIntl } from 'react-intl'
+import PropTypes from 'prop-types';
+import { isEmpty, isNil } from 'ramda';
+import React, { Component } from 'react';
+import ContentLoader from 'react-content-loader';
+import { FormattedMessage, injectIntl } from 'react-intl';
 
-import PricePropTypes from './propTypes'
+import PricePropTypes from './propTypes';
 
 /**
  * The Price component. Shows the prices information of the Product Summary.
@@ -28,11 +28,28 @@ class Price extends Component {
         height="100%"
         width="100%"
         {...loaderProps}>
-        <rect className="vtex-price-list__container--loader" />
-        <rect className="vtex-price-selling__label--loader" />
-        <rect className="vtex-price-selling--loader" />
-        <rect className="vtex-price-installments--loader" />
-        <rect className="vtex-price-savings--loader" />
+        <rect
+          height="0.75em"
+          width="50%"
+          x="25%"
+          {...loaderProps['vtex-price-list__container--loader']}
+        />
+        <rect {...loaderProps['vtex-price-selling__label--loader']} />
+        <rect
+          height="1em"
+          width="70%"
+          x="15%"
+          y="1.25em"
+          {...loaderProps['vtex-price-selling--loader']}
+        />
+        <rect
+          height="0.75em"
+          width="80%"
+          x="10%"
+          y="2.75em"
+          {...loaderProps['vtex-price-installments--loader']}
+        />
+        <rect {...loaderProps['vtex-price-savings--loader']} />
       </ContentLoader>
     </div>
   )
@@ -134,7 +151,7 @@ class Price extends Component {
     } = this.props
 
     if ((showListPrice && isNil(listPrice)) || isNil(sellingPrice)) {
-      return <Price.Loader />
+      return <Price.Loader {...this.props.styles} />
     }
 
     const differentPrices = showListPrice && sellingPrice !== listPrice

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -1,12 +1,12 @@
-import './global.css';
+import './global.css'
 
-import PropTypes from 'prop-types';
-import { isEmpty, isNil } from 'ramda';
-import React, { Component } from 'react';
-import ContentLoader from 'react-content-loader';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import PropTypes from 'prop-types'
+import { isEmpty, isNil } from 'ramda'
+import React, { Component } from 'react'
+import ContentLoader from 'react-content-loader'
+import { FormattedMessage, injectIntl } from 'react-intl'
 
-import PricePropTypes from './propTypes';
+import PricePropTypes from './propTypes'
 
 /**
  * The Price component. Shows the prices information of the Product Summary.

--- a/react/components/ProductPrice/propTypes.js
+++ b/react/components/ProductPrice/propTypes.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import { intlShape } from 'react-intl';
+import PropTypes from 'prop-types'
+import { intlShape } from 'react-intl'
 
 export default {
   /** Product selling price */

--- a/react/components/ProductPrice/propTypes.js
+++ b/react/components/ProductPrice/propTypes.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types'
-import { intlShape } from 'react-intl'
+import PropTypes from 'prop-types';
+import { intlShape } from 'react-intl';
 
 export default {
   /** Product selling price */
@@ -29,6 +29,8 @@ export default {
       Name: PropTypes.string,
     })
   ),
+  /** Component and content loader styles */
+  styles: PropTypes.object,
   /** intl property to format data */
   intl: intlShape.isRequired,
 }

--- a/react/components/Share/global.css
+++ b/react/components/Share/global.css
@@ -5,22 +5,3 @@
 .vtex-share__social-button:hover:not(:active) {
   opacity: 0.75;
 }
-
-.vtex-share__button--loader {
-  r: 1em;
-  height: 2em;
-}
-
-.vtex-share__button--loader:nth-of-type(1) {
-  cx: 1em;
-  cy: 1em;
-}
-
-.vtex-share__button--loader:nth-of-type(2) {
-  cx: 3.5em;
-  cy: 1em;
-}
-.vtex-share__button--loader:nth-of-type(3) {
-  cx: 6em;
-  cy: 1em;
-}

--- a/react/components/Share/index.js
+++ b/react/components/Share/index.js
@@ -21,25 +21,48 @@ class Share extends Component {
     title: PropTypes.string,
     /** Indcates if the component should render the Content Loader */
     loading: PropTypes.bool,
+    /** Component and content loader styles */
+    styles: PropTypes.object,
   }
 
-  static Loader = (loaderProps = {}) => (
-    <div className="vtex-share">
-      <ContentLoader
-        className="vtex-share"
-        style={{
-          width: '100%',
-          height: '100%',
-        }}
-        height="100%"
-        width="100%"
-        {...loaderProps}>
-        <circle className="vtex-share__button--loader" />
-        <circle className="vtex-share__button--loader" />
-        <circle className="vtex-share__button--loader" />
-      </ContentLoader>
-    </div>
-  )
+  static Loader = (loaderProps = {}) => {
+    const loaderStyles = {
+      r: '1em',
+      height: '2em',
+      cy: '1em',
+      ...loaderProps['vtex-share__button--loader'],
+    }
+
+    return (
+      <div className="vtex-share">
+        <ContentLoader
+          className="vtex-share"
+          style={{
+            width: '100%',
+            height: '100%',
+          }}
+          height="100%"
+          width="100%"
+          {...loaderProps}>
+          <circle
+            cx="1em"
+            {...loaderStyles}
+            {...loaderProps['vtex-share__button--loader-1']}
+          />
+          <circle
+            cx="3.5em"
+            {...loaderStyles}
+            {...loaderProps['vtex-share__button--loader-2']}
+          />
+          <circle
+            cx="6em"
+            {...loaderStyles}
+            {...loaderProps['vtex-share__button--loader-3']}
+          />
+        </ContentLoader>
+      </div>
+    )
+  }
 
   static defaultProps = {
     social: {
@@ -81,7 +104,7 @@ class Share extends Component {
     } = this.props
 
     if (loading) {
-      return <Share.Loader />
+      return <Share.Loader {...this.props.styles} />
     }
 
     return (

--- a/react/components/Share/index.js
+++ b/react/components/Share/index.js
@@ -1,12 +1,12 @@
-import './global.css';
+import './global.css'
 
-import PropTypes from 'prop-types';
-import { indexBy, prop } from 'ramda';
-import React, { Component } from 'react';
-import ContentLoader from 'react-content-loader';
+import PropTypes from 'prop-types'
+import { indexBy, prop } from 'ramda'
+import React, { Component } from 'react'
+import ContentLoader from 'react-content-loader'
 
-import SocialButton from './components/SocialButton';
-import { SOCIAL_ENUM } from './constants/social';
+import SocialButton from './components/SocialButton'
+import { SOCIAL_ENUM } from './constants/social'
 
 class Share extends Component {
   static propTypes = {

--- a/react/components/ShippingSimulator/global.css
+++ b/react/components/ShippingSimulator/global.css
@@ -12,17 +12,6 @@
   height: 100%;
 }
 
-.vtex-shipping-simulator__zipcode-label--loader {
-  height: 100%;
-  width: 7em;
-}
-
-.vtex-shipping-simulator__input--loader {
-  height: 100%;
-  width: 15em;
-  x: 8em;
-}
-
 .vtex-shipping-simulator .vtex-input {
   height: 100%;
   margin-left: 10px;

--- a/react/components/ShippingSimulator/index.js
+++ b/react/components/ShippingSimulator/index.js
@@ -1,15 +1,15 @@
-import './global.css'
+import './global.css';
 
-import Button from '@vtex/styleguide/lib/Button'
-import Input from '@vtex/styleguide/lib/Input'
-import PropTypes from 'prop-types'
-import React, { Component, Fragment } from 'react'
-import { compose, withApollo } from 'react-apollo'
-import ContentLoader from 'react-content-loader'
-import { injectIntl, intlShape } from 'react-intl'
+import Button from '@vtex/styleguide/lib/Button';
+import Input from '@vtex/styleguide/lib/Input';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { compose, withApollo } from 'react-apollo';
+import ContentLoader from 'react-content-loader';
+import { injectIntl, intlShape } from 'react-intl';
 
-import ShippingTable from './components/ShippingTable'
-import getShippingEstimates from './queries/getShippingEstimates.gql'
+import ShippingTable from './components/ShippingTable';
+import getShippingEstimates from './queries/getShippingEstimates.gql';
 
 /**
  * Shipping simulator component
@@ -23,6 +23,8 @@ class ShippingSimulator extends Component {
     skuId: PropTypes.string.isRequired,
     seller: PropTypes.number.isRequired,
     country: PropTypes.string.isRequired,
+    /** Component and content loader styles */
+    styles: PropTypes.object,
   }
 
   static Loader = (loaderProps = {}) => (
@@ -36,8 +38,17 @@ class ShippingSimulator extends Component {
         height="100%"
         width="100%"
         {...loaderProps}>
-        <rect className="vtex-shipping-simulator__zipcode-label--loader" />
-        <rect className="vtex-shipping-simulator__input--loader" />
+        <rect
+          height="100%"
+          width="7em"
+          {...loaderProps['vtex-shipping-simulator__zipcode-label--loader']}
+        />
+        <rect
+          height="100%"
+          width="15em"
+          x="8em"
+          {...loaderProps['vtex-shipping-simulator__input--loader']}
+        />
       </ContentLoader>
     </div>
   )
@@ -112,8 +123,8 @@ class ShippingSimulator extends Component {
   render() {
     const { shipping, zipcodeValue, loading } = this.state
 
-    if (!this.props.seller || !this.props.skuId) {
-      return <ShippingSimulator.Loader />
+    if (!!this.props.seller || !this.props.skuId) {
+      return <ShippingSimulator.Loader {...this.props.styles} />
     }
 
     return (

--- a/react/components/ShippingSimulator/index.js
+++ b/react/components/ShippingSimulator/index.js
@@ -123,7 +123,7 @@ class ShippingSimulator extends Component {
   render() {
     const { shipping, zipcodeValue, loading } = this.state
 
-    if (!!this.props.seller || !this.props.skuId) {
+    if (!this.props.seller || !this.props.skuId) {
       return <ShippingSimulator.Loader {...this.props.styles} />
     }
 

--- a/react/components/ShippingSimulator/index.js
+++ b/react/components/ShippingSimulator/index.js
@@ -1,15 +1,15 @@
-import './global.css';
+import './global.css'
 
-import Button from '@vtex/styleguide/lib/Button';
-import Input from '@vtex/styleguide/lib/Input';
-import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-import { compose, withApollo } from 'react-apollo';
-import ContentLoader from 'react-content-loader';
-import { injectIntl, intlShape } from 'react-intl';
+import Button from '@vtex/styleguide/lib/Button'
+import Input from '@vtex/styleguide/lib/Input'
+import PropTypes from 'prop-types'
+import React, { Component, Fragment } from 'react'
+import { compose, withApollo } from 'react-apollo'
+import ContentLoader from 'react-content-loader'
+import { injectIntl, intlShape } from 'react-intl'
 
-import ShippingTable from './components/ShippingTable';
-import getShippingEstimates from './queries/getShippingEstimates.gql';
+import ShippingTable from './components/ShippingTable'
+import getShippingEstimates from './queries/getShippingEstimates.gql'
 
 /**
  * Shipping simulator component


### PR DESCRIPTION
#### What is the purpose of this pull request?
On Firefox, it was not possible to determine the SVG's style via CSS/Style prop. So, what works on Chrome and Safari, doesn't work on Firefox. To work in all browsers, the found solution was pass every style via elements properties.
In `ProductPrice`, for example, we have:
```jsx
if ((showListPrice && isNil(listPrice)) || isNil(sellingPrice)) {
   return <Price.Loader {...this.props.styles} />
}
```

Inside `Price.Loader`:
```jsx
<rect
   height="0.75em"
   width="50%"
   x="25%"
   {...loaderProps['vtex-price-list__container--loader']}
   />
```

Therefore, components like `ProductDetails` renders `ProductPrice` this way:
```jsx
<ProductPrice
  styles={productPriceLoaderStyles}
  listPrice={path(['ListPrice'], this.commertialOffer)}
  {/* Price props */}
  />
```

And:
```jsx
const productPriceLoaderStyles = {
  'vtex-price-list__container--loader': {
    x: 0,
    width: '7.219em',
    height: '0.56em',
  },
  /* ... */
}
```

Summing up, what was done via CSS classes, now will be done via JSX.

#### What problem is this solving?
Content Loaders not rendering on Firefox.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/44031926-dfd3cd10-9edb-11e8-8168-2e0e0cf48f61.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
