### PR TITLE
Powered by Gocommerce when it's a GC account

### DIFF
--- a/react/components/Footer/components/FooterPoweredBy.js
+++ b/react/components/Footer/components/FooterPoweredBy.js
@@ -5,9 +5,6 @@ import VTEXIcon from './../images/VTEX-BW.svg'
 
 class FooterPoweredBy extends PureComponent {
   static displayName = 'FooterPoweredBy'
-  static contextTypes = {
-    account: PropTypes.string,
-  }
 
   render() {
     return (

--- a/react/components/Footer/components/FooterPoweredBy.js
+++ b/react/components/Footer/components/FooterPoweredBy.js
@@ -1,0 +1,20 @@
+import React, { PureComponent } from 'react'
+
+import VTEXIcon from './../images/VTEX-BW.svg'
+
+class FooterPoweredBy extends PureComponent {
+  static displayName = 'FooterPoweredBy'
+  static contextTypes = {
+    account: PropTypes.func,
+  }
+
+  render() {
+    const { account } = this.context
+    if(account.indexOf('gc_') >= 0 || account.indexOf('gc-') >= 0) {
+      return <strong>GC</strong>
+    }
+    return <img className="vtex-footer__vtexlogo-form-item" src={VTEXIcon} />
+  }
+}
+
+export default FooterPoweredBy

--- a/react/components/Footer/components/FooterPoweredBy.js
+++ b/react/components/Footer/components/FooterPoweredBy.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import { RenderContextConsumer } from 'render'
 
 import VTEXIcon from './../images/VTEX-BW.svg'
 
@@ -9,11 +10,17 @@ class FooterPoweredBy extends PureComponent {
   }
 
   render() {
-    const { account } = this.context
-    if(account.indexOf('gc_') >= 0 || account.indexOf('gc-') >= 0) {
-      return <strong>GC</strong>
-    }
-    return <img className="vtex-footer__vtexlogo-form-item" src={VTEXIcon} />
+    return (
+      <RenderContextConsumer>
+        {context => {
+          const { account } = context
+          if(account.indexOf('gc_') >= 0 || account.indexOf('gc-') >= 0) {
+            return <strong>GC</strong>
+          }
+          return <img className="vtex-footer__vtexlogo-form-item" src={VTEXIcon} />
+        }}
+      </RenderContextConsumer>
+    )
   }
 }
 

--- a/react/components/Footer/components/FooterPoweredBy.js
+++ b/react/components/Footer/components/FooterPoweredBy.js
@@ -5,7 +5,7 @@ import VTEXIcon from './../images/VTEX-BW.svg'
 class FooterPoweredBy extends PureComponent {
   static displayName = 'FooterPoweredBy'
   static contextTypes = {
-    account: PropTypes.func,
+    account: PropTypes.string,
   }
 
   render() {

--- a/react/components/Footer/index.js
+++ b/react/components/Footer/index.js
@@ -5,13 +5,12 @@ import FooterLinkList from './components/FooterLinkList'
 import FooterBadgeList from './components/FooterBadgeList'
 import FooterPaymentFormList from './components/FooterPaymentFormList'
 import FooterSocialNetworkList from './components/FooterSocialNetworkList'
+import FooterPoweredBy from './components/FooterPoweredBy'
 import {
   objectLikeLinkArray,
   objectLikeBadgeArray,
   objectLikePaymentFormArray,
 } from './propTypes'
-
-import VTEXIcon from './images/VTEX-BW.svg'
 
 import './global.css'
 
@@ -198,11 +197,12 @@ export default class Footer extends Component {
           <FooterBadgeList list={badges} />
           <div className="vtex-footer__badge-list vtex-footer__list-container--right-aligned">
             <span className="vtex-footer__badge"><img className="vtex-footer__logo-image" src={logo} /></span>
-            <span className="vtex-footer__badge"><img className="vtex-footer__vtexlogo-form-item" src={VTEXIcon} /></span>
+            <span className="vtex-footer__badge">
+              <FooterPoweredBy />
+            </span>
           </div>
         </div>
       </footer>
     )
   }
 }
-


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use different "Powered By" logo for VTEX and GoCommerce accounts.

#### What problem is this solving?
Dynamically change the logo for the right platform.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
