### PR TITLE
Improvement in the documentation of `CategoriesHighlights`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Component name into the documentation of `CategoryHighlights`.
 
 ## [1.14.2] - 2018-08-22
 ### Added

--- a/react/components/CategoriesHighlights/README.md
+++ b/react/components/CategoriesHighlights/README.md
@@ -1,15 +1,15 @@
-# CategoriesHighlighted description
-CategoriesHighlighted is a canonical component that any VTEX app can import.
+# CategoriesHighlights description
+CategoriesHighlights is a canonical component that any VTEX app can import.
 
 To import it into your code: 
 ```js
-import CategoriesHighlighted from 'vtex.store-components/CategoriesHighlighted'
+import CategoriesHighlights from 'vtex.store-components/CategoriesHighlights'
 ```
 
 ## Usage
-You can use it in your code like a React component with the jsx tag: `<CategoriesHighlighted />`. 
+You can use it in your code like a React component with the jsx tag: `<CategoriesHighlights />`. 
 ```jsx
-<CategoriesHighlighted 
+<CategoriesHighlights
     categoriesHighlighted={ 
         categoryX: { name: 'X', image: 'Image X' }, 
         categoryY: { name: 'Y', image: 'Image Y' } 

--- a/react/components/CategoriesHighlights/index.js
+++ b/react/components/CategoriesHighlights/index.js
@@ -8,7 +8,7 @@ import CategoryCard from './components/CategoryCard'
 import { ITEMS_PER_ROW, RECTANGULAR, SQUARED } from './constants.js'
 
 /**
- * CategoriesHighlighted is a component responsible to display the
+ * CategoriesHighlights is a component responsible to display the
  * Categories highlighted in a department.
  */
 class CategoriesHighlights extends Component {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Refactor the component name into the `CategoriesHighlights` documentation.

#### What problem is this solving?
The component was being called 'CategoriesHightlighted` instead of `CategoriesHighlights`.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
