### PR TITLE
Change mini cart and login label color from props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Remove `MiniCart` label color from `global.css`.
+- `TopMenu` to pass classnames to change the icon and label of the `MiniCart` and `Login` instead of pass the hexadecimal color.
 
 ## [2.0.3] - 2018-09-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.4] - 2018-09-05
 ### Changed
 - `TopMenu` to pass classnames to change the icon and label of the `MiniCart` and `Login` instead of pass the hexadecimal color.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove `MiniCart` label color from `global.css`.
 
 ## [2.0.3] - 2018-09-05
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/Header/components/TopMenu.js
+++ b/react/components/Header/components/TopMenu.js
@@ -65,7 +65,7 @@ class TopMenu extends Component {
         </div>
         <ExtensionPoint
           id="minicart"
-          iconColor="#979899"
+          iconClasses="gray"
           iconSize={mobileMode ? MINICART_ICON_SIZE_MOBILE : MINICART_ICON_SIZE_DESKTOP}
           iconLabel={!mobileMode ? this.translate('topMenu.minicart.icon.label') : ''}
           labelClasses="gray"

--- a/react/components/Header/components/TopMenu.js
+++ b/react/components/Header/components/TopMenu.js
@@ -58,7 +58,8 @@ class TopMenu extends Component {
         <div className="mr7-m">
           <ExtensionPoint
             id="login"
-            iconColor="#979899"
+            iconClasses="gray"
+            labelClasses="gray"
             iconSize={mobileMode ? LOGIN_ICON_SIZE_MOBILE : LOGIN_ICON_SIZE_DESKTOP}
             iconLabel={!mobileMode ? this.translate('topMenu.login.icon.label') : ''}
           />

--- a/react/components/Header/components/TopMenu.js
+++ b/react/components/Header/components/TopMenu.js
@@ -68,6 +68,7 @@ class TopMenu extends Component {
           iconColor="#979899"
           iconSize={mobileMode ? MINICART_ICON_SIZE_MOBILE : MINICART_ICON_SIZE_DESKTOP}
           iconLabel={!mobileMode ? this.translate('topMenu.minicart.icon.label') : ''}
+          labelClasses="gray"
         />
       </div>
     )

--- a/react/components/Header/global.css
+++ b/react/components/Header/global.css
@@ -21,10 +21,6 @@
   outline: 0;
 }
 
-.vtex-login__profile, .vtex-login__label {
-  color: #979899;
-}
-
 .vtex-top-menu .vtex-minicart .vtex-button {
   border-width: 0px;
 }
@@ -39,7 +35,6 @@
   .vtex-top-menu__icons {
     width: 32%;
   }
-  
 }
 
 @media only screen and (min-width: 48.05rem) and (max-width: 76rem){

--- a/react/components/Header/global.css
+++ b/react/components/Header/global.css
@@ -60,7 +60,7 @@
 }
 
 @media only screen and (max-width: 76rem) {
-  .vtex-login__profile, .vtex-login__label, .vtex-minicart__label {
+  .vtex-login__profile {
     display: none;
   }
 }

--- a/react/components/Header/global.css
+++ b/react/components/Header/global.css
@@ -21,7 +21,7 @@
   outline: 0;
 }
 
-.vtex-login__profile, .vtex-login__label, .vtex-minicart__label {
+.vtex-login__profile, .vtex-login__label {
   color: #979899;
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change mini cart label color from props.

#### What problem is this solving?
When changing the mini cart label color directly from CSS, the mini cart sidebar header title also had its color changed because it is using the mini cart.

#### How should this be manually tested?
[Click here to access the workspace.](https://waza2--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
