### PR TITLE
Added a top margin to `Footer` component in order to not collapse with `Login`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Added a top margin to `Footer` component in order to not collapse with `Login`
+- `Footer` component top margin, in order to no collapse with `Login`
 
 ## [2.0.2] - 2018-08-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `Footer` component top margin, in order to no collapse with `Login`
+- `Footer` component top margin, in order to not collapse with `Login`
 
 ## [2.0.2] - 2018-08-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added a top margin to `Footer` component in order to not collapse with `Login`
 
 ## [2.0.2] - 2018-08-31
 ### Fixed

--- a/react/components/Footer/global.css
+++ b/react/components/Footer/global.css
@@ -1,5 +1,6 @@
 .vtex-footer {
   box-shadow: 4px -4px 8px 0 rgba(0, 0, 0, 0.2);
+  margin-top: 8px;
 }
 
 .vtex-footer__badge-list {

--- a/react/components/Footer/global.css
+++ b/react/components/Footer/global.css
@@ -1,6 +1,5 @@
 .vtex-footer {
   box-shadow: 4px -4px 8px 0 rgba(0, 0, 0, 0.2);
-  margin-top: 8px;
 }
 
 .vtex-footer__badge-list {

--- a/react/components/Footer/index.js
+++ b/react/components/Footer/index.js
@@ -228,7 +228,7 @@ export default class Footer extends Component {
     } = this.props
 
     return (
-      <footer className="vtex-footer">
+      <footer className="vtex-footer mt4">
         <div className="vtex-footer__container flex justify-between bg-white mid-gray">
           <div className="vtex-footer__links-container f6 w-100-s w-80-ns">
             <FooterLinksMatrix links={sectionLinks} />


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adding a top margin to `Footer` component in order to not collapse with `Login`

#### What problem is this solving?
An overlapping of the `Login` component on its page `/login`

#### How should this be manually tested?
https://lucianooutline--storecomponents.myvtex.com/login

#### Screenshots or example usage
<img width="768" alt="image" src="https://user-images.githubusercontent.com/18706156/44999585-dcd88c80-af94-11e8-8726-e88d6d6b73ae.png">

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
