### PR TITLE
Import the Logo and SearchBar as extension points of the Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Update `Price` props documentation.
+- `Header` to import the `Logo` and `Header` as extension points.
 
 ## [2.0.6] - 2018-09-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.0] - 2018-09-14
+
 ## [2.1.1] - 2018-09-13
 
 ## [2.1.0] - 2018-09-13

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/Header/components/TopMenu.js
+++ b/react/components/Header/components/TopMenu.js
@@ -5,7 +5,6 @@ import { ExtensionPoint, Link } from 'render'
 import classNames from 'classnames'
 import ReactResizeDetector from 'react-resize-detector'
 
-import Logo from '../../../Logo'
 import SearchBar from '../../../SearchBar'
 
 const LOGO_WIDTH_MOBILE = 90
@@ -24,7 +23,8 @@ class TopMenu extends Component {
     return (
       <div className="vtex-top-menu__logo w-20-m flex justify-start">
         <Link to="/" className="outline-0">
-          <Logo
+          <ExtensionPoint
+            id="logo"
             url={logoUrl}
             title={logoTitle}
             width={mobileMode ? LOGO_WIDTH_MOBILE : LOGO_WIDTH_DESKTOP}

--- a/react/components/Header/components/TopMenu.js
+++ b/react/components/Header/components/TopMenu.js
@@ -5,8 +5,6 @@ import { ExtensionPoint, Link } from 'render'
 import classNames from 'classnames'
 import ReactResizeDetector from 'react-resize-detector'
 
-import SearchBar from '../../../SearchBar'
-
 const LOGO_WIDTH_MOBILE = 90
 const LOGO_WIDTH_DESKTOP = 150
 const LOGO_HEIGHT_MOBILE = 30
@@ -44,7 +42,8 @@ class TopMenu extends Component {
   renderSearchBar(mobileMode) {
     return (
       <div className={`vtex-top-menu__search-bar flex pa2-m w-100 w-30-m ${mobileMode ? 'order-2' : 'order-1'}`}>
-        <SearchBar
+        <ExtensionPoint
+          id="search-bar"
           placeholder={this.translate('search-placeholder')}
           emptyPlaceholder={this.translate('search-emptyPlaceholder')}
         />


### PR DESCRIPTION
#### What is the purpose of this pull request?
Import the Logo and SearchBar as extension points of the Header.

OBS.: It should be released AFTER this [PR](https://github.com/vtex-apps/dreamstore/pull/78).

#### How should this be manually tested?
[Access the workspace.](https://waza3--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
