### PR TITLE
Availability prop to BuyButton component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Availability prop to `BuyButton` component.
 
 ## [2.3.1] - 2018-09-20
 ### Changed

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -1,7 +1,8 @@
 import find from 'lodash/find'
 import PropTypes from 'prop-types'
 import React, { Component, Fragment } from 'react'
-import { injectIntl, intlShape } from 'react-intl'
+import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
+
 import { contextPropTypes, orderFormConsumer } from 'vtex.store/OrderFormContext'
 import { Button } from 'vtex.styleguide'
 
@@ -19,6 +20,7 @@ const CONSTANTS = {
 export class BuyButton extends Component {
   static defaultProps = {
     isOneClickBuy: false,
+    available: true,
   }
 
   state = {
@@ -91,17 +93,20 @@ export class BuyButton extends Component {
   }
 
   render() {
-    const loading = this.state.isLoading || !this.props.skuItems
+    const { children, skuItems, available } = this.props
+    const loading = this.state.isLoading || !skuItems
 
     return (
       <Fragment>
         {loading ? (
           <Button disabled size="small" isLoading={loading}>
-            {this.props.children}
+            {children}
           </Button>
         ) : (
-            <Button primary size="small" onClick={() => this.handleAddToCart()}>
-              {this.props.children}
+            <Button primary size="small" disabled={!available} onClick={() => this.handleAddToCart()}>
+              {available ? children : (
+                <FormattedMessage id="buyButton-label-unavailable" />
+              )}
             </Button>
           )}
       </Fragment>
@@ -127,8 +132,10 @@ BuyButton.propTypes = {
   children: PropTypes.PropTypes.node.isRequired,
   /** Should redirect to checkout after adding to cart */
   isOneClickBuy: PropTypes.bool,
-  /* Internationalization */
+  /** Internationalization */
   intl: intlShape.isRequired,
+  /** If the product is available or not*/
+  available: PropTypes.bool.isRequired
 }
 
 export default orderFormConsumer(injectIntl(BuyButton))

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -89,5 +89,6 @@
   "editor.categoriesHighlighted.cardShape.rectangular": "Rectangular",
   "header.topMenu.minicart.icon.label": "My Cart",
   "header.topMenu.login.icon.label": "Sign in",
-  "searchBar.button.cancel.label": "Cancel"
+  "searchBar.button.cancel.label": "Cancel",
+  "buyButton-label-unavailable": "Unavailable"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -89,5 +89,6 @@
   "editor.categoriesHighlighted.cardShape.rectangular": "Rectangular",
   "header.topMenu.minicart.icon.label": "Mi Cesta",
   "header.topMenu.login.icon.label": "Entrar",
-  "searchBar.button.cancel.label": "Cancelar"
+  "searchBar.button.cancel.label": "Cancelar",
+  "buyButton-label-unavailable": "Indisponible"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -87,5 +87,6 @@
   "editor.categoriesHighlighted.cardShape.rectangular": "Retangular",
   "header.topMenu.minicart.icon.label": "Meu Carrinho",
   "header.topMenu.login.icon.label": "Entrar",
-  "searchBar.button.cancel.label": "Cancelar"
+  "searchBar.button.cancel.label": "Cancelar",
+  "buyButton-label-unavailable": "Indisponível"
 }


### PR DESCRIPTION
### Related to:
- [productSummary](https://github.com/vtex-apps/product-summary/pull/55)

#### What is the purpose of this pull request?
Add availability verification for displaying the BuyButton

#### What problem is this solving?
Products were being added to the cart even if they weren´t available

#### How should this be manually tested?
[workspace](https://felipe1--storecomponents.myvtex.com/cosmeticos/d)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3926634/46212780-32425800-c30d-11e8-9e23-e03594270bbb.png)

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
