### PR TITLE
Update the Animation component to use only CSS instead of Transition from spring module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.2] - 2018-10-18
 ### Changed
 - `Animation` component to use only CSS instead of `Transition` from the `spring` module.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `Animation` component to use only CSS instead of `Transition` from the `spring` module.
 
 ## [2.4.1] - 2018-10-02
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/Animation/README.md
+++ b/react/components/Animation/README.md
@@ -20,3 +20,5 @@ You can use it in your code like a React component with the jsx tag: `<Animation
 | `children`         | `Node!`    | Component children that will be displayed inside of the animation                           |
 | `type`             | `String`   | Type of the animation, it can be 'drawerLeft', 'drawerRight', 'drawerTop' or 'drawerBottom' |
 | `isActive`         | `Boolean`  | Active the animation                                                                        |
+| `duration`         | `number`   | The animation duration in seconds, the default value is 0.4 second.                         |
+| `transfer`         | `number`   | The animation delocation in percentage, the default value is 110%.                          |

--- a/react/components/Animation/README.md
+++ b/react/components/Animation/README.md
@@ -21,4 +21,5 @@ You can use it in your code like a React component with the jsx tag: `<Animation
 | `type`             | `String`   | Type of the animation, it can be 'drawerLeft', 'drawerRight', 'drawerTop' or 'drawerBottom' |
 | `isActive`         | `Boolean`  | Active the animation                                                                        |
 | `duration`         | `number`   | The animation duration in seconds, the default value is 0.4 second.                         |
-| `transfer`         | `number`   | The animation deslocation in percentage, the default value is 110%.                         |
+| `transfer`         | `number`   | The active animation dislocation in percentage, the default value is 110%.                  |
+| `transferEnter`    | `number`   | The not active animation dislocation in percentage, the default value is 0%.                |

--- a/react/components/Animation/README.md
+++ b/react/components/Animation/README.md
@@ -21,4 +21,4 @@ You can use it in your code like a React component with the jsx tag: `<Animation
 | `type`             | `String`   | Type of the animation, it can be 'drawerLeft', 'drawerRight', 'drawerTop' or 'drawerBottom' |
 | `isActive`         | `Boolean`  | Active the animation                                                                        |
 | `duration`         | `number`   | The animation duration in seconds, the default value is 0.4 second.                         |
-| `transfer`         | `number`   | The animation delocation in percentage, the default value is 110%.                          |
+| `transfer`         | `number`   | The animation deslocation in percentage, the default value is 110%.                         |

--- a/react/components/Animation/README.md
+++ b/react/components/Animation/README.md
@@ -21,5 +21,5 @@ You can use it in your code like a React component with the jsx tag: `<Animation
 | `type`             | `String`   | Type of the animation, it can be 'drawerLeft', 'drawerRight', 'drawerTop' or 'drawerBottom' |
 | `isActive`         | `Boolean`  | Active the animation                                                                        |
 | `duration`         | `number`   | The animation duration in seconds, the default value is 0.4 second.                         |
-| `transfer`         | `number`   | The active animation dislocation in percentage, the default value is 110%.                  |
-| `transferEnter`    | `number`   | The not active animation dislocation in percentage, the default value is 0%.                |
+| `transfer`         | `number`   | The active animation deslocation in percentage, the default value is 110%.                  |
+| `transferEnter`    | `number`   | The not active animation deslocation in percentage, the default value is 0%.                |

--- a/react/components/Animation/animation.js
+++ b/react/components/Animation/animation.js
@@ -1,0 +1,29 @@
+export const DRAWER_ANIMATION = {
+  drawerHorizontal: (duration, transfer) => ({
+    transform: `translateX(${transfer}%)`,
+    transition: `transform ${duration}s ease-in-out`,
+  }),
+  drawerVertical: (duration, transfer) => ({
+    transform: `translateY(${transfer}%)`,
+    transition: `transform ${duration}s ease-in-out`,
+  }),
+}
+
+export const ANIMATIONS = {
+  drawerLeft: {
+    from: (duration, transfer) => DRAWER_ANIMATION['drawerHorizontal'](duration, transfer - transfer),
+    leave: (duration, transfer) => DRAWER_ANIMATION['drawerHorizontal'](duration, transfer),
+  },
+  drawerRight: {
+    from: (duration, transfer) => DRAWER_ANIMATION['drawerHorizontal'](duration, transfer - transfer),
+    leave: (duration, transfer) => DRAWER_ANIMATION['drawerHorizontal'](duration, -transfer),
+  },
+  drawerTop: {
+    from: (duration, transfer) => DRAWER_ANIMATION['drawerVertical'](duration, transfer - transfer),
+    leave: (duration, transfer) => DRAWER_ANIMATION['drawerVertical'](duration, transfer),
+  },
+  drawerBottom: {
+    from: (duration, transfer) => DRAWER_ANIMATION['drawerVertical'](duration, transfer - transfer),
+    leave: (duration, transfer) => DRAWER_ANIMATION['drawerVertical'](duration, -transfer),
+  },
+}

--- a/react/components/Animation/animation.js
+++ b/react/components/Animation/animation.js
@@ -14,7 +14,7 @@ export const DRAWER_ANIMATION = {
 
 export const ANIMATIONS = {
   drawerLeft: {
-    from: (duration, transfer) => DRAWER_ANIMATION[DRAWER_HORIZONTAL](duration, transfer),
+    from: (duration, transfer) => DRAWER_ANIMATION[DRAWER_HORIZONTAL](duration, -transfer),
     leave: (duration, transfer) => DRAWER_ANIMATION[DRAWER_HORIZONTAL](duration, transfer),
   },
   drawerRight: {
@@ -22,7 +22,7 @@ export const ANIMATIONS = {
     leave: (duration, transfer) => DRAWER_ANIMATION[DRAWER_HORIZONTAL](duration, -transfer),
   },
   drawerTop: {
-    from: (duration, transfer) => DRAWER_ANIMATION[DRAWER_VERTICAL](duration, transfer),
+    from: (duration, transfer) => DRAWER_ANIMATION[DRAWER_VERTICAL](duration, -transfer),
     leave: (duration, transfer) => DRAWER_ANIMATION[DRAWER_VERTICAL](duration, transfer),
   },
   drawerBottom: {

--- a/react/components/Animation/animation.js
+++ b/react/components/Animation/animation.js
@@ -1,9 +1,12 @@
+const DRAWER_HORIZONTAL = 'drawerHorizontal'
+const DRAWER_VERTICAL = 'drawerVertical'
+
 export const DRAWER_ANIMATION = {
-  drawerHorizontal: (duration, transfer) => ({
+  [DRAWER_HORIZONTAL]: (duration, transfer) => ({
     transform: `translateX(${transfer}%)`,
     transition: `transform ${duration}s ease-in-out`,
   }),
-  drawerVertical: (duration, transfer) => ({
+  [DRAWER_VERTICAL]: (duration, transfer) => ({
     transform: `translateY(${transfer}%)`,
     transition: `transform ${duration}s ease-in-out`,
   }),
@@ -11,19 +14,19 @@ export const DRAWER_ANIMATION = {
 
 export const ANIMATIONS = {
   drawerLeft: {
-    from: (duration, transfer) => DRAWER_ANIMATION['drawerHorizontal'](duration, transfer - transfer),
-    leave: (duration, transfer) => DRAWER_ANIMATION['drawerHorizontal'](duration, transfer),
+    from: (duration, transfer) => DRAWER_ANIMATION[DRAWER_HORIZONTAL](duration, transfer),
+    leave: (duration, transfer) => DRAWER_ANIMATION[DRAWER_HORIZONTAL](duration, transfer),
   },
   drawerRight: {
-    from: (duration, transfer) => DRAWER_ANIMATION['drawerHorizontal'](duration, transfer - transfer),
-    leave: (duration, transfer) => DRAWER_ANIMATION['drawerHorizontal'](duration, -transfer),
+    from: (duration, transfer) => DRAWER_ANIMATION[DRAWER_HORIZONTAL](duration, transfer),
+    leave: (duration, transfer) => DRAWER_ANIMATION[DRAWER_HORIZONTAL](duration, -transfer),
   },
   drawerTop: {
-    from: (duration, transfer) => DRAWER_ANIMATION['drawerVertical'](duration, transfer - transfer),
-    leave: (duration, transfer) => DRAWER_ANIMATION['drawerVertical'](duration, transfer),
+    from: (duration, transfer) => DRAWER_ANIMATION[DRAWER_VERTICAL](duration, transfer),
+    leave: (duration, transfer) => DRAWER_ANIMATION[DRAWER_VERTICAL](duration, transfer),
   },
   drawerBottom: {
-    from: (duration, transfer) => DRAWER_ANIMATION['drawerVertical'](duration, transfer - transfer),
-    leave: (duration, transfer) => DRAWER_ANIMATION['drawerVertical'](duration, -transfer),
+    from: (duration, transfer) => DRAWER_ANIMATION[DRAWER_VERTICAL](duration, transfer),
+    leave: (duration, transfer) => DRAWER_ANIMATION[DRAWER_VERTICAL](duration, -transfer),
   },
 }

--- a/react/components/Animation/index.js
+++ b/react/components/Animation/index.js
@@ -35,7 +35,7 @@ export default class Animation extends Component {
     transferEnter: ANIMATION_TRANSFER_ENTER,
   }
 
-  getAnimation = () => {
+  get animation() {
     const { isActive, type, duration, transfer, transferEnter } = this.props
     let animation = ANIMATIONS[type]
     if (isActive) {
@@ -48,10 +48,9 @@ export default class Animation extends Component {
 
   render() {
     const { className, children } = this.props
-    const animation = this.getAnimation()
 
     return (
-      <div className={className} style={animation}>
+      <div className={className} style={this.animation}>
         {children}
       </div>
     )

--- a/react/components/Animation/index.js
+++ b/react/components/Animation/index.js
@@ -21,9 +21,9 @@ export default class Animation extends Component {
     type: PropTypes.oneOf(['drawerLeft', 'drawerRight', 'drawerTop', 'drawerBottom']),
     /* The animation's duration in seconds */
     duration: PropTypes.number,
-    /* The active animation dislocation in percentage */
+    /* The active animation deslocation in percentage */
     transfer: PropTypes.number,
-    /* The not active animation dislocation in percentage */
+    /* The not active animation deslocation in percentage */
     transferEnter: PropTypes.number,
   }
 

--- a/react/components/Animation/index.js
+++ b/react/components/Animation/index.js
@@ -1,30 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-
-import { Transition } from 'react-spring'
-
-const ANIMATIONS = {
-  drawerLeft: {
-    from: { transform: 'translateX(100%)' },
-    enter: { transform: 'translateX(0%)' },
-    leave: { transform: 'translateX(100%)' },
-  },
-  drawerRight: {
-    from: { transform: 'translateX(-100%)' },
-    enter: { transform: 'translateX(0%)' },
-    leave: { transform: 'translateX(-100%)' },
-  },
-  drawerTop: {
-    from: { transform: 'translateY(-100%)' },
-    enter: { transform: 'translateY(0%)' },
-    leave: { transform: 'translateY(-100%)' },
-  },
-  drawerBottom: {
-    from: { transform: 'translateY(100%)' },
-    enter: { transform: 'translateY(0%)' },
-    leave: { transform: 'translateY(100%)' },
-  },
-}
+import { ANIMATIONS } from './animation'
 
 /**
  * Animation component
@@ -39,32 +15,27 @@ export default class Animation extends Component {
     className: PropTypes.string,
     /* Type of animation */
     type: PropTypes.oneOf(['drawerLeft', 'drawerRight', 'drawerTop', 'drawerBottom']),
+    /* The animation's duration in seconds */
+    duration: PropTypes.number,
+    /* The animation's deslocation in percentage */
+    transfer: PropTypes.number,
   }
 
   static defaultProps = {
     className: '',
     type: 'drawerLeft',
+    duration: 0.4,
+    transfer: 110,
   }
 
-  renderChildren = style => (
-    <div className={this.props.className}
-      style={style}
-    >
-      {this.props.children}
-    </div>
-  )
-
   render() {
-    const { isActive, type } = this.props
-    const style = ANIMATIONS[type]
+    const { isActive, type, className, children, duration, transfer } = this.props
+    const style = ANIMATIONS[type][isActive ? 'from' : 'leave'](duration, transfer)
 
     return (
-      <Transition
-        keys={isActive ? ['children'] : []}
-        {...style}
-      >
-        {isActive ? [this.renderChildren] : []}
-      </Transition>
+      <div className={className} style={style}>
+        {children}
+      </div>
     )
   }
 }

--- a/react/components/Animation/index.js
+++ b/react/components/Animation/index.js
@@ -21,7 +21,7 @@ export default class Animation extends Component {
     type: PropTypes.oneOf(['drawerLeft', 'drawerRight', 'drawerTop', 'drawerBottom']),
     /* The animation's duration in seconds */
     duration: PropTypes.number,
-    /* The active animation's dislocation in percentage */
+    /* The active animation dislocation in percentage */
     transfer: PropTypes.number,
     /* The not active animation dislocation in percentage */
     transferEnter: PropTypes.number,

--- a/react/components/Animation/index.js
+++ b/react/components/Animation/index.js
@@ -2,6 +2,10 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { ANIMATIONS } from './animation'
 
+const ANIMATION_TRANSFER = 110
+const ANIMATION_TRANSFER_ENTER = 0
+const ANIMATION_TIME = 0.4
+
 /**
  * Animation component
  */
@@ -17,23 +21,37 @@ export default class Animation extends Component {
     type: PropTypes.oneOf(['drawerLeft', 'drawerRight', 'drawerTop', 'drawerBottom']),
     /* The animation's duration in seconds */
     duration: PropTypes.number,
-    /* The animation's deslocation in percentage */
+    /* The active animation's dislocation in percentage */
     transfer: PropTypes.number,
+    /* The not active animation dislocation in percentage */
+    transferEnter: PropTypes.number,
   }
 
   static defaultProps = {
     className: '',
     type: 'drawerLeft',
-    duration: 0.4,
-    transfer: 110,
+    duration: ANIMATION_TIME,
+    transfer: ANIMATION_TRANSFER,
+    transferEnter: ANIMATION_TRANSFER_ENTER,
+  }
+
+  getAnimation = () => {
+    const { isActive, type, duration, transfer, transferEnter } = this.props
+    let animation = ANIMATIONS[type]
+    if (isActive) {
+      animation = animation['from'](duration, transferEnter)
+    } else {
+      animation = animation['leave'](duration, transfer)
+    }
+    return animation
   }
 
   render() {
-    const { isActive, type, className, children, duration, transfer } = this.props
-    const style = ANIMATIONS[type][isActive ? 'from' : 'leave'](duration, transfer)
+    const { className, children } = this.props
+    const animation = this.getAnimation()
 
     return (
-      <div className={className} style={style}>
+      <div className={className} style={animation}>
         {children}
       </div>
     )

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,6 @@
     "react-responsive-modal": "^2.0.1",
     "react-share": "^2.1.1",
     "react-slick": "^0.23.1",
-    "react-spring": "^5.6.12",
     "render": "^0.1.4",
     "slick-carousel": "^1.8.1",
     "underscore": "^1.9.1",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the Animation component to use only CSS instead of Transition from spring module.

#### How should this be manually tested?
The sidebar of the mini cart and the Category menu in the mobile mode are using this component. 
[Check it out!](https://waza2--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
