### PR TITLE
Fix BuyButton loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.3] - 2018-10-31
 ### Fixed
 - Replace spinner by content loader in BuyButton.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Replace spinner by content loader in BuyButton
+- Replace spinner by content loader in BuyButton.
 
 ## [2.4.2] - 2018-10-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Replace spinner by content loader in BuyButton
 
 ## [2.4.2] - 2018-10-18
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -26,6 +26,7 @@ export class BuyButton extends Component {
 
   state = {
     isLoading: false,
+    isAddingToCart: false,
     timeOut: null,
   }
 
@@ -44,16 +45,15 @@ export class BuyButton extends Component {
 
     orderFormContext.updateToastMessage(message)
 
-    const timeOut = window.setTimeout(() => {
+    window.setTimeout(() => {
       orderFormContext.updateToastMessage({ isSuccess: null, text: null })
       this.setState({ timeOut: null })
     }, CONSTANTS.TOAST_TIMEOUT)
-
-    this.setState({ isLoading: false, timeOut })
   }
 
-  handleAddToCart = () => {
+  handleAddToCart = async () => {
     const { skuItems, isOneClickBuy, orderFormContext } = this.props
+    this.setState({ isAddingToCart: true })
 
     const variables = {
       items: skuItems.map(skuItem => {
@@ -67,16 +67,11 @@ export class BuyButton extends Component {
       }),
     }
 
-    this.setState({ isAddingToCart: true })
-
     variables.orderFormId = orderFormContext.orderForm.orderFormId
 
     if (isOneClickBuy) location.assign(CONSTANTS.CHECKOUT_URL)
 
-    orderFormContext
-      .addItem({
-        variables,
-      })
+    await orderFormContext.addItem({ variables })
       .then(
         mutationRes => {
           const { items } = mutationRes.data.addItem
@@ -90,15 +85,14 @@ export class BuyButton extends Component {
         () => {
           this.toastMessage(false)
         }
-      ).finally(() => {
-        this.setState({ isAddingToCart: false })
-      })
+      )
+    this.setState({ isAddingToCart: false })
   }
 
   render() {
     const { children, skuItems, available } = this.props
     const loading = this.state.isLoading || !skuItems
-    const isAddingToCart = this.state.isAddingToCart
+    const { isAddingToCart } = this.state
 
     return (
       <Fragment>

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -2,6 +2,7 @@ import find from 'lodash/find'
 import PropTypes from 'prop-types'
 import React, { Component, Fragment } from 'react'
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
+import ContentLoader from 'react-content-loader'
 
 import { contextPropTypes, orderFormConsumer } from 'vtex.store/OrderFormContext'
 import { Button } from 'vtex.styleguide'
@@ -66,7 +67,7 @@ export class BuyButton extends Component {
       }),
     }
 
-    this.setState({ isLoading: true })
+    this.setState({ isAddingToCart: true })
 
     variables.orderFormId = orderFormContext.orderForm.orderFormId
 
@@ -89,26 +90,27 @@ export class BuyButton extends Component {
         () => {
           this.toastMessage(false)
         }
-      )
+      ).finally(() => {
+        this.setState({ isAddingToCart: false })
+      })
   }
 
   render() {
     const { children, skuItems, available } = this.props
     const loading = this.state.isLoading || !skuItems
+    const isAddingToCart = this.state.isAddingToCart
 
     return (
       <Fragment>
         {loading ? (
-          <Button disabled size="small" isLoading={loading}>
-            {children}
-          </Button>
+          <ContentLoader />
         ) : (
-            <Button primary size="small" disabled={!available} onClick={() => this.handleAddToCart()}>
-              {available ? children : (
-                <FormattedMessage id="buyButton-label-unavailable" />
-              )}
-            </Button>
-          )}
+          <Button primary size="small" disabled={!available} onClick={() => this.handleAddToCart()} isLoading={isAddingToCart}>
+            {available ? children : (
+              <FormattedMessage id="buyButton-label-unavailable" />
+            )}
+          </Button>
+        )}
       </Fragment>
     )
   }
@@ -135,7 +137,7 @@ BuyButton.propTypes = {
   /** Internationalization */
   intl: intlShape.isRequired,
   /** If the product is available or not*/
-  available: PropTypes.bool.isRequired
+  available: PropTypes.bool.isRequired,
 }
 
 export default orderFormConsumer(injectIntl(BuyButton))


### PR DESCRIPTION
#### What is the purpose of this pull request?
Replace Spinner with a ContentLoader in BuyButton while loading the component

#### What problem is this solving?
Making the design more consistent

#### How should this be manually tested?
[Access this workspace](https://fixloadingprodsummary--storecomponents.myvtex.com/) and in the network select slow 3G, so the loading can be seen appropriately.

#### Screenshots or example usage
*Before*
![before](https://user-images.githubusercontent.com/4912690/47517133-9fd69b00-d85d-11e8-9446-10ac5ef35053.png)

*After*
![after](https://user-images.githubusercontent.com/4912690/47517180-c0065a00-d85d-11e8-9f0d-6a58b4f84a92.png)

*While adding to cart*
![adding to cart](https://user-images.githubusercontent.com/4912690/47517200-d01e3980-d85d-11e8-87ad-969fc50bc022.png)


#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
