### PR TITLE
Assign correct size to arrow element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.6.4] - 2018-11-20
 ### Fixed
 - Assign correct size to arrow element.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Assing correct size to arrow element.
 
 ## [2.6.3] - 2018-11-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Assing correct size to arrow element.
+- Assign correct size to arrow element.
 
 ## [2.6.3] - 2018-11-20
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/Slider/global.css
+++ b/react/components/Slider/global.css
@@ -1,3 +1,9 @@
 @import url('~slick-carousel/slick/slick.css');
 @import url('~slick-carousel/slick/slick-theme.css');
 @import url('./slider.css');
+
+/* Fixes uneven arrows distance */
+.slick-prev, .slick-next {
+    width: inherit !important;
+    height: inherit !important;
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
The arrow area was not corresponding to real element size (20x20 instead of 48x48). Now is inherited from the parent

#### What problem is this solving?
If the area is wrong, align the arrows with the rest of the page is a hard task

#### How should this be manually tested?
[Access this workspace](https://alignheader--storecomponents.myvtex.com/)
Any arrow should have any the area of 48x48.

#### Screenshots or example usage
![arrow-example](https://user-images.githubusercontent.com/6964311/48021321-03db4800-e117-11e8-815d-735391ea26b8.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
