### PR TITLE
[SearchBar] Add mobileMode to change the layout in mobile devices. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `compactMode` props that change the design of `SearchBar` component to a compact layout.
 
 ## [2.5.2] - 2018-11-07
 ### Changed

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -15,9 +15,7 @@ export default class AutocompleteInput extends Component {
   }
 
   changeClassInput() {
-
     const { compactMode } = this.props
-
     if (compactMode) {
       this.inputClass.current.placeholder = ""
     }
@@ -31,19 +29,26 @@ export default class AutocompleteInput extends Component {
     this.changeClassInput()
   }
 
-  componentWillUpdate() {
-    this.changeClassInput()
+  cleanInputField() {
+    let { value } = this.props
+    console.log(value)
+    value = ""
   }
+
+
 
   render() {
 
-    const { onGoToSearchPage, compactMode, value, ...restProps } = this.props
+    const { onGoToSearchPage, onClearInput, compactMode, value, ...restProps } = this.props
 
     const prefixIcon = (
       compactMode ? <IconSearch color="#979899" /> : ""
     )
     const suffixIcon = (
-      compactMode ? !value ? "" : <IconClose className="pa0" size={10} color="#979899" />
+      compactMode ? !value ? "" :
+        <span className="flex items-center pointer" onClick={onClearInput} >
+          <IconClose className="pa0" size={10} color="#979899" />
+        </span>
         :
         <span className="flex items-center pointer" onClick={onGoToSearchPage}>
           <IconSearch color="#979899" />
@@ -51,16 +56,16 @@ export default class AutocompleteInput extends Component {
     )
 
     const classContainer = classNames(
-      
+      'w-100',
       {
-        'vtex-searchbar__border-bottom': compactMode
+        'vtex-searchbar__compact-mode': compactMode
       }
     )
 
     return (
       <div className="flex">
         <div className={classContainer}>
-          <Input ref={this.inputClass} size="large" {...restProps} suffixIcon={suffixIcon} prefix={prefixIcon} />
+          <Input ref={this.inputClass} size="large" value={value} {...restProps} suffixIcon={suffixIcon} prefix={prefixIcon} />
         </div>
       </div>
     )
@@ -85,4 +90,6 @@ AutocompleteInput.propTypes = {
   /** Function to direct the user to the searchPage */
   onGoToSearchPage: PropTypes.func.isRequired,
   compactMode: PropTypes.bool,
+  /** Clears the input */
+  onClearInput: PropTypes.func,
 }

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
-import { Input, IconClose } from 'vtex.styleguide'
-import IconSearch from '../images/IconSearch'
+import { Input, IconClose, IconSearch } from 'vtex.styleguide'
 
 /** Midleware component to adapt the styleguide/Input to be used by the Downshift*/
 export default class AutocompleteInput extends Component {

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -1,23 +1,29 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-import { Input } from 'vtex.styleguide'
+import { Input, IconClose } from 'vtex.styleguide'
 import IconSearch from '../images/IconSearch'
 
 /** Midleware component to adapt the styleguide/Input to be used by the Downshift*/
 export default class AutocompleteInput extends Component {
   render() {
-    const { onGoToSearchPage, ...restProps } = this.props
+    const { onGoToSearchPage, mobileMode, value, ...restProps } = this.props
+
+    const prefixIcon = (
+      mobileMode ? <IconSearch color="#979899" /> : ""
+    )
 
     const suffixIcon = (
-      <span className="flex items-center pointer" onClick={onGoToSearchPage}>
-        <IconSearch color="#979899" />
-      </span>
+      mobileMode ? !value ? "" : <IconClose className="pa0" size={10} color="#979899" />
+        :
+        <span className="flex items-center pointer" onClick={onGoToSearchPage}>
+          <IconSearch color="#979899" />
+        </span>
     )
 
     return (
       <div className="flex">
-        <Input size="large" {...restProps} suffixIcon={suffixIcon} />
+        <Input size="large" {...restProps} suffixIcon={suffixIcon} prefix={prefixIcon} />
       </div>
     )
   }
@@ -40,4 +46,5 @@ AutocompleteInput.propTypes = {
   placeholder: PropTypes.string,
   /** Function to direct the user to the searchPage */
   onGoToSearchPage: PropTypes.func.isRequired,
+  mobileMode: PropTypes.bool,
 }

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -21,10 +21,6 @@ export default class AutocompleteInput extends Component {
     }
   }
 
-  componentDidUpdate() {
-    this.changeClassInput()
-  }
-
   componentDidMount() {
     this.changeClassInput()
   }

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 
 import { Input, IconClose } from 'vtex.styleguide'
 import IconSearch from '../images/IconSearch'
@@ -15,15 +16,15 @@ export default class AutocompleteInput extends Component {
 
   changeClassInput() {
 
-    const { mobileMode } = this.props
+    const { compactMode } = this.props
 
-    if (mobileMode) {
+    if (compactMode) {
       this.inputClass.current.placeholder = ""
-      this.inputClass.current.classList.remove('bw1')
-      this.inputClass.current.classList.add('bn')
-      this.inputClass.current.classList.add('vtex-searchbar__border-bottom')
     }
-    console.log(this.inputClass)
+  }
+
+  componentDidUpdate() {
+    this.changeClassInput()
   }
 
   componentDidMount() {
@@ -36,22 +37,31 @@ export default class AutocompleteInput extends Component {
 
   render() {
 
-    const { onGoToSearchPage, mobileMode, value, ...restProps } = this.props
+    const { onGoToSearchPage, compactMode, value, ...restProps } = this.props
 
     const prefixIcon = (
-      mobileMode ? <IconSearch color="#979899" /> : ""
+      compactMode ? <IconSearch color="#979899" /> : ""
     )
     const suffixIcon = (
-      mobileMode ? !value ? "" : <IconClose className="pa0" size={10} color="#979899" />
+      compactMode ? !value ? "" : <IconClose className="pa0" size={10} color="#979899" />
         :
         <span className="flex items-center pointer" onClick={onGoToSearchPage}>
           <IconSearch color="#979899" />
         </span>
     )
 
+    const classContainer = classNames(
+      
+      {
+        'vtex-searchbar__border-bottom': compactMode
+      }
+    )
+
     return (
       <div className="flex">
-        <Input ref={this.inputClass} size="large" {...restProps} suffixIcon={suffixIcon} prefix={prefixIcon} />
+        <div className={classContainer}>
+          <Input ref={this.inputClass} size="large" {...restProps} suffixIcon={suffixIcon} prefix={prefixIcon} />
+        </div>
       </div>
     )
   }
@@ -74,5 +84,5 @@ AutocompleteInput.propTypes = {
   placeholder: PropTypes.string,
   /** Function to direct the user to the searchPage */
   onGoToSearchPage: PropTypes.func.isRequired,
-  mobileMode: PropTypes.bool,
+  compactMode: PropTypes.bool,
 }

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -6,13 +6,41 @@ import IconSearch from '../images/IconSearch'
 
 /** Midleware component to adapt the styleguide/Input to be used by the Downshift*/
 export default class AutocompleteInput extends Component {
+
+  constructor(props) {
+    super(props)
+    this.inputClass = React.createRef();
+    this.changeClassInput = this.changeClassInput.bind(this)
+  }
+
+  changeClassInput() {
+
+    const { mobileMode } = this.props
+
+    if (mobileMode) {
+      this.inputClass.current.placeholder = ""
+      this.inputClass.current.classList.remove('bw1')
+      this.inputClass.current.classList.add('bn')
+      this.inputClass.current.classList.add('vtex-searchbar__border-bottom')
+    }
+    console.log(this.inputClass)
+  }
+
+  componentDidMount() {
+    this.changeClassInput()
+  }
+
+  componentWillUpdate() {
+    this.changeClassInput()
+  }
+
   render() {
+
     const { onGoToSearchPage, mobileMode, value, ...restProps } = this.props
 
     const prefixIcon = (
       mobileMode ? <IconSearch color="#979899" /> : ""
     )
-
     const suffixIcon = (
       mobileMode ? !value ? "" : <IconClose className="pa0" size={10} color="#979899" />
         :
@@ -23,7 +51,7 @@ export default class AutocompleteInput extends Component {
 
     return (
       <div className="flex">
-        <Input size="large" {...restProps} suffixIcon={suffixIcon} prefix={prefixIcon} />
+        <Input ref={this.inputClass} size="large" {...restProps} suffixIcon={suffixIcon} prefix={prefixIcon} />
       </div>
     )
   }

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -29,14 +29,6 @@ export default class AutocompleteInput extends Component {
     this.changeClassInput()
   }
 
-  cleanInputField() {
-    let { value } = this.props
-    console.log(value)
-    value = ""
-  }
-
-
-
   render() {
 
     const { onGoToSearchPage, onClearInput, compactMode, value, ...restProps } = this.props

--- a/react/components/SearchBar/components/ResultsList.js
+++ b/react/components/SearchBar/components/ResultsList.js
@@ -7,7 +7,7 @@ import { Link } from 'render'
 import autocomplete from '../queries/autocomplete.gql'
 
 const listClassNames =
-  'vtex-results__list z-max absolute w-100 mt1 mt2-m shadow-3 bg-white f5 left-0'
+  'vtex-results__list z-max absolute w-100 mt1 mt2-m bg-white f5 left-0'
 const listItemClassNames =
   'vtex-results__item flex justify-start f5 pa4 pl6 outline-0'
 

--- a/react/components/SearchBar/components/ResultsList.js
+++ b/react/components/SearchBar/components/ResultsList.js
@@ -7,7 +7,7 @@ import { Link } from 'render'
 import autocomplete from '../queries/autocomplete.gql'
 
 const listClassNames =
-  'vtex-results__list z-max absolute w-100 mt1 mt2-m bg-white f5 left-0'
+  'vtex-results__list z-max absolute w-100 mt1 mt2-m pb4 bg-white f5 left-0'
 const listItemClassNames =
   'vtex-results__item flex justify-start f5 pa4 pl6 outline-0'
 

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -18,7 +18,7 @@ export default class SearchBar extends Component {
       onClearInput,
       shouldSearch,
       inputValue,
-      mobileMode
+      compactMode
     } = this.props
 
     const fallback = (
@@ -48,7 +48,7 @@ export default class SearchBar extends Component {
             }) => (
               <div className="relative-m w-100">
                 <AutocompleteInput
-                  mobileMode={mobileMode}
+                  compactMode={compactMode}
                   onGoToSearchPage={() => {
                     closeMenu()
                     onGoToSearchPage()
@@ -103,6 +103,6 @@ SearchBar.propTypes = {
   onGoToSearchPage: PropTypes.func.isRequired,
   /** Function to clear the input */
   onClearInput: PropTypes.func.isRequired,
-  /** Indentify when a the component is used in a mobile */
-  mobileMode: PropTypes.bool,
+  /** Indentify when use the compact version of the component */
+  compactMode: PropTypes.bool,
 }

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -1,10 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-
+import classNames from 'classnames'
 import AutocompleteInput from './AutocompleteInput'
 import ResultsLits from './ResultsList'
 import DownshiftComponent from 'downshift'
-
 import { NoSSR } from 'render'
 
 export default class SearchBar extends Component {
@@ -19,7 +18,10 @@ export default class SearchBar extends Component {
       onClearInput,
       shouldSearch,
       inputValue,
+      mobileMode
     } = this.props
+
+    console.log(mobileMode)
 
     const fallback = (
       <AutocompleteInput
@@ -31,8 +33,15 @@ export default class SearchBar extends Component {
       />
     )
 
+    const mainClasses = classNames(
+      'vtex-searchbar w-100 no-borders', 
+      {
+        'no-borders' : mobileMode
+      }
+    )
+
     return (
-      <div className="vtex-searchbar w-100">
+      <div className={mainClasses}>
         <NoSSR onSSR={fallback}>
           <DownshiftComponent>
             {({
@@ -44,6 +53,7 @@ export default class SearchBar extends Component {
             }) => (
               <div className="relative-m w-100">
                 <AutocompleteInput
+                  mobileMode={mobileMode}
                   onGoToSearchPage={() => {
                     closeMenu()
                     onGoToSearchPage()
@@ -98,4 +108,6 @@ SearchBar.propTypes = {
   onGoToSearchPage: PropTypes.func.isRequired,
   /** Function to clear the input */
   onClearInput: PropTypes.func.isRequired,
+  /** Indentify when a the component is used in a mobile */
+  mobileMode: PropTypes.bool,
 }

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -21,8 +21,6 @@ export default class SearchBar extends Component {
       mobileMode
     } = this.props
 
-    console.log(mobileMode)
-
     const fallback = (
       <AutocompleteInput
         placeholder={placeholder}
@@ -34,10 +32,7 @@ export default class SearchBar extends Component {
     )
 
     const mainClasses = classNames(
-      'vtex-searchbar w-100 no-borders', 
-      {
-        'no-borders' : mobileMode
-      }
+      'vtex-searchbar w-100'
     )
 
     return (

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -49,6 +49,7 @@ export default class SearchBar extends Component {
               <div className="relative-m w-100">
                 <AutocompleteInput
                   compactMode={compactMode}
+                  onClearInput={onClearInput}
                   onGoToSearchPage={() => {
                     closeMenu()
                     onGoToSearchPage()
@@ -62,6 +63,7 @@ export default class SearchBar extends Component {
                       onEnterPress(event)
                     },
                   })}
+                  
                 />
                 {shouldSearch && isOpen ? (
                   <ResultsLits

--- a/react/components/SearchBar/global.css
+++ b/react/components/SearchBar/global.css
@@ -23,10 +23,6 @@
   border-radius: 1px;
 }
 
-.vtex-searchbar .no-borders {
-  border:none !important;
-}
-
 .vtex-searchbar .vtex-results__list {
   top: 100%;
 }

--- a/react/components/SearchBar/global.css
+++ b/react/components/SearchBar/global.css
@@ -23,7 +23,10 @@
   border-radius: 1px;
 }
 
-.vtex-searchbar__border-bottom {
+.vtex-searchbar__compact-mode input{
+  border-top-style: none !important; 
+  border-left-style: none !important; 
+  border-right-style: none !important; 
   border-bottom: solid !important;
 }
 

--- a/react/components/SearchBar/global.css
+++ b/react/components/SearchBar/global.css
@@ -23,6 +23,10 @@
   border-radius: 1px;
 }
 
+.vtex-searchbar .no-borders {
+  border:none !important;
+}
+
 .vtex-searchbar .vtex-results__list {
   top: 100%;
 }

--- a/react/components/SearchBar/global.css
+++ b/react/components/SearchBar/global.css
@@ -27,7 +27,7 @@
   border-top-style: none !important; 
   border-left-style: none !important; 
   border-right-style: none !important; 
-  border-bottom: solid !important;
+  border-bottom: 2px solid !important;
 }
 
 .vtex-searchbar .vtex-results__list {

--- a/react/components/SearchBar/global.css
+++ b/react/components/SearchBar/global.css
@@ -23,6 +23,10 @@
   border-radius: 1px;
 }
 
+.vtex-searchbar__border-bottom {
+  border-bottom: solid !important;
+}
+
 .vtex-searchbar .vtex-results__list {
   top: 100%;
 }

--- a/react/components/SearchBar/global.css
+++ b/react/components/SearchBar/global.css
@@ -51,6 +51,6 @@
   .vtex-results__list {
     margin: 0px;
     max-height: calc(100vh - 6.2rem);
-    box-shadow: inset 0px 4px 4px 0 rgba(0, 0, 0, .2), 0px 4px 4px 0 rgba(0, 0, 0, .2);
+    box-shadow: inset 0px 2px 2px 0 rgba(0, 0, 0, .1);
   }
 }

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -23,7 +23,6 @@ class SearchBarContainer extends Component {
   }
 
   handleClearInput = () => {
-    console.log(this.state.inputValue)
     this.setState({ inputValue: '' })
     this.handleClearSearchResults()
   }

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -23,6 +23,7 @@ class SearchBarContainer extends Component {
   }
 
   handleClearInput = () => {
+    console.log(this.state.inputValue)
     this.setState({ inputValue: '' })
     this.handleClearSearchResults()
   }

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -64,7 +64,7 @@ class SearchBarContainer extends Component {
   }
 
   render() {
-    const { intl } = this.props
+    const { intl, mobileMode } = this.props
     const { shouldSearch, inputValue } = this.state
 
     const placeholder = intl.formatMessage({
@@ -85,6 +85,7 @@ class SearchBarContainer extends Component {
         onEnterPress={this.handleEnterPress}
         onMakeSearch={this.handleMakeSearch}
         onInputChange={this.handleInputChange}
+        mobileMode={mobileMode}
       />
     )
   }
@@ -97,6 +98,9 @@ SearchBarContainer.contextTypes = {
 SearchBarContainer.propTypes = {
   /* Internationalization */
   intl: intlShape.isRequired,
+  mobileMode: PropTypes.bool,
 }
+
+
 
 export default injectIntl(SearchBarContainer)

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -64,7 +64,7 @@ class SearchBarContainer extends Component {
   }
 
   render() {
-    const { intl, mobileMode } = this.props
+    const { intl, compactMode } = this.props
     const { shouldSearch, inputValue } = this.state
 
     const placeholder = intl.formatMessage({
@@ -85,7 +85,7 @@ class SearchBarContainer extends Component {
         onEnterPress={this.handleEnterPress}
         onMakeSearch={this.handleMakeSearch}
         onInputChange={this.handleInputChange}
-        mobileMode={mobileMode}
+        compactMode={compactMode}
       />
     )
   }
@@ -98,7 +98,8 @@ SearchBarContainer.contextTypes = {
 SearchBarContainer.propTypes = {
   /* Internationalization */
   intl: intlShape.isRequired,
-  mobileMode: PropTypes.bool,
+  /** Indentify when use the compact version of the component */
+  compactMode: PropTypes.bool,
 }
 
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Change the search bar to be according to the proposed layout 

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Add a props `compactMode` that identifies when the searchbar's layout need to be changed.

#### How should this be manually tested?
https://header--storecomponents.myvtex.com/

#### Screenshots or example usage
Before: 
![before-header-compact](https://user-images.githubusercontent.com/17649410/48153875-07510980-e2a6-11e8-8bb6-e45383058b3f.png)

After:
![after-header-compact](https://user-images.githubusercontent.com/17649410/48153887-0d46ea80-e2a6-11e8-9180-600a7202a8de.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
