### PR TITLE
Port Greeting component from 'delivery-dreamstore'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Greeting` component that renders a welcome message with the user first name
 
 ## [2.4.3] - 2018-10-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.0] - 2018-11-06
 ### Added
 - `Greeting` component that renders a welcome message with the user first name
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/Greeting.js
+++ b/react/Greeting.js
@@ -1,0 +1,1 @@
+export { default } from './components/Greeting'

--- a/react/components/Greeting/Loader.js
+++ b/react/components/Greeting/Loader.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import ContentLoader from 'react-content-loader'
+
+const GreetingLoading = props => (
+  <ContentLoader
+    height={32}
+    width={300}
+    speed={2}
+    primaryColor="#f3f3f3"
+    secondaryColor="#ecebeb"
+    className="v-mid"
+    {...props}
+  >
+    <rect rx="1" ry="1" width="300" height="32" />
+  </ContentLoader>
+)
+
+export default GreetingLoading

--- a/react/components/Greeting/README.md
+++ b/react/components/Greeting/README.md
@@ -1,0 +1,12 @@
+# Greeting
+Greeting is a canonical component that any VTEX app can import.
+
+To import it into your code: 
+```js
+import Greeting from 'vtex.store-components/Greeting'
+```
+
+## Usage
+You can use it in your code like a React component with the jsx tag: `<Greeting />`. 
+
+Greeting will render a welcome message with the user first name if that is available on orderForm.

--- a/react/components/Greeting/index.js
+++ b/react/components/Greeting/index.js
@@ -1,0 +1,42 @@
+import React, { Fragment } from 'react'
+import { compose, branch, renderComponent } from 'recompose'
+import { FormattedMessage } from 'react-intl'
+import { path } from 'ramda'
+import { orderFormConsumer, contextPropTypes } from 'vtex.store/OrderFormContext'
+
+import Loader from './Loader'
+
+const Wrapper = ({ children }) => (
+  <div className="vtex-greeting vtex-page-loading mh4 pv4 f3 fw4 c-on-base nowrap">{children}</div>
+)
+
+const withWrapper = Component => props => (
+  <Wrapper>
+    <Component {...props} />
+  </Wrapper>
+)
+
+const Greeting = ({ orderFormContext }) => {
+  const firstName = path(['orderForm', 'clientProfileData', 'firstName'], orderFormContext)  
+  if (!firstName) return null
+
+  return (
+    <Wrapper>
+      <Fragment>
+        <span className="vtex-greeting__message">
+          <FormattedMessage id="greeting" />,
+        </span>
+        <span className="vtex-greeting__first-name pl2 fw6">{firstName}</span>
+      </Fragment>
+    </Wrapper>
+  )
+}
+
+Greeting.propTypes = { orderFormContext: contextPropTypes }
+
+const enhanced = compose(
+  orderFormConsumer,
+  branch(({ loading }) => loading, renderComponent(withWrapper(Loader)))
+)
+
+export default enhanced(Greeting)

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -90,5 +90,6 @@
   "header.topMenu.minicart.icon.label": "My Cart",
   "header.topMenu.login.icon.label": "Sign in",
   "searchBar.button.cancel.label": "Cancel",
-  "buyButton-label-unavailable": "Unavailable"
+  "buyButton-label-unavailable": "Unavailable",
+  "greeting": "Hello"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -90,5 +90,6 @@
   "header.topMenu.minicart.icon.label": "Mi Cesta",
   "header.topMenu.login.icon.label": "Entrar",
   "searchBar.button.cancel.label": "Cancelar",
-  "buyButton-label-unavailable": "Indisponible"
+  "buyButton-label-unavailable": "Indisponible",
+  "greeting": "Hola"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -88,5 +88,6 @@
   "header.topMenu.minicart.icon.label": "Meu Carrinho",
   "header.topMenu.login.icon.label": "Entrar",
   "searchBar.button.cancel.label": "Cancelar",
-  "buyButton-label-unavailable": "Indisponível"
+  "buyButton-label-unavailable": "Indisponível",
+  "greeting": "Olá"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -25,6 +25,7 @@
     "react-responsive-modal": "^2.0.1",
     "react-share": "^2.1.1",
     "react-slick": "^0.23.1",
+    "recompose": "^0.30.0",
     "render": "^0.1.4",
     "slick-carousel": "^1.8.1",
     "underscore": "^1.9.1",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.0.0":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@types/async@2.0.47":
   version "2.0.47"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.47.tgz#f49ba1dd1f189486beb6e1d070a850f6ab4bd521"
@@ -81,6 +87,10 @@ boolbase@~1.0.0:
 brcast@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.1.tgz#6256a8349b20de9eed44257a9b24d71493cd48dd"
+
+change-emitter@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
 
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
@@ -272,6 +282,18 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+fbjs@^0.8.1:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 fbjs@^0.8.16:
   version "0.8.16"
@@ -781,6 +803,10 @@ react-jss@^8.1.0:
     prop-types "^15.6.0"
     theming "^1.3.0"
 
+react-lifecycles-compat@^3.0.2:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
 react-minimalist-portal@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-minimalist-portal/-/react-minimalist-portal-2.3.0.tgz#5f1c4fb6f249f7c89048214721ce39c5a1e484f9"
@@ -883,9 +909,24 @@ readable-stream@^2.0.2:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+recompose@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
+
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 render@^0.1.4:
   version "0.1.4"
@@ -938,7 +979,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-symbol-observable@^1.0.2, symbol-observable@^1.1.0:
+symbol-observable@^1.0.2, symbol-observable@^1.0.4, symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
@@ -956,6 +997,10 @@ traverser@0.0.x:
   resolved "https://registry.yarnpkg.com/traverser/-/traverser-0.0.5.tgz#c66f38c456a0c21a88014b1223580c7ebe0631eb"
   dependencies:
     curry "0.0.x"
+
+ua-parser-js@^0.7.18:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
 
 ua-parser-js@^0.7.9:
   version "0.7.18"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Port the Greeting component from `vtex.delivery-dreamstore` to here.

#### What problem is this solving?
Dreamstore and its verticals should be only theme apps, not contain any components.

#### How should this be manually tested?
1. [Visit workspace](https://dan--delivery.myvtex.com/order)
2. If you have a user that has already bought in that store, use your phone to identify your profile, if not, you can use the demo number `48987654321`
3. Greeting is on the orders page

#### Screenshots or example usage
![screenshot at nov 06 11-32-03](https://user-images.githubusercontent.com/27775611/48067566-bc58c880-e1b7-11e8-92c3-185c06c7c4a3.png)

#### Notes
This PR depends on https://github.com/vtex-apps/store/pull/112

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.