### PR TITLE
Change API of ProductName to use classes prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add `classes` prop to ProductName and remove `large` prop
 
 ## [2.6.4] - 2018-11-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- `Footer` component.
 
 ## [2.6.4] - 2018-11-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Add `classes` prop to ProductName and remove `large` prop
+- Add `classes` prop to ProductName and remove `large` prop.
 
 ## [2.6.4] - 2018-11-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Removed
-- `Footer` component.
 
 ## [2.6.4] - 2018-11-20
 ### Fixed

--- a/react/components/ProductName/README.md
+++ b/react/components/ProductName/README.md
@@ -32,10 +32,10 @@ classes: PropTypes.shape({
 Every attribute of the `classes` object represent a element of the component. To understand better see the following example of how to pass classes to every element
 ```jsx
 const classes = {
-  root: 'vtex-product-name__container some-css-class -pt4',
-  brandName: 'vtex-product-name__brand f5',
-  skuName: 'vtex-product-name__sku f6',
-  rootLoader: 'vtex-product-name vtex-product-name-loader pt5 overflow-hidden'
+  root: 'some-css-class pt4',
+  brandName: 'f5',
+  skuName: 'f6',
+  rootLoader: 'pt5 overflow-hidden'
 }
 <ProductName
   showSku

--- a/react/components/ProductName/README.md
+++ b/react/components/ProductName/README.md
@@ -48,16 +48,15 @@ const classes = {
 ```
 See that we are not passing classes to `productReference`, beacause we don't need  it, since we are not rendering it. If you have any doubt check the [Component implementation](https://github.com/vtex-apps/store-components/tree/master/react/components/ProductName).
 
-| Prop name             | Type       | Description                                      |
-| --------------------- | ---------- | ------------------------------------------------ |
-| `name`                | `String!`  | Name of the product                              |
-| `skuName`             | `String`   | Selected SKU name                                |
-| `showSku`             | `Boolean`  | Show product SKU                                 |
-| `productReference`    | `String`   | Product reference                                |
-| `classes`             | `Object`   | Classes to apply to elements of the component    |
-| `showProductReference`| `Boolean`  | Show product reference                           |
-| `brandName`           | `String`   | Brand name                                       |
-| `showBrandName`       | `Boolean`  | Show brand name                                  |
+| Prop name | Type | Description |
+| --------- | ---- | ----------- |
+| `name` | `String!` | Name of the product |
+| `skuName` | `String` | Selected SKU name |
+| `showSku` | `Boolean` | Show product SKU |
+| `productReference` | `String` | Product reference |
+| `classes` | `Object` | Classes to apply to elements of the component |
+| `showProductReference` | `Boolean` | Show product reference |
+| `brandName` | `String` | Brand name |
+| `showBrandName` | `Boolean` | Show brand name |
 
 See an example at [Product Details](https://github.com/vtex-apps/product-details/blob/master/react/ProductDetails.js#L49) app
-

--- a/react/components/ProductName/README.md
+++ b/react/components/ProductName/README.md
@@ -10,11 +10,43 @@ import ProductName from 'vtex.store-components/ProductName'
 You can use it in your code like a React component with the jsx tag: `<ProductName />`. 
 ```jsx
 <ProductName
-    name={product.productName}
-    skuName={selectedItem.name}
-    brandName={product.brand}
+  showSku
+  showBrandName
+  name={product.productName}
+  skuName={selectedItem.name}
+  brandName={product.brand}
 />
 ```
+
+## Passing classes to the elements of the component
+The `classes` prop has the following structure
+```js
+classes: PropTypes.shape({
+  root: PropTypes.string,
+  brandName: PropTypes.string,
+  skuName: PropTypes.string,
+  productReference: PropTypes.string,
+  rootLoader: PropTypes.string
+})
+```
+Every attribute of the `classes` object represent a element of the component. To understand better see the following example of how to pass classes to every element
+```jsx
+const classes = {
+  root: 'vtex-product-name__container some-css-class -pt4',
+  brandName: 'vtex-product-name__brand f5',
+  skuName: 'vtex-product-name__sku f6',
+  rootLoader: 'vtex-product-name vtex-product-name-loader pt5 overflow-hidden'
+}
+<ProductName
+  showSku
+  showBrandName
+  name={product.productName}
+  skuName={selectedItem.name}
+  brandName={product.brand}
+  classes={classes}
+/>
+```
+See that we are not passing classes to `productReference`, beacause we don't need  it, since we are not rendering it. If you have any doubt check the [Component implementation](https://github.com/vtex-apps/store-components/tree/master/react/components/ProductName).
 
 | Prop name             | Type       | Description                                      |
 | --------------------- | ---------- | ------------------------------------------------ |
@@ -22,9 +54,10 @@ You can use it in your code like a React component with the jsx tag: `<ProductNa
 | `skuName`             | `String`   | Selected SKU name                                |
 | `showSku`             | `Boolean`  | Show product SKU                                 |
 | `productReference`    | `String`   | Product reference                                |
+| `classes`             | `Object`   | Classes to apply to elements of the component    |
 | `showProductReference`| `Boolean`  | Show product reference                           |
 | `brandName`           | `String`   | Brand name                                       |
 | `showBrandName`       | `Boolean`  | Show brand name                                  |
-| `label`               | `Boolean`  | Displays large font                              |
 
 See an example at [Product Details](https://github.com/vtex-apps/product-details/blob/master/react/ProductDetails.js#L49) app
+

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -22,8 +22,6 @@ class ProductName extends Component {
     brandName: PropTypes.string,
     /** Show brand name */
     showBrandName: PropTypes.bool,
-    /** Display large font */
-    large: PropTypes.bool,
     /** Component and content loader styles */
     styles: PropTypes.object,
     /** Classes to apply to elements of the component */
@@ -81,24 +79,18 @@ class ProductName extends Component {
   render() {
     const {
       name,
+      classes,
       skuName,
-      brandName,
-      large,
-      showBrandName,
-      showProductReference,
       showSku,
+      brandName,
+      showBrandName,
       productReference,
-      classes
+      showProductReference,
     } = this.props
 
     if (!name) {
       return (
-        <ProductName.Loader
-          classes={classes}
-          skuClasses={skuClasses}
-          brandClasses={brandClasses}
-          {...this.props.styles}
-        />
+        <ProductName.Loader classes={classes} {...this.props.styles} />
       )
     }
 

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -35,7 +35,6 @@ class ProductName extends Component {
   }
 
   static defaultProps = {
-    large: false,
     showBrandName: false,
     showProductReference: false,
     showSku: false,

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import ContentLoader from 'react-content-loader'
+import { path } from 'ramda'
 
 /**
  * Name component. Show name and relevant SKU information of the Product Summary
@@ -25,6 +26,14 @@ class ProductName extends Component {
     large: PropTypes.bool,
     /** Component and content loader styles */
     styles: PropTypes.object,
+    /** Classes to apply to elements of the component */
+    classes: PropTypes.shape({
+      root: PropTypes.string,
+      brandName: PropTypes.string,
+      skuName: PropTypes.string,
+      productReference: PropTypes.string,
+      rootLoader: PropTypes.string
+    })
   }
 
   static defaultProps = {
@@ -32,10 +41,17 @@ class ProductName extends Component {
     showBrandName: false,
     showProductReference: false,
     showSku: false,
+    classes: {
+      root: null,
+      brandName: null,
+      skuName: null,
+      productReference: null,
+      rootLoader: null
+    }
   }
 
   static Loader = (loaderProps = {}) => (
-    <div className="vtex-product-name vtex-product-name-loader pt5 overflow-hidden">
+    <div className={path(['classes', 'rootLoader'], loaderProps)}>
       <ContentLoader
         style={{
           width: '100%',
@@ -72,36 +88,30 @@ class ProductName extends Component {
       showProductReference,
       showSku,
       productReference,
+      classes
     } = this.props
-
-    let brandClasses = 'vtex-product-name__brand f5'
-    let skuClasses = 'vtex-product-name__sku f6'
-
-    if (large) {
-      brandClasses += ' vtex-product-name__brand--large f2'
-      skuClasses += ' vtex-product-name__sku--large'
-    }
 
     if (!name) {
       return (
         <ProductName.Loader
-          {...this.props.styles}
-          brandClasses={brandClasses}
+          classes={classes}
           skuClasses={skuClasses}
+          brandClasses={brandClasses}
+          {...this.props.styles}
         />
       )
     }
 
     return (
-      <div className="vtex-product-name overflow-hidden c-on-base">
-        <div className={brandClasses}>
+      <div className={classes.root}>
+        <span className={classes.brandName}>
           {name} {showBrandName && brandName && `- ${brandName}`}
-        </div>
-        {showSku && <div className={skuClasses}>{skuName}</div>}
+        </span>
+        {showSku && <span className={classes.skuName}>{skuName}</span>}
         {showProductReference && productReference && (
-          <div className="vtex-product-name__product-reference pt3 f7 ttu">
+          <span className={classes.productReference}>
             {`REF: ${productReference}`}
-          </div>
+          </span>
         )}
       </div>
     )

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import ContentLoader from 'react-content-loader'
-import { path } from 'ramda'
+import classNames from 'classnames'
 
 /**
  * Name component. Show name and relevant SKU information of the Product Summary
@@ -48,7 +48,7 @@ class ProductName extends Component {
   }
 
   static Loader = (loaderProps = {}) => (
-    <div className={path(['rootLoader'], loaderProps)}>
+    <div className={classNames('vtex-product-name vtex-product-name-loader', loaderProps.className)}>
       <ContentLoader
         style={{
           width: '100%',
@@ -89,18 +89,20 @@ class ProductName extends Component {
 
     if (!name) {
       return (
-        <ProductName.Loader rootLoader={classes.rootLoader} {...this.props.styles} />
+        <ProductName.Loader className={classes.rootLoader} {...this.props.styles} />
       )
     }
 
     return (
-      <div className={classes.root}>
-        <span className={classes.brandName}>
+      <div className={classNames('vtex-product-name', classes.root)}>
+        <span className={classNames('vtex-product-name__brand', classes.brandName)}>
           {name} {showBrandName && brandName && `- ${brandName}`}
         </span>
-        {showSku && <span className={classes.skuName}>{skuName}</span>}
+        {showSku && skuName && (
+          <span className={classNames('vtex-product-name__sku', classes.skuName)}>{skuName}</span>
+        )}
         {showProductReference && productReference && (
-          <span className={classes.productReference}>
+          <span className={classNames('vtex-product-name__product-reference', classes.productReference)}>
             {`REF: ${productReference}`}
           </span>
         )}

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -48,7 +48,7 @@ class ProductName extends Component {
   }
 
   static Loader = (loaderProps = {}) => (
-    <div className={path(['classes', 'rootLoader'], loaderProps)}>
+    <div className={path(['rootLoader'], loaderProps)}>
       <ContentLoader
         style={{
           width: '100%',
@@ -89,7 +89,7 @@ class ProductName extends Component {
 
     if (!name) {
       return (
-        <ProductName.Loader classes={classes} {...this.props.styles} />
+        <ProductName.Loader rootLoader={classes.rootLoader} {...this.props.styles} />
       )
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the API of `ProductName` component to use a `classes` prop

#### What problem is this solving?
The current API of `ProductName` has css classes, and because of that is to hard to customize the component

#### How should this be manually tested?
[Workspace](https://productnameclasses--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Extra information
The `large` prop was removed since the component isn't responsable of styling or applying classes anymore

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
