### PR TITLE
Fix product description loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove `ContentLoader` of `ProductDescription`.
 
 ## [2.5.1] - 2018-11-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.2] - 2018-11-07
 ### Changed
 - Remove `ContentLoader` of `ProductDescription`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/ProductDescription/README.md
+++ b/react/components/ProductDescription/README.md
@@ -22,4 +22,4 @@ You can use it in your code like a React component with the jsx tag: `<ProductDe
 | `specifications[n].value`| `String`   | Specifications value                                                        |
 | `skuName`                | `String`   | Name of the SKU                                                             |
 
-See an example at [Product Details](https://github.com/vtex-apps/product-details/blob/master/react/ProductDetails.js#L88) app
+See an example at [Product Details](https://github.com/vtex-apps/product-details) app

--- a/react/components/ProductDescription/global.css
+++ b/react/components/ProductDescription/global.css
@@ -6,7 +6,3 @@
 .vtex-product-specifications__table-row:nth-child(odd) {
   background-color: rgba(0, 0, 0, 0.05);
 }
-
-.vtex-product-specifications-loader {
-  height: 26em;
-}

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -12,50 +12,11 @@ import './global.css'
  * Render the description and technical specifications of a product
  */
 class ProductDescription extends Component {
-  static Loader = (loaderProps = {}) => (
-    <div className="vtex-product-specifications vtex-product-specifications-loader mt6">
-      <ContentLoader
-        style={{
-          width: '100%',
-          height: '100%',
-        }}
-        height="100%"
-        width="100%"
-        {...loaderProps}>
-        <rect
-          width="15em"
-          height="2em"
-          {...loaderProps[
-            'vtex-product-specifications__description-title--loader'
-          ]}
-        />
-        <rect
-          width="100%"
-          height="5em"
-          y="3em"
-          {...loaderProps['vtex-product-specifications__description--loader']}
-        />
-        <rect
-          width="15em"
-          height="2em"
-          y="11em"
-          {...loaderProps['vtex-product-specifications__title--loader']}
-        />
-        <rect
-          width="100%"
-          height="12em"
-          y="14em"
-          {...loaderProps['vtex-product-specifications__table--loader']}
-        />
-      </ContentLoader>
-    </div>
-  )
-
   render() {
     const { specifications, skuName, description } = this.props
 
     if (!description || !specifications) {
-      return <ProductDescription.Loader {...this.props.styles} />
+      return null
     }
 
     return (
@@ -120,8 +81,6 @@ ProductDescription.propTypes = {
   ),
   /** Name of the current SKU */
   skuName: PropTypes.string,
-  /** Component and content loader styles */
-  styles: PropTypes.object,
 }
 
 export default injectIntl(ProductDescription)

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -1,6 +1,5 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import ContentLoader from 'react-content-loader'
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 
 import SpecificationRow from './SpecificationRow'


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove `ContentLoader` of `ProductDescription`

#### What problem is this solving?
Rendering a content loader of a product that doesn't have a description to render

#### How should this be manually tested?
[Workspace](https://productdescriptionloader--storecomponents.myvtex.com/iphone-xs/p)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
