### PR TITLE
Fix shelf not rendering on IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.6] - 2018-11-08
 ### Fixed
 - Removed call to `Array.from` breaking the `Shelf` on Internet Explorer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed call to `Array.from` breaking the `Shelf` on Internet Explorer.
 
 ## [2.5.5] - 2018-11-07
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/Slider/utils/ItemsPerPage.js
+++ b/react/components/Slider/utils/ItemsPerPage.js
@@ -4,9 +4,9 @@ function getItemWidth(slick) {
   const slidesNodeList = get(slick, 'innerSlider.list.childNodes[0].childNodes')
   let itemWidth = null
   if (slidesNodeList) {
-    const slidesArray = Array.from(slidesNodeList)
+    const slidesArray = Array.prototype.slice.call(slidesNodeList)
     slidesArray.map(slide => {
-      const attributes = Array.from(slide.attributes)
+      const attributes = Array.prototype.slice.call(slide.attributes)
       attributes.map(attr => {
         if (attr.nodeName === 'data-index' && attr.nodeValue === '0') {
           itemWidth = get(slide, 'childNodes[0].clientWidth')


### PR DESCRIPTION
#### What is the purpose of this pull request?
Replaced call to `Array.from` with `Array.prototype.call`, so the `Shelf` works on IE.

#### What problem is this solving?
The `Shelf` didn't render on IE.

#### How should this be manually tested?
Access [this workspace](https://lucas--storecomponents.myvtex.com/) on Internet Explorer.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
