### PR TITLE
update version of vtex.styleguide dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.6.1] - 2018-11-13
+### Changed
+- update the version of the dependency `vtex.styleguide` from 6.x to 7.x.
+
 ## [2.6.1] - 2018-11-11
 
 ## [2.6.0] - 2018-11-09

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "vtex.store": "1.x",
     "vtex.store-graphql": "2.x",
-    "vtex.styleguide": "6.x"
+    "vtex.styleguide": "7.x"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the version of dependency `vtex.styleguide`  with latest version

#### What problem is this solving?
`vtex.my-account` application Address page uses component `ContentWrapper` which is under (vtex.store-compoent/Account) this component uses new version of `vtex.styleguide`

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
