### PR TITLE
Remove classes prop and add several props to ProductName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Add several props to style the `ProductPrice` component.
-- Add `classes` prop to ProductName and remove `large` prop.
+- Add several props to style `ProductName` and remove `large` prop from it.
 
 ### Removed
 - `Header` from `vtex.store-components`.

--- a/react/components/ProductName/README.md
+++ b/react/components/ProductName/README.md
@@ -19,44 +19,34 @@ You can use it in your code like a React component with the jsx tag: `<ProductNa
 ```
 
 ## Passing classes to the elements of the component
-The `classes` prop has the following structure
-```js
-classes: PropTypes.shape({
-  root: PropTypes.string,
-  brandName: PropTypes.string,
-  skuName: PropTypes.string,
-  productReference: PropTypes.string,
-  rootLoader: PropTypes.string
-})
-```
-Every attribute of the `classes` object represent a element of the component. To understand better see the following example of how to pass classes to every element
+Every prop that ends with `Class` will be passed to an element of the component, see the code below
 ```jsx
-const classes = {
-  root: 'some-css-class pt4',
-  brandName: 'f5',
-  skuName: 'f6',
-  rootLoader: 'pt5 overflow-hidden'
-}
 <ProductName
+  skuNameClass="some-other-css-class"
+  className="pv4 overflow-hidden"
+  brandNameClass="c-muted"
   showSku
   showBrandName
+  brandName={product.brand}
   name={product.productName}
   skuName={selectedItem.name}
-  brandName={product.brand}
-  classes={classes}
 />
+})
 ```
-See that we are not passing classes to `productReference`, beacause we don't need  it, since we are not rendering it. If you have any doubt check the [Component implementation](https://github.com/vtex-apps/store-components/tree/master/react/components/ProductName).
 
 | Prop name | Type | Description |
-| --------- | ---- | ----------- |
+| --- | --- | --- |
 | `name` | `String!` | Name of the product |
 | `skuName` | `String` | Selected SKU name |
 | `showSku` | `Boolean` | Show product SKU |
 | `productReference` | `String` | Product reference |
-| `classes` | `Object` | Classes to apply to elements of the component |
 | `showProductReference` | `Boolean` | Show product reference |
 | `brandName` | `String` | Brand name |
 | `showBrandName` | `Boolean` | Show brand name |
+| `className` | `String` | Classes to be applied to root element |
+| `brandNameClass` | `String` | Classes to be applied to brandName element |
+| `skuNameClass` | `String` | Classes to be applied to skuName element |
+| `productReferenceClass` | `String` | Classes to be applied to productReference element |
+| `loaderClass` | `String` | Classes to be applied to loader root element |
 
-See an example at [Product Details](https://github.com/vtex-apps/product-details/blob/master/react/ProductDetails.js#L49) app
+See an example at [Product Details](https://github.com/vtex-apps/product-details) app

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -24,27 +24,22 @@ class ProductName extends Component {
     showBrandName: PropTypes.bool,
     /** Component and content loader styles */
     styles: PropTypes.object,
-    /** Classes to apply to elements of the component */
-    classes: PropTypes.shape({
-      root: PropTypes.string,
-      brandName: PropTypes.string,
-      skuName: PropTypes.string,
-      productReference: PropTypes.string,
-      rootLoader: PropTypes.string
-    })
+    /** Classes to be applied to root element */
+    className: PropTypes.string,
+    /** Classes to be applied to brandName element */
+    brandNameClass: PropTypes.string,
+    /** Classes to be applied to skuName element */
+    skuNameClass: PropTypes.string,
+    /** Classes to be applied to productReference element */
+    productReferenceClass: PropTypes.string,
+    /** Classes to be applied to loader root element */
+    loaderClass: PropTypes.string
   }
 
   static defaultProps = {
     showBrandName: false,
     showProductReference: false,
-    showSku: false,
-    classes: {
-      root: null,
-      brandName: null,
-      skuName: null,
-      productReference: null,
-      rootLoader: null
-    }
+    showSku: false
   }
 
   static Loader = (loaderProps = {}) => (
@@ -77,8 +72,12 @@ class ProductName extends Component {
 
   render() {
     const {
+      productReferenceClass,
+      brandNameClass,
+      skuNameClass,
+      loaderClass,
+      className,
       name,
-      classes,
       skuName,
       showSku,
       brandName,
@@ -89,20 +88,20 @@ class ProductName extends Component {
 
     if (!name) {
       return (
-        <ProductName.Loader className={classes.rootLoader} {...this.props.styles} />
+        <ProductName.Loader className={loaderClass} {...this.props.styles} />
       )
     }
 
     return (
-      <div className={classNames('vtex-product-name', classes.root)}>
-        <span className={classNames('vtex-product-name__brand', classes.brandName)}>
+      <div className={classNames('vtex-product-name', className)}>
+        <span className={classNames('vtex-product-name__brand', brandNameClass)}>
           {name} {showBrandName && brandName && `- ${brandName}`}
         </span>
         {showSku && skuName && (
-          <span className={classNames('vtex-product-name__sku', classes.skuName)}>{skuName}</span>
+          <span className={classNames('vtex-product-name__sku', skuNameClass)}>{skuName}</span>
         )}
         {showProductReference && productReference && (
-          <span className={classNames('vtex-product-name__product-reference', classes.productReference)}>
+          <span className={classNames('vtex-product-name__product-reference', productReferenceClass)}>
             {`REF: ${productReference}`}
           </span>
         )}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove `classes` prop from `ProductName` and add several props to make it easier to style it

#### What problem is this solving?
`ProductName` is not too easy to style

#### How should this be manually tested?
[Workspace](https://productnamecssprops--storecomponents.myvtex.com/iphone-xs/p)

#### Screenshots or example usage
![captura de tela de 2018-11-21 11-20-06](https://user-images.githubusercontent.com/8517023/48847062-68391100-ed7f-11e8-9df5-4207cb7407d7.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Requires change to documentation, which has been updated accordingly.
