### PR TITLE
Make ProductDescription use design tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Add several props to style the `ProductPrice` component.
 - Add several props to style `ProductName` and remove `large` prop from it.
+- Make `ProductDescription` use design tokens.
 
 ### Removed
 - `Header` from `vtex.store-components`.

--- a/react/components/ProductDescription/SpecificationRow.js
+++ b/react/components/ProductDescription/SpecificationRow.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 export default function SpecificationRow({ name, values }) {
   return (
     <tr className="vtex-product-specifications__table-row">
-      <th className="vtex-product-specifications__specification-name dtc-ns tr-ns ttu normal w-25-ns pt2 pb2-ns ph6 br-ns b--muted-3 db-s tl-s pb0-s w-auto-s bn-s">
+      <th className="vtex-product-specifications__specification-name dtc-ns tr-ns ttu t-body c-muted-1 w-25-ns pt2 pb2-ns ph6 br-ns b--muted-3 db-s tl-s pb0-s w-auto-s bn-s">
         {name}
       </th>
       <td className="vtex-product-specifications__specification-values dtc-ns pv2 ph6 c-muted-2 db-s">

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -20,10 +20,9 @@ class ProductDescription extends Component {
 
     return (
       <div className="vtex-product-description ma2">
-        <div className="t-heading-5 mb3">
+        <div className="t-heading-5 mb6-ns mb5-s">
           <FormattedMessage id="product-description.title" />
         </div>
-
         <span
           className="measure-wide c-muted-1"
           dangerouslySetInnerHTML={{ __html: description }}

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -24,7 +24,7 @@ class ProductDescription extends Component {
           <FormattedMessage id="product-description.title" />
         </div>
         <span
-          className="measure-wide c-muted-1"
+          className="vtex-product-description__text measure-wide c-muted-1"
           dangerouslySetInnerHTML={{ __html: description }}
         />
 

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -20,18 +20,18 @@ class ProductDescription extends Component {
 
     return (
       <div className="vtex-product-description ma2">
-        <div className="f4 b ttu mb3">
+        <div className="t-heading-5 mb3">
           <FormattedMessage id="product-description.title" />
         </div>
 
         <span
-          className="measure-wide"
+          className="measure-wide c-muted-1"
           dangerouslySetInnerHTML={{ __html: description }}
         />
 
         {specifications.length > 0 && (
           <div className="vtex-product-specifications mt6">
-            <div className="vtex-product-specifications__title f4 b ttu mb6-ns mb5-s">
+            <div className="vtex-product-specifications__title t-heading-5 mb6-ns mb5-s">
               <FormattedMessage id="technicalspecifications.title" />
             </div>
             <table className="vtex-product-specifications__table w-100">


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make `ProductDescription` use design tokens

#### What problem is this solving?
`ProductDescription wasn't using design tokens

#### How should this be manually tested?
[Workspace](https://productdescriptiondesigntokens--storecomponents.myvtex.com/iphone-xs/p)

#### Screenshots or example usage
![captura de tela de 2018-11-21 11-57-10](https://user-images.githubusercontent.com/8517023/48849200-9d942d80-ed84-11e8-9638-91e6e25c5727.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
