### PR TITLE
Use design tokens in AvailabilitySubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add several props to style the `ProductPrice` component.
 - Add several props to style `ProductName` and remove `large` prop from it.
 - Make `ProductDescription` use design tokens.
+- Make `AvailabilitySubscriber` use design tokens.
 
 ### Removed
 - `Header` from `vtex.store-components`.

--- a/react/components/AvailabilitySubscriber/index.js
+++ b/react/components/AvailabilitySubscriber/index.js
@@ -155,10 +155,10 @@ class AvailabilitySubscriber extends Component {
       <ApolloConsumer>
         {client => (
           <div className="vtex-availability-subscriber">
-            <div className="vtex-availability-subcriber__title f5 fw4 mb3">
+            <div className="vtex-availability-subcriber__title t-body mb3">
               {this.translate('availability-subscriber.title')}
             </div>
-            <div className="vtex-availability-subscriber__subscribe-label f6 fw3">
+            <div className="vtex-availability-subscriber__subscribe-label t-small fw3">
               {this.translate('availability-subscriber.subscribe-label')}
             </div>
             <form className="vtex-availability-subscriber__form mb4" onSubmit={(e) => this.handleSubmit(e, client)}>
@@ -193,12 +193,12 @@ class AvailabilitySubscriber extends Component {
                 </div>
               </div>
               {sendStatus === 'success' &&
-                <div className="vtex-availability-subscriber__message vtex-availability-subscriber__success green fw6">
+                <div className="vtex-availability-subscriber__message vtex-availability-subscriber__success t-body c-success">
                   {this.translate('availability-subscriber.added-message')}
                 </div>
               }
               {sendStatus === 'error' &&
-                <div className="vtex-availability-subscriber__message vtex-availability-subscriber__error heavy-rebel-pink">
+                <div className="vtex-availability-subscriber__message vtex-availability-subscriber__error c-danger">
                   {this.translate('availability-subscriber.error-message')}
                 </div>
               }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make `AvailabilitySubscriber` use design tokens

#### What problem is this solving?
`AvailabilitySubscriber` is not using design tokens

#### How should this be manually tested?
[Workspace](https://availabilitycsstokens--storecomponents.myvtex.com/make-b--brilho-labial-star-lip-7ml-166starlipbril/p)

#### Screenshots or example usage
![captura de tela de 2018-11-21 15-03-44](https://user-images.githubusercontent.com/8517023/48860304-4f405800-ed9f-11e8-88c7-8d7d8309ac9c.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
