### PR TITLE
Fix DiscountBadge conditional div root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The root div of `DiscountBadge` is now always rendered.
 
 ## [3.1.8] - 2018-12-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.1.9] - 2018-12-06
 ### Fixed
 - The root div of `DiscountBadge` is now always rendered.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/DiscountBadge/index.js
+++ b/react/components/DiscountBadge/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { FormattedNumber } from 'react-intl'
 import PropTypes from 'prop-types'
 
@@ -14,16 +14,16 @@ class DiscountBadge extends Component {
   render() {
     const { listPrice, sellingPrice, label } = this.props
     const percent = this.calculateDiscountTax(listPrice, sellingPrice)
-    return percent ? (
+    return (
       <div className="vtex-discount-badge relative dib w-100">
-        <div className="t-mini white absolute right-0 pv2 ph3 bg-emphasis">
-          {label === '' && '-'}
-          <FormattedNumber value={percent} style="percent" /> {label}
-        </div>
+        {percent ? (
+          <div className="t-mini white absolute right-0 pv2 ph3 bg-emphasis">
+            {label === '' && '-'}
+            <FormattedNumber value={percent} style="percent" /> {label}
+          </div>
+        ) : null}
         {this.props.children}
       </div>
-    ) : (
-      this.props.children
     )
   }
 }

--- a/react/components/DiscountBadge/index.js
+++ b/react/components/DiscountBadge/index.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import { FormattedNumber } from 'react-intl'
 import PropTypes from 'prop-types'
 


### PR DESCRIPTION
#### What is the purpose of this pull request? What problem is this solving?
`DiscountBadge` had a root div that was being added depending in a conditional, but it was causing some layout bugs.

#### How should this be manually tested?
[Workspace](https://fixsummarylayout--storecomponents.myvtex.com/)

#### Screenshots or example usage
Before:
![before](https://user-images.githubusercontent.com/8517023/49529201-4b7afe00-f894-11e8-87ba-b6c68f4a3e8b.png)
After:
![captura de tela de 2018-12-05 13-47-08](https://user-images.githubusercontent.com/8517023/49529214-5170df00-f894-11e8-9a14-73b7c3ed354f.png)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
