### PR TITLE
fix export on buy button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix export on BuyButton
 
 ## [3.3.1] - 2018-12-27
 ### Fixed

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -22,7 +22,7 @@ const CONSTANTS = {
  * BuyButton Component.
  * Adds a list of sku items to the cart.
  */
-export class BuyButton extends Component {
+class BuyButton extends Component {
   static defaultProps = {
     isOneClickBuy: false,
     available: true,
@@ -136,5 +136,7 @@ BuyButton.propTypes = {
   /** Function used to show toasts (messages) to user */
   showToast: PropTypes.func.isRequired,
 }
+
+export { BuyButton }
 
 export default compose(withToast, orderFormConsumer, injectIntl)(BuyButton)


### PR DESCRIPTION
You cant `export class` with `export default`

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
