### PR TITLE
Fix/add.shipping.estimate.app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.5.1] - 2019-01-09
 ### Added
 -  `vtex.shipping-estimate-translator` app to translate and place the correct delivery time on `ShippingSimulator`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+-  added vtex.shipping.simulator app to translate and place the correct delivery time on `ShippingSimulator`
 
 ## [3.5.0] - 2019-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-#### Added
+### Added
 -  `vtex.shipping-estimate-translator` app to translate and place the correct delivery time on `ShippingSimulator`
 
 ## [3.5.0] - 2019-01-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
--  added vtex.shipping.simulator app to translate and place the correct delivery time on `ShippingSimulator`
+#### Added
+-  `vtex.shipping-estimate-translator` app to translate and place the correct delivery time on `ShippingSimulator`
 
 ## [3.5.0] - 2019-01-09
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
+    "vtex.shipping-estimate-translator": "1.x",
     "vtex.store-graphql": "2.x",
     "vtex.store-resources": "0.x",
     "vtex.styleguide": "8.x",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -28,7 +28,6 @@
   "pricing.interest-free": "interest-free",
   "loading": "Loading…",
   "shipping.label": "Calculate shipping",
-  "shipping.eta": "up to {eta} days",
   "shipping.free": "Free",
   "shipping.empty-sla": "There's no shipping information available for the informed zip code",
   "buybutton.buy-success": "Your product was add to the cart!",

--- a/messages/es-AR.json
+++ b/messages/es-AR.json
@@ -28,7 +28,6 @@
   "pricing.interest-free": "sin interés",
   "loading": "Cargando…",
   "shipping.label": "Calcular el flete",
-  "shipping.eta": "hasta {eta} días",
   "shipping.free": "Gratis",
   "shipping.empty-sla": "No hay información de envío disponible para el código postal informado",
   "buybutton.buy-success": "Su producto se ha agregado a la cesta!",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -28,7 +28,6 @@
   "pricing.interest-free": "sem juros",
   "loading": "Carregando…",
   "shipping.label": "Calcular o frete",
-  "shipping.eta": "até {eta} dias",
   "shipping.free": "Grátis",
   "shipping.empty-sla": "Não existe um frete disponível para o CEP informado",
   "buybutton.buy-success": "Seu produto foi adicionado ao carrinho!",

--- a/react/components/ShippingSimulator/components/ShippingTableRow.js
+++ b/react/components/ShippingSimulator/components/ShippingTableRow.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { intlShape, injectIntl } from 'react-intl'
+import TranslateEstimate from 'vtex.shipping-estimate-translator/TranslateEstimate'
 import classNames from 'classnames'
 
 const ShippingTableRow = ({ name, shippingEstimate, price, intl }) => {
@@ -12,13 +13,7 @@ const ShippingTableRow = ({ name, shippingEstimate, price, intl }) => {
     'tc': price === undefined,
   })
 
-  let etaText, valueText
-
-  if (shippingEstimate === undefined) {
-    etaText = '-'
-  } else {
-    etaText = intl.formatMessage({ id: 'shipping.eta' }, { eta: shippingEstimate })
-  }
+  let valueText
 
   if (price === undefined) {
     valueText = '-'
@@ -42,7 +37,7 @@ const ShippingTableRow = ({ name, shippingEstimate, price, intl }) => {
         </label>
       </td>
       <td className={etaClassName}>
-        {etaText}
+        <TranslateEstimate shippingEstimate={shippingEstimate} />
       </td>
       <td className={valueClassName}>
         {valueText}


### PR DESCRIPTION
#### What is the purpose of this pull request?
adds vtex.shipping.simulator app to translate and place the correct specification of the deliveryTime on `ShippingSimulator`

#### What problem is this solving?
-  translate and place the correct specification of the deliveryTime on `ShippingSimulator`

#### How should this be manually tested?
run the project at the product detail of the dreamStore

#### Screenshots or example usage
![screen shot 2019-01-09 at 09 40 16](https://user-images.githubusercontent.com/13008014/50897213-98517780-13f2-11e9-9920-8e11d88a9fdc.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

Rewrite of #241