### PR TITLE
Proxy unused props of Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Proxy unused props of the `Container` component to the root element.
 
 ## [3.5.1] - 2019-01-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.5.2] - 2019-01-09
 ### Changed
 - Proxy unused props of the `Container` component to the root element.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/Container/index.js
+++ b/react/components/Container/index.js
@@ -2,11 +2,11 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const Container = ({ className, children }, ref) => {
+const Container = ({ className, children, ...props }, ref) => {
   const classes = classNames('ph3 ph5-m ph8-l ph9-xl', className)
 
   return (
-    <section className={classes} ref={ref}>
+    <section {...props} className={classes} ref={ref}>
       {children}
     </section>
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Pass on unused props of the `Container` component to the root `section` element.

#### What problem is this solving?
You couldn't pass in the `style` prop.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
