### PR TITLE
Fix incorrect click area on product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.9.2] - 2019-01-25
 ### Fixed
 - Incorrect click area on product summary.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Incorrect click area on product summary.
 
 ## [3.9.0] - 2019-01-25
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -43,7 +43,9 @@ export class BuyButton extends Component {
     this.props.showToast({ message })
   };
 
-  handleAddToCart = async () => {
+  handleAddToCart = async (e) => {
+    e.preventDefault()
+    e.stopPropagation()
     const { skuItems, isOneClickBuy, orderFormContext } = this.props
     this.setState({ isAddingToCart: true })
 
@@ -90,20 +92,20 @@ export class BuyButton extends Component {
         {loading ? (
           <ContentLoader />
         ) : (
-            <Button
-              primary
-              block={large}
-              disabled={!available}
-              onClick={() => this.handleAddToCart()}
-              isLoading={isAddingToCart}
-            >
-              {available ? (
-                children
-              ) : (
-                  <FormattedMessage id="buyButton-label-unavailable" />
-                )}
-            </Button>
-          )}
+          <Button
+            primary
+            block={large}
+            disabled={!available}
+            onClick={this.handleAddToCart}
+            isLoading={isAddingToCart}
+          >
+            {available ? (
+              children
+            ) : (
+              <FormattedMessage id="buyButton-label-unavailable" />
+            )}
+          </Button>
+        )}
       </Fragment>
     )
   }

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -43,7 +43,7 @@ export class BuyButton extends Component {
     this.props.showToast({ message })
   };
 
-  handleAddToCart = async (e) => {
+  handleAddToCart = async e => {
     e.preventDefault()
     e.stopPropagation()
     const { skuItems, isOneClickBuy, orderFormContext } = this.props


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix incorrect click area on the product.

#### What problem is this solving?
The product summary has an area that is clickable but nothing happens. All the product area clicks must redirect to the product page, with the exception of the buy button area.

#### How should this be manually tested?
[Access this](https://clickare--storecomponents.myvtex.com/)

#### Screenshots or example usage
https://lh6.googleusercontent.com/aGXEjI_WZag1OwPM5c5A2VcbVoAssYvUJp9lwKuo3QPKHorQPn8uFeOM0hVZT8k85YydhTss1q0yFlnbuK7R-bgEKgRIHU4YhTCzS4LkJgDou-tLIAJ8yZOTTN9jFeWOLgVfZKE9

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
