### PR TITLE
fix infinite Carousel loading on image load error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fix infinite Carousel loading on image load error on `ProductImages`.
 
 ## [3.5.3] - 2019-01-10
 ### Changed


### PR DESCRIPTION
#### What is the purpose of this pull request?
the component Carousel is showing the loading state when a image has any error to load, the 
expected behavior is to show the other images discarding the ones with error

#### What problem is this solving?
fix infinite Carousel loading on image load error

#### How should this be manually tested?
link the project at any product detail

#### Screenshots or example usage
![screen shot 2019-01-11 at 15 40 27](https://user-images.githubusercontent.com/13008014/51050234-41e16600-15b7-11e9-9af7-3a89855eee5e.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
