### PR TITLE
Fix SearchBar padding in mobile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.5.6] - 2019-01-14
 ### Fixed
 - Add `SearchBar` padding in mobile view.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add `SearchBar` padding in mobile view.
 
 ## [3.5.5] - 2019-01-14
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -32,7 +32,7 @@ export default class SearchBar extends Component {
     )
 
     const mainClasses = classNames(
-      'vtex-searchbar w-100'
+      'vtex-searchbar w-100 ph5 ph0-ns pb5 pb0-ns'
     )
 
     return (


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Fix SearchBar left, right and bottom padding in mobile view.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Use mobile view in this link
[https://fixsearchbarpaddingmobile--storecomponents.myvtex.com/](https://fixsearchbarpaddingmobile--storecomponents.myvtex.com/)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/6223208/51129771-173b1b80-180a-11e9-907b-d0b6bf690253.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
