### PR TITLE
Fix propTypes being passed to forwardRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixes warning of `propTypes` being passed to `React.forwardRef`.
 
 ## [3.6.2] - 2019-01-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.6.3] - 2019-01-17
 ### Fixed
 - Fixes warning of `propTypes` being passed to `React.forwardRef`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/Container/index.js
+++ b/react/components/Container/index.js
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const Container = ({ className, children, ...props }, ref) => {
+const render = ({ className, children, ...props }, ref) => {
   const classes = classNames('ph3 ph5-m ph8-l ph9-xl', className)
 
   return (
@@ -12,9 +12,13 @@ const Container = ({ className, children, ...props }, ref) => {
   )
 }
 
+render.displayName = 'Container'
+
+const Container = React.forwardRef(render)
+
 Container.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
 }
 
-export default React.forwardRef(Container)
+export default Container


### PR DESCRIPTION
#### What is the purpose of this pull request?
Move `propTypes` static property to the component returned by `React.forwardRef` instead of the render function.

#### What problem is this solving?
React was warning about it not supporting `propTypes` in the render function the `forwardRef` function receives.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
