### PR TITLE
Use header elements in ProductDetails instead of span tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use header elements in `ProductDetails` instead of span tags.
 
 ## [3.6.0] - 2019-01-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.6.1] - 2019-01-17
 ### Fixed
 - Use header elements in `ProductDetails` instead of span tags.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -25,9 +25,9 @@ class ProductDescription extends Component {
     return (
       <div className={`${styles.productDescriptionContainer} flex-l`}>
         <div className="w-100 w-60-l">
-          <div className="t-heading-5 mb5">
-            <FormattedMessage id="product-description.title" />
-          </div>
+          <FormattedMessage id="product-description.title">
+            {(txt) => (<h2 className="t-heading-5 mb5 mt0">{txt}</h2>)}
+          </FormattedMessage>
 
           <div className="c-muted-1">
             <GradientCollapse collapseHeight={220}>
@@ -37,9 +37,11 @@ class ProductDescription extends Component {
         </div>
         {specifications.length > 0 && (
           <div className={`${styles.specifications} mt9 mt0-l w-100 w-40-l pl8-l`}>
-            <div className={`${styles.specificationsTitle} t-heading-5 mb5`}>
-              <FormattedMessage id="technicalspecifications.title" />
-            </div>
+            <FormattedMessage id="technicalspecifications.title">
+              {(txt) => (
+                <h2 className={`${styles.specificationsTitle} t-heading-5 mb5 mt0`}>{txt}</h2>
+              )}
+            </FormattedMessage>
             <GradientCollapse collapseHeight={220}>
               <table className={`${styles.specificationsTable} w-100 bg-base border-collapse`}>
                 <thead>


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
We basically do not use header elements (h1, h2, h3) in our components and it is desirable to use these elements to make our html codebase more meaningful (by adding semantic html elements). 

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Using header elements in `ProductDetails` component instead of span tags.

#### How should this be manually tested?
[https://useheaderelement--storecomponents.myvtex.com](https://useheaderelement--storecomponents.myvtex.com)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
