### PR TITLE
Use header elements in ProductName instead of span tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Use header elements in `ProductName`.
+- Use header elements in `ProductName` through tag prop.
 
 ## [3.6.1] - 2019-01-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.6.2] - 2019-01-17
 ### Fixed
 - Use header elements in `ProductName` through tag prop.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use header elements in `ProductName` instead of span tags.
 
 ## [3.6.1] - 2019-01-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Use header elements in `ProductName` instead of span tags.
+- Use header elements in `ProductName`.
 
 ## [3.6.1] - 2019-01-17
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/ProductName/index.js
+++ b/react/components/ProductName/index.js
@@ -36,12 +36,15 @@ class ProductName extends Component {
     productReferenceClass: PropTypes.string,
     /** Classes to be applied to loader root element */
     loaderClass: PropTypes.string,
+    /** HTML tag to be used in the component container */
+    tag: PropTypes.oneOf(['div', 'h1', 'h2', 'h3']),
   }
 
   static defaultProps = {
     showBrandName: false,
     showProductReference: false,
-    showSku: false
+    showSku: false,
+    tag: 'div',
   }
 
   static Loader = (loaderProps = {}) => (
@@ -88,6 +91,7 @@ class ProductName extends Component {
       showBrandName,
       productReference,
       showProductReference,
+      tag:Wrapper,
     } = this.props
 
     if (!name) {
@@ -96,7 +100,7 @@ class ProductName extends Component {
       )
     }
 
-    const productNameClasses = classNames(`${productName.productNameContainer}`, {
+    const productNameClasses = classNames(`${productName.productNameContainer} mv0`, {
       [`${className}`]: className
     })
 
@@ -113,7 +117,7 @@ class ProductName extends Component {
     })
 
     return (
-      <div className={productNameClasses}>
+      <Wrapper className={productNameClasses}>
         <span className={productBrandClasses}>
           {name} {showBrandName && brandName && `- ${brandName}`}
         </span>
@@ -125,7 +129,7 @@ class ProductName extends Component {
             {`REF: ${productReference}`}
           </span>
         )}
-      </div>
+      </Wrapper>
     )
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
We basically do not use header elements (h1, h2, h3) in our components and it is desirable to use these elements to make our html codebase more meaningful (by adding semantic html elements).

**Note:** This PR is dependent of this [one](https://github.com/vtex-apps/product-details/pull/78) so it must be merged after.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Using header elements in `ProductName` component instead of span tags.

#### How should this be manually tested?
[https://alves--storecomponents.myvtex.com](https://alves--storecomponents.myvtex.com/?__disableSSR)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
