### PR TITLE
Fix propTypes on BuyButton component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix propTypes on `BuyButton`.
 
 ## [3.9.2] - 2019-01-25
 ### Fixed

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -120,7 +120,7 @@ BuyButton.propTypes = {
       /** Quantity of the product sku to be added to the cart */
       quantity: PropTypes.number.isRequired,
       /** Which seller is being referenced by the button */
-      seller: PropTypes.number.isRequired,
+      seller: PropTypes.string.isRequired,
     })
   ),
   /** Context used to call the add to cart mutation and retrieve the orderFormId **/


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix wrong `BuyButton` proptypes on `skuItems`.

#### How should this be manually tested?
[Access this workspace](https://categorybug--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
