### PR TITLE
Show interest with fee when biggest is one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Show installments with fee when the biggest with free is 1.
 
 ## [3.11.0] - 2019-01-28
 ### Changed
-- Bump messages builder to `1.x`. 
+- Bump messages builder to `1.x`.
 
 ### Fixed
 - Fix typo on added to cart message in english
@@ -108,7 +110,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.5.3] - 2019-01-10
 ### Changed
-- Change the syntax of routes `/` to `.`. 
+- Change the syntax of routes `/` to `.`.
 
 ## [3.5.2] - 2019-01-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.11.1] - 2019-01-29
 ### Fixed
 - Show installments with fee when the biggest with free is 1.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/ProductPrice/Installments.js
+++ b/react/components/ProductPrice/Installments.js
@@ -47,7 +47,7 @@ export default class Installments extends Component {
     }
 
     const noInterestRateInstallments = installments.filter(
-      installment => !installment.InterestRate
+      installment => !installment.InterestRate && installment.NumberOfInstallments > 1
     )
 
     /*


### PR DESCRIPTION
#### What is the purpose of this pull request?
If the biggest interest free installment is one, then show the biggest if interest.

#### What problem is this solving?
When interest fee is 1, there is no meaning in showing for the user.

#### Screenshots or example usage
Before:
![screen shot 2019-01-29 at 14 40 47](https://user-images.githubusercontent.com/3163867/51924300-e8a96d00-23d3-11e9-992f-2740bf79a65b.png)
After:
![screen shot 2019-01-29 at 14 38 13](https://user-images.githubusercontent.com/3163867/51924298-e8a96d00-23d3-11e9-8dbb-0a1cca1678fd.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
