### PR TITLE
Declaring some fancy new interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Declare interfaces for components used in `ProductDetail`.
 
 ## [3.12.4] - 2019-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.13.0] - 2019-02-05
 ### Added
 - Declare interfaces for components used in `ProductDetail`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.12.4",
+  "version": "3.13.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -4,5 +4,32 @@
   },
   "search-bar": {
     "component": "SearchBar"
+  },
+  "buy-button": {
+    "component": "BuyButton"
+  },
+  "product-name": {
+    "component": "ProductName"
+  },
+  "product-images": {
+    "component": "ProductImages"
+  },
+  "product-price": {
+    "component": "ProductPrice"
+  },
+  "product-description": {
+    "component": "ProductDescription"
+  },
+  "sku-selector": {
+    "component": "SkuSelector"
+  },
+  "shipping-simulator": {
+    "component": "ShippingSimulator"
+  },
+  "share": {
+    "component": "Share"
+  },
+  "availability-subscriber": {
+    "component": "AvailabilitySubscriber"
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -21,7 +21,7 @@
     "component": "ProductDescription"
   },
   "sku-selector": {
-    "component": "SkuSelector"
+    "component": "SKUSelector"
   },
   "shipping-simulator": {
     "component": "ShippingSimulator"


### PR DESCRIPTION
#### What is the purpose of this pull request?

It declares some new _interfaces_ for the components of this repository used in the `product-details` one. Further, more components (interfaces) shall be added.

#### What problem is this solving?
The problem that were not possible to inject other components in the `product-details` app (like a custom buy-buttom for the Instore, randomly saying...)

*ORDER OF RELEASE*
1. [`store-components`](https://github.com/vtex-apps/store-components/pull/278)
2. [`product-details`](https://github.com/vtex-apps/product-details/pull/81)
3. [`dreamstore`](https://github.com/vtex-apps/dreamstore/pull/120)

#### How should this be manually tested?

Using [this](https://inga--storecomponents.myvtex.com/) workspace

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
