### PR TITLE
Feature/options buybutton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Make it possible to be able to add items with assembly options on `BuyButton`
 
 ## [3.13.0] - 2019-02-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.13.1] - 2019-02-05
 ### Added
 - Make it possible to be able to add items with assembly options on `BuyButton`
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React, { Component, Fragment } from 'react'
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
 import ContentLoader from 'react-content-loader'
-import { compose } from 'ramda'
+import { compose, pick } from 'ramda'
 import { Pixel } from 'vtex.pixel-manager/PixelContext'
 
 import {
@@ -50,12 +50,11 @@ export class BuyButton extends Component {
 
     const variables = {
       items: skuItems.map(skuItem => {
-        const { skuId, quantity, seller } = skuItem
+        const { skuId } = skuItem
         return {
           id: parseInt(skuId),
           index: 1,
-          quantity,
-          seller,
+          ...pick(['quantity', 'seller', 'options'], skuItem),
         }
       }),
     }
@@ -128,10 +127,12 @@ BuyButton.propTypes = {
         PropTypes.string,
         PropTypes.number,
       ]).isRequired,
-      name: PropTypes.string.isRequired,
-      price: PropTypes.number.isRequired,
-      variant: PropTypes.string,
-      brand: PropTypes.string.isRequired,
+      options: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        quantity: PropTypes.number.isRequired,
+        assemblyId: PropTypes.string.isRequired,
+        seller: PropTypes.string.isRequired,
+      }))
     })
   ),
   /** Context used to call the add to cart mutation and retrieve the orderFormId **/

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -127,6 +127,10 @@ BuyButton.propTypes = {
         PropTypes.string,
         PropTypes.number,
       ]).isRequired,
+      name: PropTypes.string.isRequired,
+      price: PropTypes.number.isRequired,
+      variant: PropTypes.string,
+      brand: PropTypes.string.isRequired,
       options: PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.string.isRequired,
         quantity: PropTypes.number.isRequired,


### PR DESCRIPTION
BuyButton now supports adding items to cart with assembly options.

By using `R.pick`, if options is `undefined` it will not insert it on the payload, so it is safe.

wks to test: http://bbteste--delivery.myvtex.com

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
