### PR TITLE
Now the page won't scroll after changing SKU'S

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- After switching secondary variations on a product, those changes won't be kept on `history`.
+
+### Fixed
+- Remove scrolling to top after changing SKU in `SKUSelector`.
 
 ## [3.13.1] - 2019-02-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.14.0] - 2019-02-06
 ### Added
 - After switching secondary variations on a product, those changes won't be kept on `history`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.14.1] - 2019-02-06
+
 ## [3.14.0] - 2019-02-06
 ### Added
 - After switching secondary variations on a product, those changes won't be kept on `history`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/SKUSelector/components/SKUSelector.js
+++ b/react/components/SKUSelector/components/SKUSelector.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { curry } from 'ramda'
 
 import Variation from './Variation'
 import { SKUSelectorPropTypes } from '../utils/proptypes'
@@ -10,18 +11,20 @@ export default class SKUSelector extends Component {
   render() {
     const { selectedId, onSelectSku, mainVariation, secondaryVariation, maxSkuPrice } = this.props
 
+    const onSkuSelected = curry(onSelectSku) 
+
     return (
       <div className={styles.skuSelectorContainer}>
         <Variation
           variation={mainVariation}
-          onSelectItem={onSelectSku}
+          onSelectItem={onSkuSelected(true)}
           isSelected={(sku) => { return sku[mainVariation.name] === mainVariation.value }}
           maxSkuPrice={maxSkuPrice}
         />
         {
           secondaryVariation.name && <Variation
             variation={secondaryVariation}
-            onSelectItem={onSelectSku}
+            onSelectItem={onSkuSelected(false)}
             isSelected={sku => sku.itemId === selectedId}
             maxSkuPrice={maxSkuPrice}
           />

--- a/react/components/SKUSelector/index.js
+++ b/react/components/SKUSelector/index.js
@@ -3,32 +3,50 @@ import { withRuntimeContext } from 'vtex.render-runtime'
 
 import SKUSelector from './components/SKUSelector'
 import { SKUSelectorContainerPropTypes } from './utils/proptypes'
-import { getMainVariationName, getVariationOptions, getMaxSkuPrice, parseSku } from './utils'
+import {
+  getMainVariationName,
+  getVariationOptions,
+  getMaxSkuPrice,
+  parseSku,
+} from './utils'
 
 /**
  * Display a list of SKU items of a product and its specifications.
  */
 class SKUSelectorContainer extends Component {
-  handleSkuSelection = (skuId) => {
-    this.props.onSKUSelected ? this.props.onSKUSelected(skuId) : this.redirectToSku(skuId)
+  handleSkuSelection = (isMainVariation, skuId) => {
+    this.props.onSKUSelected
+      ? this.props.onSKUSelected(skuId, isMainVariation)
+      : this.redirectToSku(skuId, isMainVariation)
   }
 
-  redirectToSku(skuId) {
-    const { runtime: { navigate } } = this.props
+  redirectToSku(skuId, isMainVariation) {
+    const {
+      runtime: { navigate },
+    } = this.props
     const slug = this.props.productSlug
 
     navigate({
       page: 'store.product',
       params: { slug },
       query: `skuId=${skuId}`,
+      scrollOptions: false,
+      replace: !isMainVariation
     })
   }
 
   render() {
-    if (!this.props.skuSelected || !this.props.skuSelected.variations || this.props.skuSelected.variations.length === 0) return null
+    if (
+      !this.props.skuSelected ||
+      !this.props.skuSelected.variations ||
+      this.props.skuSelected.variations.length === 0
+    )
+      return null
 
-    const skuSelected = this.props.skuSelected && parseSku(this.props.skuSelected)
-    const skuItems = this.props.skuItems && this.props.skuItems.map(sku => parseSku(sku))
+    const skuSelected =
+      this.props.skuSelected && parseSku(this.props.skuSelected)
+    const skuItems =
+      this.props.skuItems && this.props.skuItems.map(sku => parseSku(sku))
     const itemId = skuSelected.itemId
     const variations = skuSelected.variations
 
@@ -42,11 +60,18 @@ class SKUSelectorContainer extends Component {
     const maxSkuPrice = getMaxSkuPrice(skuItems)
     const secondaryVariation = {}
 
-    const filteredSkus = skuItems.filter(sku => sku[name] === mainVariation.value)
+    const filteredSkus = skuItems.filter(
+      sku => sku[name] === mainVariation.value
+    )
 
     if (variations.length > 1) {
-      secondaryVariation.name = variations.filter(variation => variation !== name)[0]
-      secondaryVariation.options = getVariationOptions(secondaryVariation.name, filteredSkus)
+      secondaryVariation.name = variations.filter(
+        variation => variation !== name
+      )[0]
+      secondaryVariation.options = getVariationOptions(
+        secondaryVariation.name,
+        filteredSkus
+      )
     }
 
     return (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes, in a way, the navigate function on `SKUSelector` regarding scrolling the page after a change in the SKU.

_E de quebra_, also pass the `replace` option as true when the changes of SKU happens in a secondary variation, so when the user clicks on the back button of the browser, it won't keep going back to each previously selected variation. But this behaviour will keep happening for the main variation. All of this was specified by @gabrielgalc 
 
**THIS LAST FEATURE DEPENDS ON [THIS](https://github.com/vtex-apps/render-runtime/pull/218) PR ON RENDER-RUNTIME** .

_I've also done some prettier here and there_
#### What problem is this solving?
Scrolling the page after the user selected a variation on the Product's page maah 
You can see this behavior on [master](https://storecomponents.myvtex.com). Just select the **Basic Shirt.**

#### How should this be manually tested?
Using [lucis](https://lucis--storecomponents.myvtex.com) and also selecting the **Basic Shirt**.

#### Screenshots or example usage
Naah.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
