### PR TITLE
add BuyButton on press callbacks (start & finish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add callbacks to click event on `BuyButton`
 
 ## [3.14.1] - 2019-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.14.2] - 2019-02-08
 ### Added
 - Add callbacks to click event on `BuyButton`
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -45,9 +45,9 @@ export class BuyButton extends Component {
   }
 
   handleAddToCart = async () => {
-    const { skuItems, isOneClickBuy, orderFormContext, push, onAddPress, onAddFinish } = this.props
+    const { skuItems, isOneClickBuy, orderFormContext, push, onAddStart, onAddFinish } = this.props
     this.setState({ isAddingToCart: true })
-    onAddPress && onAddPress()
+    onAddStart && onAddStart()
 
     const variables = {
       items: skuItems.map(skuItem => {
@@ -156,7 +156,7 @@ BuyButton.propTypes = {
   /** Function used to show toasts (messages) to user */
   showToast: PropTypes.func.isRequired,
   /** Function to be called on the start of add to cart click event */
-  onAddPress: PropTypes.func,
+  onAddStart: PropTypes.func,
   /** Function to be called on the end of add to cart event */
   onAddFinish: PropTypes.func,
 }

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -45,8 +45,9 @@ export class BuyButton extends Component {
   }
 
   handleAddToCart = async () => {
-    const { skuItems, isOneClickBuy, orderFormContext, push } = this.props
+    const { skuItems, isOneClickBuy, orderFormContext, push, onAddPress, onAddFinish } = this.props
     this.setState({ isAddingToCart: true })
+    onAddPress && onAddPress()
 
     const variables = {
       items: skuItems.map(skuItem => {
@@ -83,6 +84,7 @@ export class BuyButton extends Component {
       }
     )
     this.setState({ isAddingToCart: false })
+    onAddFinish && onAddFinish()
   }
 
   render() {
@@ -153,6 +155,10 @@ BuyButton.propTypes = {
   available: PropTypes.bool.isRequired,
   /** Function used to show toasts (messages) to user */
   showToast: PropTypes.func.isRequired,
+  /** Function to be called on the start of add to cart click event */
+  onAddPress: PropTypes.func,
+  /** Function to be called on the end of add to cart event */
+  onAddFinish: PropTypes.func,
 }
 
 export default compose(


### PR DESCRIPTION
#### What is the purpose of this pull request?
I'd like to in my components, know when the buybutton has been pressed and has finished processing. To make adjustments on the parent component while the mutation is called.

#### What problem is this solving?
Add props `onAddPress` and `onAddFinish` that are called at the start and end of the handle button click method

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
