### PR TITLE
Use the LinkState API to delete the store-resources dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use the `apollo-link-state` into the `Greeting` component and remove the `orderFormConsumer` usage.
 
 ## [3.16.3] - 2019-02-14
 

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "vtex.shipping-estimate-translator": "2.x",
     "vtex.store-graphql": "2.x",
-    "vtex.store-resources": "0.x",
     "vtex.styleguide": "9.x",
     "vtex.dreamstore-icons": "0.x"
   }

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -85,7 +85,7 @@ export class BuyButton extends Component {
         data: { addToCart: linkStateItems },
       } = await addToCart(minicartItems)
 
-      const success = skuItems.map(skuItem =>
+      const success = linkStateItems && skuItems.map(skuItem =>
         !!linkStateItems.find(({ id }) => id === skuItem.skuId)
       )
 

--- a/react/components/Greeting/index.js
+++ b/react/components/Greeting/index.js
@@ -1,15 +1,23 @@
+import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 import { compose, branch, renderComponent } from 'recompose'
 import { FormattedMessage } from 'react-intl'
 import { path } from 'ramda'
-import { orderFormConsumer, contextPropTypes } from 'vtex.store-resources/OrderFormContext'
+import { graphql } from 'react-apollo'
+import gql from 'graphql-tag'
 
 import Loader from './Loader'
 
 import styles from './styles.css'
 
 const Wrapper = ({ children }) => (
-  <div className={`${styles.greetingContainer} mh4 pv4 t-heading-4 c-on-base nowrap`}>{children}</div>
+  <div
+    className={`${
+      styles.greetingContainer
+    } mh4 pv4 t-heading-4 c-on-base nowrap`}
+  >
+    {children}
+  </div>
 )
 
 const withWrapper = Component => props => (
@@ -18,8 +26,8 @@ const withWrapper = Component => props => (
   </Wrapper>
 )
 
-const Greeting = ({ orderFormContext }) => {
-  const firstName = path(['orderForm', 'clientProfileData', 'firstName'], orderFormContext)
+const Greeting = ({ orderForm }) => {
+  const firstName = path(['clientProfileData', 'firstName'], orderForm)
   if (!firstName) return null
 
   return (
@@ -34,11 +42,32 @@ const Greeting = ({ orderFormContext }) => {
   )
 }
 
-Greeting.propTypes = { orderFormContext: contextPropTypes }
+Greeting.propTypes = {
+  orderForm: PropTypes.shape({
+    clientProfileData: PropTypes.shape({
+      firstName: PropTypes.string,
+    }),
+  }),
+}
 
-const enhanced = compose(
-  orderFormConsumer,
-  branch(({ loading }) => loading, renderComponent(withWrapper(Loader)))
+const withLinkStateOrderForm = graphql(
+  gql`
+    query {
+      orderForm @client {
+        clientProfileData {
+          firstName
+        }
+      }
+    }
+  `,
+  {
+    props: ({ data: { orderForm } }) => ({
+      orderForm,
+    }),
+  }
 )
 
-export default enhanced(Greeting)
+export default compose(
+  withLinkStateOrderForm,
+  branch(({ loading }) => loading, renderComponent(withWrapper(Loader)))
+)(Greeting)


### PR DESCRIPTION
**Related to vtex-apps/minicart#104**

#### What is the purpose of this pull request?

Use the LinkState API to delete the store-resources dependency

#### What problem is this solving?

We want to remove the orderFormContext and to do so, we need to put the orderForm into the LinkState. The only component that still needed the store-resources was the Greeting component.

#### How should this be manually tested?

[Access the workspace](https://linkstate--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
