### PR TITLE
Fix product images refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Base settings for tests.
 
+### Fixed
+- Fix product images carousel refresh bug.
+
 ## [3.17.0] - 2019-02-15
 ### Added
 - Support to CSS Modules in `Share`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.17.2] - 2019-02-18
+
 ## [3.17.1] - 2019-02-18
 ### Fixed
 - Quick fix on `AutocompleteInput` to remove warnings.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -68,6 +68,8 @@ class Carousel extends Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.debouncedRebuildOnUpdate)
+
+    this.debouncedRebuildOnUpdate.flush()
   }
 
   onSlideChange = () => {

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -24,8 +24,6 @@ const initialState = {
 }
 
 class Carousel extends Component {
-  _mounted = false
-
   state = initialState
 
   thumbSwiper = React.createRef()
@@ -46,11 +44,6 @@ class Carousel extends Component {
   }
 
   debouncedRebuildOnUpdate = debounce(() => {
-    // fix: cannot call setState on unmounted component
-    if (!this._mounted) {
-      return
-    }
-
     this.thumbSwiper.current && this.thumbSwiper.current.swiper.update()
   }, 500)
 
@@ -71,14 +64,10 @@ class Carousel extends Component {
     window.addEventListener('resize', this.debouncedRebuildOnUpdate)
 
     this.setInitialVariablesState()
-
-    this._mounted = true
   }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.debouncedRebuildOnUpdate)
-
-    this._mounted = false
   }
 
   onSlideChange = () => {

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -69,7 +69,7 @@ class Carousel extends Component {
   componentWillUnmount() {
     window.removeEventListener('resize', this.debouncedRebuildOnUpdate)
 
-    this.debouncedRebuildOnUpdate.flush()
+    this.debouncedRebuildOnUpdate.clear()
   }
 
   onSlideChange = () => {

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import debounce from 'debounce'
 import classNames from 'classnames'
-import { path } from 'ramda'
+import { path, equals } from 'ramda'
 
 import { IconCaret } from 'vtex.dreamstore-icons'
 
@@ -17,8 +17,6 @@ const Swiper = window.navigator ? require('react-id-swiper').default : null
 
 const initialState = {
   loaded: [],
-  thumbSwiper: null,
-  gallerySwiper: null,
   thumbUrl: [],
   alt: [],
   thumbsLoaded: false,
@@ -26,13 +24,17 @@ const initialState = {
 }
 
 class Carousel extends Component {
+  _mounted = false
+
   state = initialState
+
+  thumbSwiper = React.createRef()
+  gallerySwiper = React.createRef()
 
   setInitialVariablesState() {
     const slides = this.props.slides || []
 
     this.isVideo = []
-    this.rebuildGalleryOnUpdate = false
     this.thumbLoadCount = 0
 
     slides.forEach((slide, i) => {
@@ -44,7 +46,12 @@ class Carousel extends Component {
   }
 
   debouncedRebuildOnUpdate = debounce(() => {
-    this.state.thumbSwiper && this.state.thumbSwiper.update()
+    // fix: cannot call setState on unmounted component
+    if (!this._mounted) {
+      return
+    }
+
+    this.thumbSwiper.current && this.thumbSwiper.current.swiper.update()
   }, 500)
 
   getThumb = thumbUrl => {
@@ -64,34 +71,23 @@ class Carousel extends Component {
     window.addEventListener('resize', this.debouncedRebuildOnUpdate)
 
     this.setInitialVariablesState()
+
+    this._mounted = true
   }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.debouncedRebuildOnUpdate)
-  }
 
-  linkThumb = () => {
-    const _this = this
-    return function() {
-      this.visibleSlidesIndexes || (this.visibleSlidesIndexes = []) // Swiper bug fix
-      _this.rebuildGalleryOnUpdate = true
-      _this.setState({ thumbSwiper: this })
-    }
-  }
-
-  linkGallery = () => {
-    const _this = this
-    return function() {
-      _this.setState({ gallerySwiper: this })
-    }
+    this._mounted = false
   }
 
   onSlideChange = () => {
-    const _this = this
-    return function() {
-      const { activeIndex } = this
-      _this.setState({ activeIndex })
-    }
+    const activeIndex = path([
+      'swiper',
+      'activeIndex',
+      this.gallerySwiper.currrent,
+    ])
+    this.setState({ activeIndex })
   }
 
   setVideoThumb = i => (url, title) => {
@@ -144,10 +140,11 @@ class Carousel extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { gallerySwiper, loaded, activeIndex } = this.state
-    const { isVideo } = this
+    const { loaded, activeIndex } = this.state
+    const isVideo = this.isVideo
+    const gallerySwiper = path(['swiper'], this.gallerySwiper.current)
 
-    if (prevProps.slides !== this.props.slides) {
+    if (!equals(prevProps.slides, this.props.slides)) {
       this.setInitialVariablesState()
       this.setState(initialState)
       return
@@ -167,7 +164,6 @@ class Carousel extends Component {
 
   render() {
     const { thumbSwiper, thumbsLoaded } = this.state
-    const { rebuildGalleryOnUpdate } = this
     const { slides } = this.props
 
     if (!thumbsLoaded || Swiper == null) {
@@ -202,7 +198,6 @@ class Carousel extends Component {
       zoom: {
         maxRatio: 2,
       },
-      rebuildOnUpdate: rebuildGalleryOnUpdate,
       resistanceRatio: slides.length > 1 ? 0.85 : 0,
       renderNextButton: () => (
         <span className={`swiper-caret-next pl7 right-1 ${caretClassName}`}>
@@ -223,11 +218,9 @@ class Carousel extends Component {
         </span>
       ),
       on: {
-        init: this.linkGallery(),
-        slideChange: this.onSlideChange(),
+        slideChange: this.onSlideChange,
       },
     }
-    this.rebuildGalleryOnUpdate = false
 
     const thumbnailParams = {
       observer: true,
@@ -240,9 +233,6 @@ class Carousel extends Component {
       touchRatio: 0.4,
       mousewheel: true,
       preloadImages: true,
-      on: {
-        init: this.linkThumb(),
-      },
       shouldSwiperUpdate: true,
     }
 
@@ -256,7 +246,7 @@ class Carousel extends Component {
             { 'db-ns': slides.length > 1 }
           )}
         >
-          <Swiper {...thumbnailParams}>
+          <Swiper {...thumbnailParams} ref={this.thumbSwiper}>
             {slides.map((slide, i) => (
               <div key={i} className="swiper-slide w-100 h-auto mb5">
                 <img
@@ -281,7 +271,7 @@ class Carousel extends Component {
             }
           )}
         >
-          <Swiper {...galleryParams}>
+          <Swiper {...galleryParams} ref={this.gallerySwiper}>
             {slides.map((slide, i) => (
               <div key={i} className="swiper-slide center-all">
                 {this.renderSlide(slide, i)}

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -64,7 +64,7 @@ ProductImages.propTypes = {
       thumbnailUrl: PropTypes.string,
       /** Text that describes the image */
       imageText: PropTypes.string.isRequired,
-    }),
+    })
   ),
 }
 

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -31,7 +31,7 @@ const ProductImages = props => {
     return () => {
       window.removeEventListener('resize', debouncedGetBestUrl)
 
-      debouncedGetBestUrl.flush()
+      debouncedGetBestUrl.clear()
     }
   }, [])
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix precondition on state reset of the `Carousel` component.

#### What problem is this solving?
Due to the wrong precondition check, the component was "flashing", even though the images and thumbnails were already loaded.

#### How should this be manually tested?
[Workspace](https://lucas--instoreqa.myvtex.com/instore/1177?skuId=3333). Or link this branch in any workspace with `vtex link`.

#### Screenshots

Before:
![before](https://user-images.githubusercontent.com/10223856/52972265-15302380-3399-11e9-8979-cda5c88aaebe.gif)

After:
![after](https://user-images.githubusercontent.com/10223856/52972269-182b1400-3399-11e9-83fb-978d82df1195.gif)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
