### PR TITLE
Logo min width for desktop & mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.19.1] - 2019-02-26
 ### Added
 - `min-width` for Logo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `min-width` for Logo
 
 ## [3.19.0] - 2019-02-25
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.19.0",
+  "version": "3.19.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/Logo/index.js
+++ b/react/components/Logo/index.js
@@ -33,8 +33,8 @@ export default class Logo extends Component {
   render() {
     const { width, height, isMobile, color, showLabel, url, title } = this.props
     const logoClassNames = classNames(`${styles.logoContainer}`, {
-      [styles.maxSizeDesktop]: !isMobile,
-      [styles.maxSizeMobile]: isMobile,
+      [styles.sizeDesktop]: !isMobile,
+      [styles.sizeMobile]: isMobile,
     })
 
     if (url) {

--- a/react/components/Logo/styles.css
+++ b/react/components/Logo/styles.css
@@ -1,11 +1,13 @@
-.maxSizeDesktop {
+.sizeDesktop {
   max-width: 150px;
   max-height: 75px;
+  min-width: 120px;
 }
 
-.maxSizeMobile {
+.sizeMobile {
   max-width: 90px;
   max-height: 40px;
+  min-width: 72px;
 }
 
 .logoContainer {}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Set a min-width for logo images.

#### What problem is this solving?
SVG logos don't appear (0 px width) (e.g: [cobasi's logo](https://static.cobasi.com.br/loja/Images/logo_digital_cobasi.svg))

#### How should this be manually tested?
- Upload a svg logo on /admin/cms/storefront

#### Screenshots or example usage
Before: 
<img width="885" alt="screen shot 2019-02-25 at 11 55 03 am" src="https://user-images.githubusercontent.com/7633179/53351906-a3a82600-3900-11e9-8da3-59bb0a29b4f7.png">
After:
<img width="887" alt="screen shot 2019-02-25 at 11 55 19 am" src="https://user-images.githubusercontent.com/7633179/53351927-ad318e00-3900-11e9-9e72-a9a2a776473f.png">



#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
