### PR TITLE
Prop logoUrl dynamic using {{account}} in the string url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- logoUrl now support `{{account.name}}` in the string url.
+  eg. store with account name gc-xoi8837:
+  https://static.gocommerce.com/{{account.name}}/assets/logo.png
+  it will render https://static.gocommerce.com/gc-xoi8837/assets/logo.png
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- logoUrl now support `{{account.name}}` in the string url.
+- logoUrl now support `{{account}}` in the string url.
   eg. store with account name gc-xoi8837:
-  https://static.gocommerce.com/{{account.name}}/assets/logo.png
+  https://static.gocommerce.com/{{account}}/assets/logo.png
   it will render https://static.gocommerce.com/gc-xoi8837/assets/logo.png
 
 ### Changed
@@ -39,22 +39,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make the clear button on `SearchBar` work as expected.
 
 ## [3.19.1] - 2019-02-26
-
 ### Added
-
 - `min-width` for Logo
 
 ## [3.19.0] - 2019-02-25
-
 ### Added
-
 - `UserAddress` component.
 - Added `ProductImages` docs.
 
 ## [3.18.2] - 2019-02-25
-
 ### Fixed
-
 - Improve CSS handles in `ProductImages` component.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.19.5] - 2019-03-07
 ### Added
 - logoUrl now support `{{account}}` in the string url.
   eg. store with account name gc-xoi8837:

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.19.4",
+  "version": "3.19.5",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/Logo/index.js
+++ b/react/components/Logo/index.js
@@ -21,6 +21,8 @@ class Logo extends Component {
     height: PropTypes.number,
     /** Set label visibility */
     showLabel: PropTypes.bool,
+    /** Render Runtime */
+    runtime: PropTypes.object,
   }
 
   static defaultProps = {
@@ -32,9 +34,7 @@ class Logo extends Component {
   }
 
   getUrl(url, runtime) {
-    let urlReplace = url.replace(/{{account.name}}/g, runtime.account)
-
-    return urlReplace
+    return url.replace(/{{account}}/g, runtime.account)
   }
 
   render() {

--- a/react/components/Logo/index.js
+++ b/react/components/Logo/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { withRuntimeContext } from 'vtex.render-runtime'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import styles from './styles.css'
@@ -6,7 +7,7 @@ import styles from './styles.css'
 /**
  * Logo of the store
  */
-export default class Logo extends Component {
+class Logo extends Component {
   static propTypes = {
     /** URL of the logo */
     url: PropTypes.string,
@@ -30,24 +31,53 @@ export default class Logo extends Component {
     height: 177,
   }
 
+  getUrl(url, runtime) {
+    let urlReplace = url.replace(/{{account.name}}/g, runtime.account)
+
+    return urlReplace
+  }
+
   render() {
-    const { width, height, isMobile, color, showLabel, url, title } = this.props
+    const {
+      width,
+      height,
+      isMobile,
+      color,
+      showLabel,
+      url,
+      title,
+      runtime,
+    } = this.props
     const logoClassNames = classNames(`${styles.logoContainer}`, {
       [styles.sizeDesktop]: !isMobile,
       [styles.sizeMobile]: isMobile,
     })
 
     if (url) {
-      return <img className={`${logoClassNames} store-logo`} src={url} alt={title} />
+      return (
+        <img
+          className={`${logoClassNames} store-logo`}
+          src={this.getUrl(url, runtime)}
+          alt={title}
+        />
+      )
     }
 
     if (!showLabel) {
       return (
         <div className={`${logoClassNames} store-logo`}>
-          <svg xmlns="http://www.w3.org/2000/svg" width={`${width}px`} height={`${height}px`} viewBox="0 0 24 24">
-            <path fill={color} d="M22.2029951,2 L4.28456322,2 C2.89573023,2 2.00548,3.45312422 2.65431247,4.64375547 L4.44783693,7.95552421 L1.19680743,7.95552421 C0.296493196,7.95552421 -0.280470412,8.85287845 0.140086685,9.62472859 L5.90522357,20.1887392 C6.35336788,21.0110278 7.56744234,21.0045158 8.01748106,20.1831745 L9.58332217,17.3210893 L11.5485268,20.925543 C12.2398649,22.1940814 14.1130726,22.195147 14.8071339,20.9280294 L23.7877802,4.5463122 C24.4227598,3.38729378 23.5564264,2 22.2029951,2 M14.1533286,8.98098734 L10.2804619,16.0501827 C9.98102805,16.5965991 9.17318428,16.5957703 8.87505286,16.0487619 L5.03936375,9.00975856 C4.75958436,8.4962574 5.14355582,7.87820895 5.74242344,7.87820895 L13.4699233,7.87820895 C14.0535173,7.87820895 14.427188,8.48110219 14.1533286,8.98098734" className="fill-rebel-pink">
-            </path>
-            <path d="M0 0h24v24H0z" fill="none"></path>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={`${width}px`}
+            height={`${height}px`}
+            viewBox="0 0 24 24"
+          >
+            <path
+              fill={color}
+              d="M22.2029951,2 L4.28456322,2 C2.89573023,2 2.00548,3.45312422 2.65431247,4.64375547 L4.44783693,7.95552421 L1.19680743,7.95552421 C0.296493196,7.95552421 -0.280470412,8.85287845 0.140086685,9.62472859 L5.90522357,20.1887392 C6.35336788,21.0110278 7.56744234,21.0045158 8.01748106,20.1831745 L9.58332217,17.3210893 L11.5485268,20.925543 C12.2398649,22.1940814 14.1130726,22.195147 14.8071339,20.9280294 L23.7877802,4.5463122 C24.4227598,3.38729378 23.5564264,2 22.2029951,2 M14.1533286,8.98098734 L10.2804619,16.0501827 C9.98102805,16.5965991 9.17318428,16.5957703 8.87505286,16.0487619 L5.03936375,9.00975856 C4.75958436,8.4962574 5.14355582,7.87820895 5.74242344,7.87820895 L13.4699233,7.87820895 C14.0535173,7.87820895 14.427188,8.48110219 14.1533286,8.98098734"
+              className="fill-rebel-pink"
+            />
+            <path d="M0 0h24v24H0z" fill="none" />
           </svg>
         </div>
       )
@@ -55,17 +85,31 @@ export default class Logo extends Component {
 
     return (
       <div className={`${logoClassNames} store-logo`}>
-        <svg width={width} height={height} viewBox='0 0 142 80' fill='none' xmlns='http://www.w3.org/2000/svg'>
-          <rect width='142' height='80' fill='#F2F4F5' stroke='#E3E4E6' />
-          <path d='M84.8156 47.5402L77.8157 33.9407C77.5479 33.4222 77.0282 33.0703 76.4349 33.0108C75.8434 32.9445 75.2572 33.1876 74.8844 33.6381L68.8854 40.9206L64.9707 38.386C64.5717 38.1293 64.08 38.0392 63.6162 38.1412C63.149 38.2432 62.7447 38.5271 62.4997 38.9249L57.2497 47.4246C56.9242 47.9499 56.9172 48.6026 57.227 49.1381C57.5367 49.6719 58.1195 50 58.7495 50H83.2494C83.8567 50 84.4184 49.694 84.7386 49.1925C85.0589 48.691 85.0851 48.0655 84.8156 47.5402Z' fill='#CACBCC' />
-          <path d='M67.5 33C69.433 33 71 31.433 71 29.5C71 27.567 69.433 26 67.5 26C65.567 26 64 27.567 64 29.5C64 31.433 65.567 33 67.5 33Z' fill='#CACBCC' />
+        <svg
+          width={width}
+          height={height}
+          viewBox="0 0 142 80"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect width="142" height="80" fill="#F2F4F5" stroke="#E3E4E6" />
+          <path
+            d="M84.8156 47.5402L77.8157 33.9407C77.5479 33.4222 77.0282 33.0703 76.4349 33.0108C75.8434 32.9445 75.2572 33.1876 74.8844 33.6381L68.8854 40.9206L64.9707 38.386C64.5717 38.1293 64.08 38.0392 63.6162 38.1412C63.149 38.2432 62.7447 38.5271 62.4997 38.9249L57.2497 47.4246C56.9242 47.9499 56.9172 48.6026 57.227 49.1381C57.5367 49.6719 58.1195 50 58.7495 50H83.2494C83.8567 50 84.4184 49.694 84.7386 49.1925C85.0589 48.691 85.0851 48.0655 84.8156 47.5402Z"
+            fill="#CACBCC"
+          />
+          <path
+            d="M67.5 33C69.433 33 71 31.433 71 29.5C71 27.567 69.433 26 67.5 26C65.567 26 64 27.567 64 29.5C64 31.433 65.567 33 67.5 33Z"
+            fill="#CACBCC"
+          />
           <defs>
             <clipPath id="clip0">
               <rect width="127" height="65" fill="white" />
             </clipPath>
           </defs>
         </svg>
-      </div >
+      </div>
     )
   }
 }
+
+export default withRuntimeContext(Logo)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Be interpretable {{account}} in logoUrl. The component will render the logo path by the account name.
eg. store with account name gc-xoi8837:

```
"props": {
  "logoUrl": "https://static.gocommerce.com/{{account}}/assets/gocommerce/png/logo.png"
}
```

**It will render like:**
https://static.gocommerce.com/gc-xoi8837/assets/gocommerce/png/logo.png

#### What problem is this solving?
On developing themes to Gocommerce, we face the problem to set the prop logoUrl on blocks.json, since all store that installs the theme, it will have the same logo. With the possibility to inform {{account}} inside the string, this problem will be solved.

#### How should this be manually tested?

#### Screenshots or example usage
```
"header.full": {
    "blocks": ["login", "minicart", "logo", "search-bar", "menu-link", "telemarketing", "category-menu"],
    "props": {
      "logoUrl": "https://static.gocommerce.com/{{account}}/assets/gocommerce/png/logo.png"
    }
}
```

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
