### PR TITLE
Fix BuyButton event propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Clicking the `BuyButton` will no more redirect if there is an `anchor` tag ancestor.
 
 ## [3.19.8] - 2019-03-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.19.9] - 2019-03-14
 ### Fixed
 - Clicking the `BuyButton` will no more redirect if there is an `anchor` tag ancestor.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.19.8",
+  "version": "3.19.9",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -44,7 +44,10 @@ export class BuyButton extends Component {
     this.props.showToast({ message })
   }
 
-  handleAddToCart = async () => {
+  handleAddToCart = async (event) => {
+    event.stopPropagation()
+    event.preventDefault()
+
     const { skuItems, isOneClickBuy, orderFormContext, push, onAddStart, onAddFinish } = this.props
     this.setState({ isAddingToCart: true })
     onAddStart && onAddStart()

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -44,7 +44,7 @@ export class BuyButton extends Component {
     this.props.showToast({ message })
   }
 
-  handleAddToCart = async (event) => {
+  handleAddToCart = async event => {
     event.stopPropagation()
     event.preventDefault()
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the BuyButton event propagation

#### What problem is this solving?

When there is an anchor tag with a BuyButton inside, the `click` event bubbles to the anchor tag and it redirects. For example, in the ProductSummary, we have something like:

```jsx
<Link ...>
  <a ...> // Generated by Link
    ...
    <BuyButton onClick={...} ...>
      <button onclick="..." ... />
    </BuyButton>
  </a>
</Link>
```

And when the button is clicked, the ancestors handles the click event too.

#### How should this be manually tested?

[Access the workspace](https://buybutton--storecomponents.myvtex.com/) and click the buy button.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/54282044-d9dcdb00-4579-11e9-8f2b-b030c87e0efc.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
