### PR TITLE
Set focus on search bar when search icon is clicked [mobile]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.19.7] - 2019-03-14
+
 ### Added
 
 - Add behavior test to SKUSelector.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Set `SearchBar` input focus when user click search icon on mobile devices.
+- Set `SearchBar` input focus when user click search icon.
 
 ## [3.19.6] - 2019-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add behavior test to SKUSelector.
 
+### Fixed
+
+- Set `SearchBar` input focus when user click search icon on mobile devices.
+
 ## [3.19.6] - 2019-03-11
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.19.6",
+  "version": "3.19.7",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/__mocks__/vtex.render-runtime.js
+++ b/react/__mocks__/vtex.render-runtime.js
@@ -1,8 +1,8 @@
 import React from 'react'
 
-export function withRuntimeContext(Comp) {
-  return Comp
-}
+export const withRuntimeContext = Comp => props => (
+  <Comp {...props} runtime={{ hints: { mobile: false } }} />
+)
 
 export const Link = ({ children }) => <a>{children}</a>
 

--- a/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
+++ b/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
@@ -24,7 +24,6 @@ exports[`<SearchBar /> should match snapshot 1`] = `
               id="downshift-1-input"
               placeholder="Search"
               role="combobox"
-              runtime="[object Object]"
               suffix="[object Object]"
               value=""
             />

--- a/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
+++ b/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
@@ -24,6 +24,7 @@ exports[`<SearchBar /> should match snapshot 1`] = `
               id="downshift-1-input"
               placeholder="Search"
               role="combobox"
+              runtime="[object Object]"
               suffix="[object Object]"
               value=""
             />

--- a/react/components/SearchBar/README.md
+++ b/react/components/SearchBar/README.md
@@ -1,11 +1,13 @@
 # Search Bar
 
 ## Description
+
 `Search Bar` is a VTEX Component that shows a search bar with autocomplete options and displays the matching products as well. This component can be imported and used by any VTEX App.
 
 :loudspeaker: **Disclaimer:** Don't fork this project, use, contribute, or open issue with your feature request.
 
 ## Table of Contents
+
 - [Usage](#usage)
   - [Blocks API](#blocks-api)
     - [Configuration](#configuration)
@@ -16,7 +18,7 @@
 
 You should follow the usage instruction in the main [README](https://github.com/vtex-apps/store-components/blob/master/README.md#usage).
 
-Then, add `search-bar` block into your app theme, as we do in our [Store Header](https://github.com/vtex-apps/store-header/blob/master/store/blocks.json). 
+Then, add `search-bar` block into your app theme, as we do in our [Store Header](https://github.com/vtex-apps/store-header/blob/master/store/blocks.json).
 
 ### Blocks API
 
@@ -34,24 +36,27 @@ For now this block does not have any required or optional blocks.
 
 Through the Storefront, you can change the `SearchBar`'s behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name          | Type      | Description                                                          | Default value
-| ------------------ | --------- | -------------------------------------------------------------------- |------------- |
-| `placeholder`      | `String!`  | Placeholder to be used on the input                             | - |
-| `emptyPlaceholder` | `String!`  | Shows a placeholder when the ResultList hasn't results to displayed  | - |
-| `compactMode` | `Boolean`  | Identify when to use the compact version of the component  | - |
-| `hasIconLeft` | `Boolean`  | Identify if the search icon is on left or right position  | - |
-| `iconClasses` | `String`  | Custom classes for the search icon  | - |
+| Prop name          | Type      | Description                                                         | Default value |
+| ------------------ | --------- | ------------------------------------------------------------------- | ------------- |
+| `placeholder`      | `String!` | Placeholder to be used on the input                                 | -             |
+| `emptyPlaceholder` | `String!` | Shows a placeholder when the ResultList hasn't results to displayed | -             |
+| `compactMode`      | `Boolean` | Identify when to use the compact version of the component           | -             |
+| `hasIconLeft`      | `Boolean` | Identify if the search icon is on left or right position            | -             |
+| `iconClasses`      | `String`  | Custom classes for the search icon                                  | -             |
+| `autoFocus`        | `Boolean` | Identify if the search input should autofocus or not                | -             |
 
 ### Styles API
+
 You should follow the Styles API instruction in the main [README](/README.md#styles-api).
 
 #### CSS Namespaces
+
 Below, we describe the namespace that are defined in the `SearchBar`.
 
-| Class name | Description | Component Source |
-| ---------- | ----------- | ---------------- |
-| `searchBarContainer` | The main container of `SearchBar` | [SearchBar](/react/components/SearchBar/components/SearchBar.js) |
-| `resultsList` | The list containing the results of the search | [ResultsList](/react/components/SearchBar/components/ResultsList.js) |
-| `resultsItemImage` | The image from a product returned by the search | [ResultsList](/react/components/SearchBar/components/ResultsList.js) |
-| `compactMode` | Properties to be applied to the input when `compactMode` prop is true | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `paddingInput` | The padding of the `SearchBar` input | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| Class name           | Description                                                           | Component Source                                                                 |
+| -------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `searchBarContainer` | The main container of `SearchBar`                                     | [SearchBar](/react/components/SearchBar/components/SearchBar.js)                 |
+| `resultsList`        | The list containing the results of the search                         | [ResultsList](/react/components/SearchBar/components/ResultsList.js)             |
+| `resultsItemImage`   | The image from a product returned by the search                       | [ResultsList](/react/components/SearchBar/components/ResultsList.js)             |
+| `compactMode`        | Properties to be applied to the input when `compactMode` prop is true | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `paddingInput`       | The padding of the `SearchBar` input                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -1,75 +1,83 @@
-import React, { useLayoutEffect, useRef } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 import { Input } from 'vtex.styleguide'
 import { IconClose, IconSearch } from 'vtex.store-icons'
-import { useRuntime } from 'vtex.render-runtime'
+import { withRuntimeContext } from 'vtex.render-runtime'
 
 import styles from '../styles.css'
 
 /** Midleware component to adapt the styleguide/Input to be used by the Downshift*/
-const AutocompleteInput = (
-  onGoToSearchPage,
-  onClearInput,
-  compactMode,
-  value,
-  hasIconLeft,
-  iconClasses,
-  ...restProps
-) => {
-  let inputRef = useRef(null)
-  const { mobile: isMobile } = useRuntime().hints
+class AutocompleteInput extends Component {
+  constructor(props) {
+    super(props)
+    this.inputRef = React.createRef()
+  }
 
-  const changeClassInput = () => {
+  changeClassInput = () => {
+    const { compactMode } = this.props
     if (compactMode) {
-      inputRef.current.placeholder = ''
-      inputRef.current.classList.add(styles.paddingInput)
+      this.inputRef.current.placeholder = ''
+      this.inputRef.current.classList.add(styles.paddingInput)
     }
   }
 
-  useLayoutEffect(() => {
-    changeClassInput()
-    isMobile && inputRef.current.focus()
-  }, [])
+  componentDidMount() {
+    const { runtime } = this.props
+    this.changeClassInput()
+    runtime.hints.mobile && this.inputRef.current.focus()
+  }
 
-  const suffix = (
-    <span
-      className={`${iconClasses} flex items-center pointer`}
-      onClick={() => value && onClearInput()}
-    >
-      {value ? (
-        <IconClose type="line" size={22} />
-      ) : (
-        !hasIconLeft && <IconSearch />
-      )}
-    </span>
-  )
+  render() {
+    const {
+      onGoToSearchPage,
+      onClearInput,
+      compactMode,
+      value,
+      hasIconLeft,
+      iconClasses,
+      ...restProps
+    } = this.props
 
-  const prefix = (
-    <span className={iconClasses}>
-      <IconSearch />
-    </span>
-  )
+    const suffix = (
+      <span
+        className={`${iconClasses} flex items-center pointer`}
+        onClick={() => value && onClearInput()}
+      >
+        {value ? (
+          <IconClose type="line" size={22} />
+        ) : (
+          !hasIconLeft && <IconSearch />
+        )}
+      </span>
+    )
 
-  const classContainer = classNames('w-100', {
-    [styles.compactMode]: compactMode,
-  })
+    const prefix = (
+      <span className={iconClasses}>
+        <IconSearch />
+      </span>
+    )
 
-  return (
-    <div className="flex">
-      <div className={classContainer}>
-        <Input
-          ref={inputRef}
-          size="large"
-          value={value}
-          prefix={hasIconLeft && prefix}
-          suffix={suffix}
-          {...restProps}
-        />
+    const classContainer = classNames('w-100', {
+      [styles.compactMode]: compactMode,
+    })
+
+    return (
+      <div className="flex">
+        <div className={classContainer}>
+          <Input
+            ref={this.inputRef}
+            size="large"
+            value={value}
+            prefix={hasIconLeft && prefix}
+            suffix={suffix}
+            {...restProps}
+          />
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
 AutocompleteInput.propTypes = {
@@ -98,4 +106,4 @@ AutocompleteInput.propTypes = {
   iconClasses: PropTypes.string,
 }
 
-export default AutocompleteInput
+export default withRuntimeContext(AutocompleteInput)

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -104,6 +104,8 @@ AutocompleteInput.propTypes = {
   hasIconLeft: PropTypes.bool,
   /** Custom classes for the search icon */
   iconClasses: PropTypes.string,
+  /** Identify if the search input should autofocus or not */
+  autoFocus: PropTypes.bool,
 }
 
 export default AutocompleteInput

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import { path } from 'ramda'
 
 import { Input } from 'vtex.styleguide'
 import { IconClose, IconSearch } from 'vtex.store-icons'
@@ -26,7 +27,8 @@ class AutocompleteInput extends Component {
   componentDidMount() {
     const { runtime } = this.props
     this.changeClassInput()
-    runtime.hints.mobile && this.inputRef.current.focus()
+    console.log('device', path(['hints', 'mobile'], runtime))
+    path(['hints', 'mobile'], runtime) && this.inputRef.current.focus()
   }
 
   render() {

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useLayoutEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
@@ -18,7 +18,7 @@ const AutocompleteInput = (
   iconClasses,
   ...restProps
 ) => {
-  let inputRef = React.createRef()
+  let inputRef = useRef(null)
   const { mobile: isMobile } = useRuntime().hints
 
   const changeClassInput = () => {
@@ -28,10 +28,10 @@ const AutocompleteInput = (
     }
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     changeClassInput()
     isMobile && inputRef.current.focus()
-  })
+  }, [])
 
   const suffix = (
     <span

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -1,80 +1,75 @@
-import React, { Component } from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 import { Input } from 'vtex.styleguide'
 import { IconClose, IconSearch } from 'vtex.store-icons'
+import { useRuntime } from 'vtex.render-runtime'
 
 import styles from '../styles.css'
 
 /** Midleware component to adapt the styleguide/Input to be used by the Downshift*/
-export default class AutocompleteInput extends Component {
-  constructor(props) {
-    super(props)
-    this.inputRef = React.createRef()
-  }
+const AutocompleteInput = (
+  onGoToSearchPage,
+  onClearInput,
+  compactMode,
+  value,
+  hasIconLeft,
+  iconClasses,
+  ...restProps
+) => {
+  let inputRef = React.createRef()
+  const { mobile: isMobile } = useRuntime().hints
 
-  changeClassInput = () => {
-    const { compactMode } = this.props
+  const changeClassInput = () => {
     if (compactMode) {
-      this.inputRef.current.placeholder = ''
-      this.inputRef.current.classList.add(styles.paddingInput)
+      inputRef.current.placeholder = ''
+      inputRef.current.classList.add(styles.paddingInput)
     }
   }
 
-  componentDidMount() {
-    this.changeClassInput()
-  }
+  useEffect(() => {
+    changeClassInput()
+    isMobile && inputRef.current.focus()
+  })
 
-  render() {
-    const {
-      onGoToSearchPage,
-      onClearInput,
-      compactMode,
-      value,
-      hasIconLeft,
-      iconClasses,
-      ...restProps
-    } = this.props
+  const suffix = (
+    <span
+      className={`${iconClasses} flex items-center pointer`}
+      onClick={() => value && onClearInput()}
+    >
+      {value ? (
+        <IconClose type="line" size={22} />
+      ) : (
+        !hasIconLeft && <IconSearch />
+      )}
+    </span>
+  )
 
-    const suffix = (
-      <span
-        className={`${iconClasses} flex items-center pointer`}
-        onClick={() => value && onClearInput()}
-      >
-        {value ? (
-          <IconClose type="line" size={22} />
-        ) : (
-          !hasIconLeft && <IconSearch />
-        )}
-      </span>
-    )
+  const prefix = (
+    <span className={iconClasses}>
+      <IconSearch />
+    </span>
+  )
 
-    const prefix = (
-      <span className={iconClasses}>
-        <IconSearch />
-      </span>
-    )
+  const classContainer = classNames('w-100', {
+    [styles.compactMode]: compactMode,
+  })
 
-    const classContainer = classNames('w-100', {
-      [styles.compactMode]: compactMode,
-    })
-
-    return (
-      <div className="flex">
-        <div className={classContainer}>
-          <Input
-            ref={this.inputRef}
-            size="large"
-            value={value}
-            prefix={hasIconLeft && prefix}
-            suffix={suffix}
-            {...restProps}
-          />
-        </div>
+  return (
+    <div className="flex">
+      <div className={classContainer}>
+        <Input
+          ref={inputRef}
+          size="large"
+          value={value}
+          prefix={hasIconLeft && prefix}
+          suffix={suffix}
+          {...restProps}
+        />
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 AutocompleteInput.propTypes = {
@@ -102,3 +97,5 @@ AutocompleteInput.propTypes = {
   /** Custom classes for the search icon */
   iconClasses: PropTypes.string,
 }
+
+export default AutocompleteInput

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -5,7 +5,6 @@ import { path } from 'ramda'
 
 import { Input } from 'vtex.styleguide'
 import { IconClose, IconSearch } from 'vtex.store-icons'
-import { withRuntimeContext } from 'vtex.render-runtime'
 
 import styles from '../styles.css'
 
@@ -25,9 +24,9 @@ class AutocompleteInput extends Component {
   }
 
   componentDidMount() {
-    const { runtime } = this.props
+    const { autoFocus } = this.props
     this.changeClassInput()
-    path(['hints', 'mobile'], runtime) && this.inputRef.current.focus()
+    autoFocus && this.inputRef.current.focus()
   }
 
   render() {
@@ -107,4 +106,4 @@ AutocompleteInput.propTypes = {
   iconClasses: PropTypes.string,
 }
 
-export default withRuntimeContext(AutocompleteInput)
+export default AutocompleteInput

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -27,7 +27,6 @@ class AutocompleteInput extends Component {
   componentDidMount() {
     const { runtime } = this.props
     this.changeClassInput()
-    console.log('device', path(['hints', 'mobile'], runtime))
     path(['hints', 'mobile'], runtime) && this.inputRef.current.focus()
   }
 

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import AutocompleteInput from './AutocompleteInput'
-import ResultsLits from './ResultsList'
+import ResultsLists from './ResultsList'
 import DownshiftComponent from 'downshift'
 import { NoSSR } from 'vtex.render-runtime'
 
@@ -21,7 +21,7 @@ export default class SearchBar extends Component {
       shouldSearch,
       inputValue,
       compactMode,
-      hasIconLeft, 
+      hasIconLeft,
       iconClasses,
     } = this.props
 
@@ -36,7 +36,7 @@ export default class SearchBar extends Component {
         iconClasses={iconClasses}
       />
     )
-    
+
     const mainClasses = classNames(styles.searchBarContainer)
 
     return (
@@ -50,41 +50,40 @@ export default class SearchBar extends Component {
               isOpen,
               closeMenu,
             }) => (
-                <div className="relative-m w-100">
-                  <AutocompleteInput
-                    compactMode={compactMode}
-                    onClearInput={onClearInput}
-                    hasIconLeft={hasIconLeft}
-                    iconClasses={iconClasses}
-                    onGoToSearchPage={() => {
+              <div className="relative-m w-100">
+                <AutocompleteInput
+                  compactMode={compactMode}
+                  onClearInput={onClearInput}
+                  hasIconLeft={hasIconLeft}
+                  iconClasses={iconClasses}
+                  onGoToSearchPage={() => {
+                    closeMenu()
+                    onGoToSearchPage()
+                  }}
+                  {...getInputProps({
+                    placeholder,
+                    value: inputValue,
+                    onChange: onInputChange,
+                    onKeyDown: event => {
                       closeMenu()
-                      onGoToSearchPage()
+                      onEnterPress(event)
+                    },
+                  })}
+                />
+                {shouldSearch && isOpen ? (
+                  <ResultsLists
+                    {...{
+                      inputValue,
+                      selectedItem,
+                      highlightedIndex,
+                      emptyPlaceholder,
+                      closeMenu,
+                      onClearInput,
                     }}
-                    {...getInputProps({
-                      placeholder,
-                      value: inputValue,
-                      onChange: onInputChange,
-                      onKeyDown: event => {
-                        closeMenu()
-                        onEnterPress(event)
-                      },
-                    })}
-
                   />
-                  {shouldSearch && isOpen ? (
-                    <ResultsLits
-                      {...{
-                        inputValue,
-                        selectedItem,
-                        highlightedIndex,
-                        emptyPlaceholder,
-                        closeMenu,
-                        onClearInput,
-                      }}
-                    />
-                  ) : null}
-                </div>
-              )}
+                ) : null}
+              </div>
+            )}
           </DownshiftComponent>
         </NoSSR>
       </div>
@@ -116,5 +115,5 @@ SearchBar.propTypes = {
   /** Identify if the search icon is on left or right position */
   hasIconLeft: PropTypes.bool,
   /** Custom classes for the search icon */
-  iconClasses: PropTypes.string 
+  iconClasses: PropTypes.string,
 }

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -23,6 +23,7 @@ export default class SearchBar extends Component {
       compactMode,
       hasIconLeft,
       iconClasses,
+      autoFocus,
     } = this.props
 
     const fallback = (
@@ -52,6 +53,7 @@ export default class SearchBar extends Component {
             }) => (
               <div className="relative-m w-100">
                 <AutocompleteInput
+                  autoFocus={autoFocus}
                   compactMode={compactMode}
                   onClearInput={onClearInput}
                   hasIconLeft={hasIconLeft}

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -118,4 +118,6 @@ SearchBar.propTypes = {
   hasIconLeft: PropTypes.bool,
   /** Custom classes for the search icon */
   iconClasses: PropTypes.string,
+  /** Identify if the search input should autofocus or not */
+  autoFocus: PropTypes.bool,
 }

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -62,7 +62,14 @@ class SearchBarContainer extends Component {
   }
 
   render() {
-    const { intl, compactMode, hasIconLeft, iconClasses } = this.props
+    const {
+      intl,
+      compactMode,
+      hasIconLeft,
+      iconClasses,
+      autoFocus,
+    } = this.props
+
     const { shouldSearch, inputValue } = this.state
 
     const placeholder = intl.formatMessage({
@@ -74,6 +81,7 @@ class SearchBarContainer extends Component {
 
     return (
       <SearchBar
+        autoFocus={autoFocus}
         placeholder={placeholder}
         emptyPlaceholder={emptyPlaceholder}
         shouldSearch={shouldSearch}
@@ -103,7 +111,9 @@ SearchBarContainer.propTypes = {
   /** Identify if the search icon is on left or right position */
   hasIconLeft: PropTypes.bool,
   /** Custom classes for the search icon */
-  iconClasses: PropTypes.string
+  iconClasses: PropTypes.string,
+  /** Identify if the search input should autofocus or not */
+  autoFocus: PropTypes.bool,
 }
 
 export default injectIntl(SearchBarContainer)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Set the focus of the search bar when user clicks on the search icon on mobile devices.

#### What problem is this solving?
The user had to click twice on the search to actually search something.

#### How should this be manually tested?
[Access](https://barfocus--storecomponents.myvtex.com), set to mobile devices and refresh page

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
