### PR TITLE
Change cursor to pointer when product details thumbs are hovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Change cursor to `pointer` when product details thumbs are hovered.
+
 ## [3.19.8] - 2019-03-14
+
 ### Changed
+
 - Change messages basic languages files.
 
 ## [3.19.7] - 2019-03-14

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -250,7 +250,7 @@ class Carousel extends Component {
                   src={slide.thumbUrl || this.state.thumbUrl[i]}
                 />
                 <div
-                  className={`absolute absolute--fill b--solid b--muted-2 bw1 ${
+                  className={`absolute absolute--fill b--solid b--muted-2 bw1 pointer ${
                     styles.carouselThumbBorder
                     }`}
                 />


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Change cursor to pointer when product details thumbs are hovered.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The cursor changes indicates to the user that the element is clickable, thus changing the cursor improves the UX.

#### How should this be manually tested?
[workspace](https://fixthumbcursor--storecomponents.myvtex.com/panama-hat/p)
#### Screenshots or example usage
*Before*
![Before](https://user-images.githubusercontent.com/4912690/54378928-26eaab00-4667-11e9-8ac0-61a9115149c9.png)
*After*
![After](https://user-images.githubusercontent.com/4912690/54378936-2baf5f00-4667-11e9-8abd-e9dd0880a826.png)


#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
