### PR TITLE
Fix labels to selling price and list price.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.21.1] - 2019-03-28
+
 ### Fixed
 
 - Fix labels to selling price and list price.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix labels to selling price and list price.
+
 ## [3.21.0] - 2019-03-27
 
 ### Added
+
 - Add `ProductHighlights` component.
 - Add `Newsletter` component.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.21.0",
+  "version": "3.21.1",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -74,8 +74,6 @@ class Price extends Component {
 
     const differentPrices = showListPrice && sellingPrice !== listPrice
 
-    console.log(sellingPrice, listPrice)
-
     return (
       <div className={classNames(productPrice.priceContainer, className)}>
         {differentPrices && (

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -74,6 +74,8 @@ class Price extends Component {
 
     const differentPrices = showListPrice && sellingPrice !== listPrice
 
+    console.log(sellingPrice, listPrice)
+
     return (
       <div className={classNames(productPrice.priceContainer, className)}>
         {differentPrices && (
@@ -87,7 +89,7 @@ class Price extends Component {
               <div
                 className={classNames(
                   productPrice.listPriceLabel,
-                  listPriceLabelClass
+                  'dib ph2 t-small-ns t-mini'
                 )}
               >
                 <FormattedMessage id="pricing.from" />
@@ -109,7 +111,7 @@ class Price extends Component {
             sellingPriceContainerClass
           )}
         >
-          {showLabels && (
+          {showLabels && listPrice !== sellingPrice && (
             <div
               className={classNames(
                 productPrice.sellingPriceLabel,


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
Label for list price with ~strikethrough~, and selling price with label `To` even if not have an offer.

#### How should this be manually tested?
Before:
<img width="129" alt="summaryTo" src="https://user-images.githubusercontent.com/10901554/55174625-9038e680-515c-11e9-88cb-562de4784c16.png">
<img width="132" alt="summarylistout" src="https://user-images.githubusercontent.com/10901554/55174628-9202aa00-515c-11e9-8984-1c1a721a611b.png">

After: 

<img width="128" alt="summaryToFix" src="https://user-images.githubusercontent.com/10901554/55174649-9f1f9900-515c-11e9-9231-0e929fa5b50c.png">
<img width="132" alt="summarylistoutfix" src="https://user-images.githubusercontent.com/10901554/55174657-a0e95c80-515c-11e9-8b8c-a7274867ffb5.png">


#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
