### PR TITLE
Using setQuery instead navigate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Using `setQuery` instead `navigate` in sku-selector handle.
+
 ## [3.21.7] - 2019-04-01
+
 ### Changed
+
 - Use location-marker from `store-icons` on `UserAddress`.
 
 ## [3.21.6] - 2019-04-01
+
 ### Added
+
 - New blocks `notification.bar` and `notification.inline`.
 
 ## [3.21.5] - 2019-04-01
+
 ### Fixed
+
 - Parse local state order form.
 
 ## [3.21.4] - 2019-03-29
+
 ### Added
+
 - Implement query to get pickup point checkedIn name on `UserAddress`.
 
 ## [3.21.1] - 2019-03-28

--- a/react/components/SKUSelector/index.js
+++ b/react/components/SKUSelector/index.js
@@ -14,14 +14,13 @@ import {
  * Display a list of SKU items of a product and its specifications.
  */
 class SKUSelectorContainer extends Component {
-
   static defaultProps = {
     alwaysShowSecondary: true,
   }
 
   state = { mainVariation: null, secondaryVariation: null }
 
-  buildVariations = (rawSkuSelected) => {
+  buildVariations = rawSkuSelected => {
     const skuSelected = rawSkuSelected && parseSku(rawSkuSelected)
     const skuItems =
       this.props.skuItems && this.props.skuItems.map(sku => parseSku(sku))
@@ -51,18 +50,24 @@ class SKUSelectorContainer extends Component {
   }
 
   componentDidMount() {
-    this.setState(this.buildVariations(this.props.skuSelected || this.props.skuItems[0]))
+    this.setState(
+      this.buildVariations(this.props.skuSelected || this.props.skuItems[0])
+    )
   }
 
   handleSkuSelection = (isMainVariation, skuId) => {
-
-    const selectedSku = this.props.skuItems.find(({ itemId }) => itemId === skuId)
+    const selectedSku = this.props.skuItems.find(
+      ({ itemId }) => itemId === skuId
+    )
     const variations = this.buildVariations(selectedSku)
 
     variations.mainVariation.value = selectedSku.variations[0].values[0]
     variations.secondaryVariation.value = null
-    // If there is secondary variation and there is only one option, assign skuId value to it  
-    if (variations.secondaryVariation.options && variations.secondaryVariation.options.length === 1) {
+    // If there is secondary variation and there is only one option, assign skuId value to it
+    if (
+      variations.secondaryVariation.options &&
+      variations.secondaryVariation.options.length === 1
+    ) {
       variations.secondaryVariation.value = skuId
     }
     if (!isMainVariation) {
@@ -72,25 +77,18 @@ class SKUSelectorContainer extends Component {
     this.setState(variations)
 
     const isSecondaryPicked = !!variations.secondaryVariation.value
-    
+
     this.props.onSKUSelected
       ? this.props.onSKUSelected(skuId, isMainVariation, isSecondaryPicked)
-      : this.redirectToSku(skuId, isMainVariation)
+      : this.redirectToSku(skuId)
   }
 
-  redirectToSku(skuId, isMainVariation) {
+  redirectToSku(skuId) {
     const {
-      runtime: { navigate },
+      runtime: { setQuery },
     } = this.props
-    const slug = this.props.productSlug
 
-    navigate({
-      page: 'store.product',
-      params: { slug },
-      query: `skuId=${skuId}`,
-      scrollOptions: false,
-      replace: !isMainVariation
-    })
+    setQuery({ skuId })
   }
 
   render() {

--- a/react/components/SKUSelector/index.js
+++ b/react/components/SKUSelector/index.js
@@ -80,15 +80,15 @@ class SKUSelectorContainer extends Component {
 
     this.props.onSKUSelected
       ? this.props.onSKUSelected(skuId, isMainVariation, isSecondaryPicked)
-      : this.redirectToSku(skuId)
+      : this.redirectToSku(skuId, isMainVariation)
   }
 
-  redirectToSku(skuId) {
+  redirectToSku(skuId, isMainVariation) {
     const {
       runtime: { setQuery },
     } = this.props
 
-    setQuery({ skuId })
+    setQuery({ skuId }, { replace: !isMainVariation })
   }
 
   render() {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Using `setQuery` instead `navigate` in sku-selector handle.

#### What problem is this solving?

When navigating consecutively between skus with different queries the `RenderProvider` set the `query` in the state with the info of the first URL query, after this, set the `query` in the state with the second URL query and after this `RenderProvider` set `query` again with the info of the first URL to finally set to second. You can check this behavior [here](https://storecomponents.myvtex.com/)

#### How should this be manually tested?

[Access this workspace](https://setquerysku--storecomponents.myvtex.com)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
