### PR TITLE
Set position of product image thumbs by prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Place thumbs according to position on `ProductImages`.
+
 ## [3.21.8] - 2019-04-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.22.0] - 2019-04-04
+
 ### Added
 
 - Place thumbs according to position on `ProductImages`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.21.8",
+  "version": "3.22.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.21.8",
+  "version": "3.22.0",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -271,7 +271,7 @@ class Carousel extends Component {
           className={classNames(
             `w-100 border-box ${styles.carouselGaleryCursor}`,
             {
-              [`w-100 w-80-ns border-box ${imageClasses}`]: slides.length > 1,
+              [`w-80-ns border-box ${imageClasses}`]: slides.length > 1,
             }
           )}
         >

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -226,26 +226,27 @@ class Carousel extends Component {
       shouldSwiperUpdate: true,
     }
 
-    let imageClasses = '',
-      thumbClasses = ''
+    const imageClasses = classNames(
+      `w-100 border-box ${styles.carouselGaleryCursor}`,
+      {
+        [`w-80-ns border-box ${imageClasses}`]: slides.length > 1,
+        'ml-20-ns': position === 'left',
+        'mr-20-ns': position === 'right',
+      }
+    )
 
-    if (position === 'left') {
-      imageClasses = 'ml-20-ns'
-      thumbClasses = 'left-0 pr5'
-    } else if (position === 'right') {
-      thumbClasses = 'right-0 pl5'
-      imageClasses = 'mr-20-ns'
-    }
+    const thumbClasses = classNames(
+      `w-20 ${styles.carouselGaleryThumbs} bottom-0 top-0 absolute dn`,
+      {
+        'db-ns': slides.length > 1,
+        'left-0 pr5': position === 'left',
+        'right-0 pl5': position === 'right',
+      }
+    )
 
     return (
       <div className={'relative overflow-hidden'}>
-        <div
-          className={classNames(
-            `w-20 ${styles.carouselGaleryThumbs} bottom-0 top-0 absolute dn`,
-            { 'db-ns': slides.length > 1 },
-            [thumbClasses]
-          )}
-        >
+        <div className={thumbClasses}>
           <Swiper {...thumbnailParams} ref={this.thumbSwiper}>
             {slides.map((slide, i) => (
               <div
@@ -267,14 +268,7 @@ class Carousel extends Component {
             ))}
           </Swiper>
         </div>
-        <div
-          className={classNames(
-            `w-100 border-box ${styles.carouselGaleryCursor}`,
-            {
-              [`w-80-ns border-box ${imageClasses}`]: slides.length > 1,
-            }
-          )}
-        >
+        <div className={imageClasses}>
           <Swiper {...galleryParams} ref={this.gallerySwiper}>
             {slides.map((slide, i) => (
               <div key={i} className="swiper-slide center-all">

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -73,7 +73,10 @@ class Carousel extends Component {
   }
 
   onSlideChange = () => {
-    const activeIndex = path(['swiper', 'activeIndex'], this.gallerySwiper.current)
+    const activeIndex = path(
+      ['swiper', 'activeIndex'],
+      this.gallerySwiper.current
+    )
     this.setState({ activeIndex })
   }
 
@@ -151,7 +154,7 @@ class Carousel extends Component {
 
   render() {
     const { thumbSwiper, thumbsLoaded } = this.state
-    const { slides } = this.props
+    const { slides, position } = this.props
 
     if (!thumbsLoaded || Swiper == null) {
       return <Loader slidesAmount={slides ? slides.length : 0} />
@@ -165,19 +168,19 @@ class Carousel extends Component {
       pagination:
         slides.length > 1
           ? {
-            el: '.swiper-pagination',
-            clickable: true,
-            bulletActiveClass:
-              'c-action-primary swiper-pagination-bullet-active',
-          }
+              el: '.swiper-pagination',
+              clickable: true,
+              bulletActiveClass:
+                'c-action-primary swiper-pagination-bullet-active',
+            }
           : {},
       navigation:
         slides.length > 1
           ? {
-            prevEl: '.swiper-caret-prev',
-            nextEl: '.swiper-caret-next',
-            disabledClass: `c-disabled ${styles.carouselCursorDefault}`,
-          }
+              prevEl: '.swiper-caret-prev',
+              nextEl: '.swiper-caret-next',
+              disabledClass: `c-disabled ${styles.carouselCursorDefault}`,
+            }
           : {},
       thumbs: {
         swiper: thumbSwiper,
@@ -223,21 +226,31 @@ class Carousel extends Component {
       shouldSwiperUpdate: true,
     }
 
+    let imageClasses = '',
+      thumbClasses = ''
+
+    if (position === 'left') {
+      imageClasses = 'ml-20-ns'
+      thumbClasses = 'left-0 pr5'
+    } else if (position === 'right') {
+      thumbClasses = 'right-0 pl5'
+      imageClasses = 'mr-20-ns'
+    }
+
     return (
       <div className={'relative overflow-hidden'}>
         <div
           className={classNames(
-            `w-20 ${
-            styles.carouselGaleryThumbs
-            } bottom-0 top-0 left-0 absolute pr5 dn`,
-            { 'db-ns': slides.length > 1 }
+            `w-20 ${styles.carouselGaleryThumbs} bottom-0 top-0 absolute dn`,
+            { 'db-ns': slides.length > 1 },
+            [thumbClasses]
           )}
         >
           <Swiper {...thumbnailParams} ref={this.thumbSwiper}>
             {slides.map((slide, i) => (
-              <div 
+              <div
                 key={i}
-                className="swiper-slide w-100 h-auto mb5 pointer" 
+                className="swiper-slide w-100 h-auto mb5 pointer"
                 onClick={() => this.gallerySwiper.current.swiper.slideTo(i)}
               >
                 <img
@@ -248,7 +261,7 @@ class Carousel extends Component {
                 <div
                   className={`absolute absolute--fill b--solid b--muted-2 bw1 ${
                     styles.carouselThumbBorder
-                    }`}
+                  }`}
                 />
               </div>
             ))}
@@ -258,7 +271,7 @@ class Carousel extends Component {
           className={classNames(
             `w-100 border-box ${styles.carouselGaleryCursor}`,
             {
-              'w-80-ns ml-20-ns': slides.length > 1,
+              [`w-100 w-80-ns border-box ${imageClasses}`]: slides.length > 1,
             }
           )}
         >

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -1,11 +1,9 @@
 import PropTypes from 'prop-types'
 import React, { useMemo, useEffect, useState } from 'react'
-import { path } from 'ramda'
 import debounce from 'debounce'
 
 import Carousel from './components/Carousel'
 import styles from './styles.css'
-
 
 const getBestUrlIndex = thresholds => {
   const windowSize = window.innerWidth
@@ -21,6 +19,7 @@ const getBestUrlIndex = thresholds => {
 
 const ProductImages = props => {
   const [_, setState] = useState(0)
+  const { position } = props
 
   const debouncedGetBestUrl = debounce(() => {
     // force update
@@ -55,12 +54,14 @@ const ProductImages = props => {
 
   return (
     <div className={`${styles.content} w-100`}>
-      <Carousel slides={slides} />
+      <Carousel slides={slides} position={position} />
     </div>
   )
 }
 
 ProductImages.propTypes = {
+  /** The position of the thumbs */
+  position: PropTypes.oneOf(['left', 'right']),
   /** Array of images to be passed for the Thumbnail Slider component as a props */
   images: PropTypes.arrayOf(
     PropTypes.shape({
@@ -78,6 +79,7 @@ ProductImages.propTypes = {
 
 ProductImages.defaultProps = {
   images: [],
+  position: 'left',
 }
 
 export default ProductImages


### PR DESCRIPTION
#### What is the purpose of this pull request?
The position of the product image thumbnails can be set to 'left' or 'right'

#### What problem is this solving?
Have more option to customize the thumbs position of the Product Image.

This PR solves [this issue](https://github.com/vtex-apps/store-components/issues/359)

#### How should this be manually tested?
[Access this workspace](https://theo--storecomponents.myvtex.com/fashion-eyeglasses/p)

#### Screenshots or example usage

Right option:

![image](https://user-images.githubusercontent.com/5597778/55573264-f0d99d80-56df-11e9-91a0-f37a00763767.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
