### PR TITLE
Add fillRowWithEmptyCards Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Add `fillRowWithEmptyCards` option to `CategoriesHighlights`.
 
 ## [3.22.2] - 2019-04-05
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -65,6 +65,7 @@
   "editor.categoriesHighlighted.cardShape": "editor.categoriesHighlighted.cardShape",
   "editor.categoriesHighlighted.cardShape.squared": "editor.categoriesHighlighted.cardShape.squared",
   "editor.categoriesHighlighted.cardShape.rectangular": "editor.categoriesHighlighted.cardShape.rectangular",
+  "editor.categoriesHighlighted.fillRowWithEmptyCards": "editor.categoriesHighlighted.fillRowWithEmptyCards",
   "searchBar.button.cancel.label": "searchBar.button.cancel.label",
   "buyButton-label-unavailable": "buyButton-label-unavailable",
   "greeting": "greeting",

--- a/messages/en.json
+++ b/messages/en.json
@@ -65,6 +65,7 @@
   "editor.categoriesHighlighted.cardShape": "Box shape",
   "editor.categoriesHighlighted.cardShape.squared": "Squared",
   "editor.categoriesHighlighted.cardShape.rectangular": "Rectangular",
+  "editor.categoriesHighlighted.fillRowWithEmptyCards": "Fill Row with Empty Cards",
   "searchBar.button.cancel.label": "Cancel",
   "buyButton-label-unavailable": "Unavailable",
   "greeting": "Hello",

--- a/messages/es.json
+++ b/messages/es.json
@@ -65,6 +65,7 @@
   "editor.categoriesHighlighted.cardShape": "Forma de la caja",
   "editor.categoriesHighlighted.cardShape.squared": "Cuadrada",
   "editor.categoriesHighlighted.cardShape.rectangular": "Rectangular",
+  "editor.categoriesHighlighted.fillRowWithEmptyCards": "Rellene la fila con tarjetas vacías",
   "searchBar.button.cancel.label": "Cancelar",
   "buyButton-label-unavailable": "Indisponible",
   "greeting": "Hola",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -65,6 +65,7 @@
   "editor.categoriesHighlighted.cardShape": "Forma da caixa",
   "editor.categoriesHighlighted.cardShape.squared": "Quadrada",
   "editor.categoriesHighlighted.cardShape.rectangular": "Retangular",
+  "editor.categoriesHighlighted.fillRowWithEmptyCards": "Encher Linha com Cartões Vazios",
   "searchBar.button.cancel.label": "Cancelar",
   "buyButton-label-unavailable": "Indisponível",
   "greeting": "Olá",

--- a/react/components/CategoriesHighlights/README.md
+++ b/react/components/CategoriesHighlights/README.md
@@ -39,6 +39,7 @@ You can use it in your code like a React component with the jsx tag: `<Categorie
 | `showCategoriesHighlighted`         | `Boolean!` | Flag which indicates if the categories highlighted should be displayed or not             | false
 | `quantityOfItems`                   | `Number!`  | Number of categories highlighted to be displayed (it should be 2 or 4)                    | 2
 | `boxShape`                          | `String!`  | Shape of the card box which wraps each category (it should be 'squared' or 'rectangular') | `squared`                              
+| `fillRowWithEmptyCards`         | `Boolean!` | Flag which indicates if the row should be filled with empty cards             | true
 
 Category Highlight:
 

--- a/react/components/CategoriesHighlights/index.js
+++ b/react/components/CategoriesHighlights/index.js
@@ -21,6 +21,8 @@ class CategoriesHighlights extends Component {
     quantityOfItems: PropTypes.number.isRequired,
     /** Shape of the card box which wraps each category (it should be 'squared' or 'rectangular')  */
     cardShape: PropTypes.oneOf([SQUARED, RECTANGULAR]).isRequired,
+    /** Flag which indicates if the row should be filled with empty cards */
+    fillRowWithEmptyCards: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -28,6 +30,7 @@ class CategoriesHighlights extends Component {
     showCategoriesHighlighted: false,
     quantityOfItems: ITEMS_PER_ROW,
     cardShape: SQUARED,
+    fillRowWithEmptyCards: true,
   }
 
   static uiSchema = {
@@ -112,6 +115,12 @@ class CategoriesHighlights extends Component {
           properties: categoriesHighlightedProps,
           isLayout: false,
         },
+        fillRowWithEmptyCards: {
+          type: 'boolean',
+          title: 'editor.categoriesHighlighted.fillRowWithEmptyCards',
+          default: true,
+          isLayout: true,
+        },
       },
     }
   }
@@ -122,17 +131,20 @@ class CategoriesHighlights extends Component {
       showCategoriesHighlighted,
       quantityOfItems,
       cardShape,
+      fillRowWithEmptyCards,
     } = this.props
 
     if (!showCategoriesHighlighted) return null
 
     let categories = values(categoriesHighlighted).map(category => category)
-    range(categories.length, quantityOfItems).forEach(() => {
-      categories.push({
-        name: '',
-        image: '',
+    if (fillRowWithEmptyCards) {
+      range(categories.length, quantityOfItems).forEach(() => {
+        categories.push({
+          name: '',
+          image: '',
+        })
       })
-    })
+    }
 
     return (
       <div
@@ -146,13 +158,16 @@ class CategoriesHighlights extends Component {
               key={`row${indexRow}`}
               className="flex flex-row flex-wrap items-center justify-center"
             >
-              {range(0, ITEMS_PER_ROW).map(indexCol => (
-                <CategoryCard
-                  key={2 * indexRow + indexCol}
-                  shape={cardShape}
-                  {...categories[2 * indexRow + indexCol]}
-                />
-              ))}
+              {range(0, ITEMS_PER_ROW).map(
+                indexCol =>
+                  categories[2 * indexRow + indexCol] && (
+                    <CategoryCard
+                      key={2 * indexRow + indexCol}
+                      shape={cardShape}
+                      {...categories[2 * indexRow + indexCol]}
+                    />
+                  )
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow users to choose to fill category cards up to the row length. This value defaults to true.

#### What problem is this solving?
We plan to use `CategoriesHighlights` in the `vtex.search-result` app to show the category tree response. The current behaviour of this component is to show empty cards, if the categories do not add up to complete the row. We do not want this to happen in the search result page.

#### How should this be manually tested?
Try the search result page [here](https://sahan--biscoindqa.myvtex.com/south-co/b).

#### Screenshots or example usage
##### without fill
![ch-without-fill](https://user-images.githubusercontent.com/42151054/55788350-c7e94c00-5ad5-11e9-9a57-587c9b9bd8d9.png)
##### with fill
![ch-with-fill](https://user-images.githubusercontent.com/42151054/55788352-c91a7900-5ad5-11e9-8427-f99ae69b97df.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
