### PR TITLE
[CH] Fix propType Name showCategoriesHighlighted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Fix propType name for `showCategoriesHighlighted` in `CategoriesHighlights`.
 
 ## [3.22.2] - 2019-04-05
 ### Fixed

--- a/react/components/CategoriesHighlights/index.js
+++ b/react/components/CategoriesHighlights/index.js
@@ -16,7 +16,7 @@ class CategoriesHighlights extends Component {
     /** Categories highlighted in the department */
     categoriesHighlighted: PropTypes.object,
     /** Flag which indicates if the categories highlighted should be displayed or not */
-    showCategoriesHighlights: PropTypes.bool,
+    showCategoriesHighlighted: PropTypes.bool,
     /** Number of categories highlighted to be displayed (it should be 2 or 4) */
     quantityOfItems: PropTypes.number.isRequired,
     /** Shape of the card box which wraps each category (it should be 'squared' or 'rectangular')  */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix `propType` name for `showCategoriesHighlighted` in `CategoriesHighlights` component.

#### What problem is this solving?
The `propType` name for prop `showCategoriesHighlighted` is set to `showCategoriesHighlights` as of now.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
