### PR TITLE
Ensure mutation to require acronym as String - Availability Subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Ensure mutation to require acronym as String
 
 ## [3.22.2] - 2019-04-05
 ### Fixed

--- a/react/components/AvailabilitySubscriber/mutations/addToAvailabilitySubscriberMutation.gql
+++ b/react/components/AvailabilitySubscriber/mutations/addToAvailabilitySubscriberMutation.gql
@@ -1,4 +1,4 @@
-mutation availabilitySubscribe($acronym: String, $document: DocumentInput) {
+mutation availabilitySubscribe($acronym: String!, $document: DocumentInput) {
   updateDocument(acronym: $acronym, document: $document) {
     cacheId
     id


### PR DESCRIPTION
#### What problem is this solving?
Solve the use of the component Availability subscribe that is not working due the mutation not requiring acronym as String

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
