### PR TITLE
Remove sku variations sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.25.6] - 2019-04-15
 ### Changed
 - Remove sort of sku item variations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove sort of sku item variations.
 
 ## [3.25.5] - 2019-04-12
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.25.5",
+  "version": "3.25.6",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.25.4",
+  "version": "3.25.6",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/__tests__/components/__snapshots__/SKUSelector.test.js.snap
+++ b/react/__tests__/components/__snapshots__/SKUSelector.test.js.snap
@@ -36,7 +36,7 @@ exports[`<SKUSelector /> should match the snapshot 1`] = `
               >
                 <img
                   alt=""
-                  src="sku-image-Yellow-url"
+                  src="sku-image-Black-url"
                 />
               </div>
             </div>
@@ -80,7 +80,7 @@ exports[`<SKUSelector /> should match the snapshot 1`] = `
               >
                 <img
                   alt=""
-                  src="sku-image-Black-url"
+                  src="sku-image-Yellow-url"
                 />
               </div>
             </div>

--- a/react/components/SKUSelector/index.js
+++ b/react/components/SKUSelector/index.js
@@ -4,12 +4,7 @@ import { useRuntime } from 'vtex.render-runtime'
 
 import SKUSelector from './components/SKUSelector'
 import { skuShape } from './utils/proptypes'
-import {
-  getMainVariationName,
-  getVariationOptions,
-  getMaxSkuPrice,
-  parseSku,
-} from './utils'
+import { getMainVariationName, getMaxSkuPrice, parseSku } from './utils'
 
 /**
  * Display a list of SKU items of a product and its specifications.
@@ -36,7 +31,7 @@ const SKUSelectorContainer = ({
       const mainVariation = {
         name,
         value: skuSelected ? sku[name] : null,
-        options: getVariationOptions(name, parsedItems),
+        options: parsedItems,
       }
 
       const secondaryVariation = { value: skuSelected ? itemId : null }
@@ -47,10 +42,7 @@ const SKUSelectorContainer = ({
         secondaryVariation.name = variations.find(
           variation => variation !== name
         )
-        secondaryVariation.options = getVariationOptions(
-          secondaryVariation.name,
-          filteredSkus
-        )
+        secondaryVariation.options = filteredSkus
       }
 
       return { mainVariation, secondaryVariation }

--- a/react/components/SKUSelector/utils/index.js
+++ b/react/components/SKUSelector/utils/index.js
@@ -42,22 +42,6 @@ export const parseSku = sku => {
 }
 
 /**
- * Retrieves a list of unique options of a given variation
- * @param {string} variation
- * @param {skus} skus
- */
-export const getVariationOptions = (variation, skus) => {
-  const hTable = {}
-
-  skus.reverse().map(sku => {
-    const value = sku[variation]
-    hTable[value] = sku
-  })
-
-  return Object.values(hTable).sort((a, b) => a[variation] - b[variation])
-}
-
-/**
  * Verifies if the variation is color
  * @param {string} variation
  */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the sort of the SKU items variations.

#### What problem is this solving?
The order the variations are given back from the API must be respected.

#### How should this be manually tested?
[wks](https://lucas2--storecomponents.myvtex.com/classic-shoes/p?skuId=35).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
