### PR TITLE
Add CSS classes for reaching a sku variation name and value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- CSS classes for reaching a sku variation name and value.
+
 ## [3.28.1] - 2019-04-25
 ### Fixed
 - Fix propType `ShippingSimulator` error, removed warning from console.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.29.0] - 2019-04-25
+
 ### Added
 - CSS classes for reaching a sku variation name and value.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.28.1",
+  "version": "3.29.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.28.1",
+  "version": "3.29.0",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/__tests__/components/__snapshots__/SKUSelector.test.js.snap
+++ b/react/__tests__/components/__snapshots__/SKUSelector.test.js.snap
@@ -6,7 +6,7 @@ exports[`<SKUSelector /> should match the snapshot 1`] = `
     class="skuSelectorContainer"
   >
     <div
-      class="skuSelectorSubcontainer flex flex-column mb7"
+      class="skuSelectorSubcontainer skuSelectorSubcontainer--Color flex flex-column mb7"
     >
       <div
         class="skuSelectorNameContainer ma1"
@@ -20,7 +20,7 @@ exports[`<SKUSelector /> should match the snapshot 1`] = `
           class="inline-flex flex-wrap ml2"
         >
           <div
-            class="skuSelectorItem relative di pointer flex items-center outline-0 skuSelectorItemImage"
+            class="skuSelectorItem skuSelectorItem--Black relative di pointer flex items-center outline-0 skuSelectorItemImage"
             role="button"
             tabindex="0"
           >
@@ -44,7 +44,7 @@ exports[`<SKUSelector /> should match the snapshot 1`] = `
             </div>
           </div>
           <div
-            class="skuSelectorItem relative di pointer flex items-center outline-0 skuSelectorItemImage"
+            class="skuSelectorItem skuSelectorItem--Blue relative di pointer flex items-center outline-0 skuSelectorItemImage"
             role="button"
             tabindex="0"
           >
@@ -68,7 +68,7 @@ exports[`<SKUSelector /> should match the snapshot 1`] = `
             </div>
           </div>
           <div
-            class="skuSelectorItem relative di pointer flex items-center outline-0 skuSelectorItemImage"
+            class="skuSelectorItem skuSelectorItem--Yellow relative di pointer flex items-center outline-0 skuSelectorItemImage"
             role="button"
             tabindex="0"
           >

--- a/react/components/SKUSelector/components/SelectorItem.js
+++ b/react/components/SKUSelector/components/SelectorItem.js
@@ -24,6 +24,7 @@ const SelectorItem = ({
   price,
   onClick,
   isImage,
+  variationValue,
 }) => {
   const discount = getDiscount(maxPrice, price)
 
@@ -33,6 +34,7 @@ const SelectorItem = ({
       tabIndex={0}
       className={classNames(
         styles.skuSelectorItem,
+        `${styles.skuSelectorItem}--${variationValue}`,
         'relative di pointer flex items-center outline-0',
         {
           [styles.skuSelectorItemImage]: isImage,
@@ -95,6 +97,8 @@ SelectorItem.propTypes = {
   skuId: PropTypes.string,
   /** True if it's an image variation */
   isImage: PropTypes.bool,
+  /** Value of the variation */
+  variationValue: PropTypes.string.isRequired,
 }
 
 export default SelectorItem

--- a/react/components/SKUSelector/components/Variation.js
+++ b/react/components/SKUSelector/components/Variation.js
@@ -11,7 +11,11 @@ const Variation = ({ variation, onSelectItem, maxSkuPrice, isSelected }) => {
   const displayImage = isColor(variation.name)
 
   return (
-    <div className={`${styles.skuSelectorSubcontainer} flex flex-column mb7`}>
+    <div
+      className={`${styles.skuSelectorSubcontainer} ${
+        styles.skuSelectorSubcontainer
+      }--${variation.name} flex flex-column mb7`}
+    >
       <div className={`${styles.skuSelectorNameContainer} ma1`}>
         <span
           className={`${
@@ -34,6 +38,7 @@ const Variation = ({ variation, onSelectItem, maxSkuPrice, isSelected }) => {
                 price={seller.commertialOffer.Price}
                 onClick={() => onSelectItem(skuItem.itemId)}
                 isImage={displayImage}
+                variationValue={skuItem[variation.name]}
               >
                 {displayImage && skuImage ? (
                   <img


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add CSS classes for reaching a sku variation name and value

#### What problem is this solving?
Make it possible for a custom CSS to customize each sku selector variation.

#### How should this be manually tested?
https://breno2--storecomponents.myvtexdev.com/classic-shoes/p

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/284515/56754505-9d4cf380-6763-11e9-8b91-36bac7d22b98.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
