### PR TITLE
Add BRAND field in skuItemToMinicartItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.30.2] - 2019-04-30
 ### Fixed
 - Add `brand` props to send to minicart on `BuyButton`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add `brand` props to send to minicart on `BuyButton`.
 
 ## [3.30.1] - 2019-04-29
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.30.1",
+  "version": "3.30.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.29.1",
+  "version": "3.30.2",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -60,6 +60,7 @@ export class BuyButton extends Component {
           'name',
           'options',
           'listPrice',
+          'brand'
         ],
         restSkuItem
       ),


### PR DESCRIPTION
#### What is the purpose of this pull request?
Return `Brand` prop in `skuItemToMinicartItem`.

#### What problem is this solving?
`Brand` is required in `MiniCart` and `google-tag-manager`.

#### How should this be manually tested?
[Workspace](https://thay--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
