### PR TITLE
Hide InstallmentPrice when there is only 1x options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.32.0] - 2019-05-02
 ### Changed
 - Hide `InstallmentsPrice` when there's only _1x_ options.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Hide `InstallmentsPrice` when there's only _1x_ options.
 
 ## [3.31.0] - 2019-04-30
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.31.0",
+  "version": "3.32.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/ProductPrice/Installments.js
+++ b/react/components/ProductPrice/Installments.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react'
 import classNames from 'classnames'
-import { is, isEmpty } from 'ramda'
+import { isEmpty } from 'ramda'
 import { FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
 

--- a/react/components/ProductPrice/Installments.js
+++ b/react/components/ProductPrice/Installments.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react'
 import classNames from 'classnames'
-import { isEmpty } from 'ramda'
+import { is, isEmpty } from 'ramda'
 import { FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
 
@@ -9,18 +9,17 @@ import PricePropTypes from './propTypes'
 import productPrice from './styles.css'
 
 /** Installments component */
-const Installments = (
+const Installments = ({
   showLabels,
   formatNumber,
-  installments,
+  installments = [],
   currencyOptions,
   className,
   installmentClass,
-  interestRateClass
-) => {
+  interestRateClass,
+}) => {
   if (
     !installments ||
-    isEmpty(installments) ||
     isEmpty(
       installments.filter(
         ({ NumberOfInstallments }) => NumberOfInstallments > 1

--- a/react/components/ProductPrice/Installments.js
+++ b/react/components/ProductPrice/Installments.js
@@ -42,7 +42,15 @@ export default class Installments extends Component {
       interestRateClass,
     } = this.props
 
-    if (!installments || isEmpty(installments)) {
+    if (
+      !installments ||
+      isEmpty(installments) ||
+      isEmpty(
+        installments.filter(
+          ({ NumberOfInstallments }) => NumberOfInstallments > 1
+        )
+      )
+    ) {
       return null
     }
 

--- a/react/components/ProductPrice/Installments.js
+++ b/react/components/ProductPrice/Installments.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Fragment } from 'react'
 import classNames from 'classnames'
 import { isEmpty } from 'ramda'
 import { FormattedMessage } from 'react-intl'
@@ -9,112 +9,111 @@ import PricePropTypes from './propTypes'
 import productPrice from './styles.css'
 
 /** Installments component */
-export default class Installments extends Component {
-  static propTypes = {
-    /** Classes to be applied to the root element */
-    className: PropTypes.string,
-    /** Classes to be applied to installment value element */
-    installmentClass: PropTypes.string,
-    /** Classes to be applied to interest rate element */
-    interestRateClass: PropTypes.string,
-    /** Product installments to be displayed */
-    installments: PricePropTypes.installments,
-    /** Pages editor config to display labels */
-    showLabels: PropTypes.bool.isRequired,
-    /** react-intl function to format the prices*/
-    formatNumber: PropTypes.func.isRequired,
-    /** Options to be passe to the formatNumber function*/
-    currencyOptions: PropTypes.shape({
-      style: PropTypes.string.isRequired,
-      currency: PropTypes.string.isRequired,
-      minimumFractionDigits: PropTypes.number.isRequired,
-      maximumFractionDigits: PropTypes.number.isRequired,
-    }).isRequired,
-  }
-  render() {
-    const {
-      showLabels,
-      formatNumber,
-      installments,
-      currencyOptions,
-      className,
-      installmentClass,
-      interestRateClass,
-    } = this.props
-
-    if (
-      !installments ||
-      isEmpty(installments) ||
-      isEmpty(
-        installments.filter(
-          ({ NumberOfInstallments }) => NumberOfInstallments > 1
-        )
+const Installments = (
+  showLabels,
+  formatNumber,
+  installments,
+  currencyOptions,
+  className,
+  installmentClass,
+  interestRateClass
+) => {
+  if (
+    !installments ||
+    isEmpty(installments) ||
+    isEmpty(
+      installments.filter(
+        ({ NumberOfInstallments }) => NumberOfInstallments > 1
       )
-    ) {
-      return null
-    }
-
-    const noInterestRateInstallments = installments.filter(
-      installment =>
-        !installment.InterestRate && installment.NumberOfInstallments > 1
     )
-
-    /*
-     * - The selected installment will be the one with the highest `NumberOfInstallments`;
-     * - If there is no 'interest-free' installments, the normal installments will be analyzed.
-     */
-    const installment = (isEmpty(noInterestRateInstallments)
-      ? installments
-      : noInterestRateInstallments
-    ).reduce((previous, current) =>
-      previous.NumberOfInstallments > current.NumberOfInstallments
-        ? previous
-        : current
-    )
-
-    const formattedInstallmentPrice = formatNumber(
-      installment.Value,
-      currencyOptions
-    )
-
-    const [installmentsElement, installmentPriceElement, timesElement] = [
-      installment.NumberOfInstallments,
-      formattedInstallmentPrice,
-      <Fragment>x</Fragment>,
-    ].map((element, index) => (
-      <span className={installmentClass} key={index}>
-        {element}
-      </span>
-    ))
-
-    return (
-      <div className={classNames(productPrice.installmentsPrice, className)}>
-        {showLabels ? (
-          <FormattedMessage
-            id="store/pricing.installment-display"
-            values={{
-              installments: installmentsElement,
-              installmentPrice: installmentPriceElement,
-              times: timesElement,
-            }}
-          />
-        ) : (
-          <Fragment>
-            {installmentsElement}
-            {timesElement} {installmentPriceElement}
-          </Fragment>
-        )}
-        {!installment.InterestRate && (
-          <div
-            className={classNames(
-              productPrice.interestRatePrice,
-              interestRateClass
-            )}
-          >
-            <FormattedMessage id="store/pricing.interest-free" />
-          </div>
-        )}
-      </div>
-    )
+  ) {
+    return null
   }
+
+  const noInterestRateInstallments = installments.filter(
+    installment =>
+      !installment.InterestRate && installment.NumberOfInstallments > 1
+  )
+
+  /*
+   * - The selected installment will be the one with the highest `NumberOfInstallments`;
+   * - If there is no 'interest-free' installments, the normal installments will be analyzed.
+   */
+  const installment = (isEmpty(noInterestRateInstallments)
+    ? installments
+    : noInterestRateInstallments
+  ).reduce((previous, current) =>
+    previous.NumberOfInstallments > current.NumberOfInstallments
+      ? previous
+      : current
+  )
+
+  const formattedInstallmentPrice = formatNumber(
+    installment.Value,
+    currencyOptions
+  )
+
+  const [installmentsElement, installmentPriceElement, timesElement] = [
+    installment.NumberOfInstallments,
+    formattedInstallmentPrice,
+    <Fragment key="x">x</Fragment>,
+  ].map((element, index) => (
+    <span className={installmentClass} key={index}>
+      {element}
+    </span>
+  ))
+
+  return (
+    <div className={classNames(productPrice.installmentsPrice, className)}>
+      {showLabels ? (
+        <FormattedMessage
+          id="store/pricing.installment-display"
+          values={{
+            installments: installmentsElement,
+            installmentPrice: installmentPriceElement,
+            times: timesElement,
+          }}
+        />
+      ) : (
+        <Fragment>
+          {installmentsElement}
+          {timesElement} {installmentPriceElement}
+        </Fragment>
+      )}
+      {!installment.InterestRate && (
+        <div
+          className={classNames(
+            productPrice.interestRatePrice,
+            interestRateClass
+          )}
+        >
+          <FormattedMessage id="store/pricing.interest-free" />
+        </div>
+      )}
+    </div>
+  )
 }
+
+Installments.propTypes = {
+  /** Classes to be applied to the root element */
+  className: PropTypes.string,
+  /** Classes to be applied to installment value element */
+  installmentClass: PropTypes.string,
+  /** Classes to be applied to interest rate element */
+  interestRateClass: PropTypes.string,
+  /** Product installments to be displayed */
+  installments: PricePropTypes.installments,
+  /** Pages editor config to display labels */
+  showLabels: PropTypes.bool.isRequired,
+  /** react-intl function to format the prices*/
+  formatNumber: PropTypes.func.isRequired,
+  /** Options to be passe to the formatNumber function*/
+  currencyOptions: PropTypes.shape({
+    style: PropTypes.string.isRequired,
+    currency: PropTypes.string.isRequired,
+    minimumFractionDigits: PropTypes.number.isRequired,
+    maximumFractionDigits: PropTypes.number.isRequired,
+  }).isRequired,
+}
+
+export default Installments


### PR DESCRIPTION
[Story](https://app.clubhouse.io/vtex-dev/story/10621/remove-the-installment-advice-when-it-s-only-1x).

[Before](https://pauloafonso--invictastores.myvtex.com/invicta-pro-diver-swiss-movement-quartz-watch---stainless-steel-case-stainless-steel-band---model-0069--/p) this fix.

[After](https://invictastores.myvtex.com/invicta-pro-diver-swiss-movement-quartz-watch---stainless-steel-case-stainless-steel-band---model-0069--/p) this fix.

After the fix on [storecomponents](https://pauloafonso--storecomponents.myvtex.com/panama-hat/p)

(I've improved the verification because `render-ssr` was throwing a error about it)

(Also took a chance to refact the component, but in a separate commit)