### PR TITLE
Carousel renders a placeholder when there is no image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Instead of rendering a content loader when there is no image to be rendered in `Carousel`, it now renders a placeholder.
 
 ## [3.32.0] - 2019-05-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.32.1] - 2019-05-03
 ### Fixed
 - Instead of rendering a content loader when there is no image to be rendered in `Carousel`, it now renders a placeholder.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.32.0",
+  "version": "3.32.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.31.0",
+  "version": "3.32.1",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/__tests__/components/__snapshots__/ProductImages.test.js.snap
+++ b/react/__tests__/components/__snapshots__/ProductImages.test.js.snap
@@ -26,48 +26,44 @@ exports[`<ProductImages /> should match the snapshot with no images 1`] = `
   <div
     class="content w-100"
   >
-    <div
-      class="w-100 aspect-ratio aspect-ratio--1x1"
+    <svg
+      fill="none"
+      height="100%"
+      viewBox="0 0 512 512"
+      width="100%"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <svg
-        class="content-loader-mock"
-      >
-        <rect
-          class="dn db-ns"
-          height="18%"
-          width="18%"
-        />
-        <rect
-          class="dn db-ns"
-          height="18%"
-          width="18%"
-          y="20%"
-        />
-        <rect
-          class="dn db-ns"
-          height="18%"
-          width="18%"
-          y="40%"
-        />
-        <rect
-          class="dn db-ns"
-          height="18%"
-          width="18%"
-          y="61%"
-        />
-        <rect
-          class="dn db-ns"
-          height="89%"
-          width="89%"
-          x="20%"
-        />
-        <rect
-          class="db dn-ns"
-          height="100%"
-          width="100%"
-        />
-      </svg>
-    </div>
+      <rect
+        fill="#F2F2F2"
+        height="512"
+        width="512"
+      />
+      <rect
+        height="150.474"
+        stroke="#CACBCC"
+        stroke-width="2"
+        width="144.286"
+        x="183.857"
+        y="180.2"
+      />
+      <path
+        d="M183.78 303.688H328.214"
+        stroke="#CACBCC"
+        stroke-width="2"
+      />
+      <path
+        d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
+        stroke="#CACBCC"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+      <path
+        d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
+        stroke="#CACBCC"
+        stroke-width="2"
+      />
+    </svg>
   </div>
 </DocumentFragment>
 `;
@@ -77,48 +73,44 @@ exports[`<ProductImages /> should match the snapshot with thumbnails in right po
   <div
     class="content w-100"
   >
-    <div
-      class="w-100 aspect-ratio aspect-ratio--1x1"
+    <svg
+      fill="none"
+      height="100%"
+      viewBox="0 0 512 512"
+      width="100%"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <svg
-        class="content-loader-mock"
-      >
-        <rect
-          class="dn db-ns"
-          height="18%"
-          width="18%"
-        />
-        <rect
-          class="dn db-ns"
-          height="18%"
-          width="18%"
-          y="20%"
-        />
-        <rect
-          class="dn db-ns"
-          height="18%"
-          width="18%"
-          y="40%"
-        />
-        <rect
-          class="dn db-ns"
-          height="18%"
-          width="18%"
-          y="61%"
-        />
-        <rect
-          class="dn db-ns"
-          height="89%"
-          width="89%"
-          x="20%"
-        />
-        <rect
-          class="db dn-ns"
-          height="100%"
-          width="100%"
-        />
-      </svg>
-    </div>
+      <rect
+        fill="#F2F2F2"
+        height="512"
+        width="512"
+      />
+      <rect
+        height="150.474"
+        stroke="#CACBCC"
+        stroke-width="2"
+        width="144.286"
+        x="183.857"
+        y="180.2"
+      />
+      <path
+        d="M183.78 303.688H328.214"
+        stroke="#CACBCC"
+        stroke-width="2"
+      />
+      <path
+        d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
+        stroke="#CACBCC"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+      <path
+        d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
+        stroke="#CACBCC"
+        stroke-width="2"
+      />
+    </svg>
   </div>
 </DocumentFragment>
 `;

--- a/react/components/ProductImages/components/Carousel/ImagePlaceholder.js
+++ b/react/components/ProductImages/components/Carousel/ImagePlaceholder.js
@@ -1,0 +1,36 @@
+import React from 'react'
+
+export default function ImagePlaceholder() {
+  return (
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 512 512"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect width="512" height="512" fill="#F2F2F2" />
+      <rect
+        x="183.857"
+        y="180.2"
+        width="144.286"
+        height="150.474"
+        stroke="#CACBCC"
+        strokeWidth="2"
+      />
+      <path d="M183.78 303.688H328.214" stroke="#CACBCC" strokeWidth="2" />
+      <path
+        d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
+        stroke="#CACBCC"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
+        stroke="#CACBCC"
+        strokeWidth="2"
+      />
+    </svg>
+  )
+}

--- a/react/components/ProductImages/components/Carousel/Loader.js
+++ b/react/components/ProductImages/components/Carousel/Loader.js
@@ -1,40 +1,11 @@
 import ContentLoader from 'react-content-loader'
 import React from 'react'
 
+import ImagePlaceholder from './ImagePlaceholder'
+
 export default props => {
   if (props.slidesAmount === 0) {
-    return (
-      <svg
-        width="100%"
-        height="100%"
-        viewBox="0 0 512 512"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <rect width="512" height="512" fill="#F2F2F2" />
-        <rect
-          x="183.857"
-          y="180.2"
-          width="144.286"
-          height="150.474"
-          stroke="#CACBCC"
-          strokeWidth="2"
-        />
-        <path d="M183.78 303.688H328.214" stroke="#CACBCC" strokeWidth="2" />
-        <path
-          d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
-          stroke="#CACBCC"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
-          stroke="#CACBCC"
-          strokeWidth="2"
-        />
-      </svg>
-    )
+    return <ImagePlaceholder />
   }
   if (props.slidesAmount === 1) {
     return (

--- a/react/components/ProductImages/components/Carousel/Loader.js
+++ b/react/components/ProductImages/components/Carousel/Loader.js
@@ -2,6 +2,40 @@ import ContentLoader from 'react-content-loader'
 import React from 'react'
 
 export default props => {
+  if (props.slidesAmount === 0) {
+    return (
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 512 512"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect width="512" height="512" fill="#F2F2F2" />
+        <rect
+          x="183.857"
+          y="180.2"
+          width="144.286"
+          height="150.474"
+          stroke="#CACBCC"
+          strokeWidth="2"
+        />
+        <path d="M183.78 303.688H328.214" stroke="#CACBCC" strokeWidth="2" />
+        <path
+          d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
+          stroke="#CACBCC"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
+          stroke="#CACBCC"
+          strokeWidth="2"
+        />
+      </svg>
+    )
+  }
   if (props.slidesAmount === 1) {
     return (
       <div className="w-100 aspect-ratio aspect-ratio--1x1">


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

[Infinite content loader when there is no image to be rendered](https://app.clubhouse.io/vtex-dev/story/10296/product-without-image-with-infinite-loading)

#### How should this be manually tested?

[Access the workspace](https://placeholder--invictastores.myvtex.com/impact-cases) and click a product with no image

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/57147099-30f27580-6d9d-11e9-9d8b-5137f586b191.png)

![image](https://user-images.githubusercontent.com/15948386/57146929-dd802780-6d9c-11e9-9f13-f880299124b4.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
