### PR TITLE
Correct discount badge container width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.37.2] - 2019-05-21
 ### Fixed
 - Removed `w-100` from `DiscountBadge` to avoid it to pass the image width. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed `w-100` from `DiscountBadge` to avoid it to pass the image width. 
 
 ## [3.37.1] - 2019-05-20
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.37.1",
+  "version": "3.37.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.37.1",
+  "version": "3.37.2",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/__tests__/components/__snapshots__/DiscountBadge.test.js.snap
+++ b/react/__tests__/components/__snapshots__/DiscountBadge.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<DiscountBadge /> component should match snapshot with label 1`] = `
 <DocumentFragment>
   <div
-    class="discountContainer relative dib w-100"
+    class="discountContainer relative dib"
   >
     <div
       class="t-mini white absolute right-0 pv2 ph3 bg-emphasis"
@@ -21,7 +21,7 @@ exports[`<DiscountBadge /> component should match snapshot with label 1`] = `
 exports[`<DiscountBadge /> component should match snapshot without label 1`] = `
 <DocumentFragment>
   <div
-    class="discountContainer relative dib w-100"
+    class="discountContainer relative dib"
   >
     <div
       class="t-mini white absolute right-0 pv2 ph3 bg-emphasis"

--- a/react/components/DiscountBadge/index.js
+++ b/react/components/DiscountBadge/index.js
@@ -17,7 +17,7 @@ class DiscountBadge extends Component {
     const { listPrice, sellingPrice, label } = this.props
     const percent = this.calculateDiscountTax(listPrice, sellingPrice)
     return (
-      <div className={`${styles.discountContainer} relative dib w-100`}>
+      <div className={`${styles.discountContainer} relative dib`}>
         {percent ? (
           <div className="t-mini white absolute right-0 pv2 ph3 bg-emphasis">
             {label === '' && '-'}


### PR DESCRIPTION
#### What is the purpose of this pull request?
The `w-100` caused badge to pass the parent width in some scenarios.

#### How should this be manually tested?
https://discbadge--storecomponents.myvtex.com/

**OBS: Its important to [SliderNext](https://github.com/vtex-apps/slider/pull/24)**

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
