### PR TITLE
Add the carouselImagePlaceholder CSS handle to allow custom image pla…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the `carouselImagePlaceholder` CSS handler to allow custom image placeholders.
 
 ## [3.32.2] - 2019-05-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.33.0] - 2019-05-08
 ### Added
 - Add the `carouselImagePlaceholder` CSS handler to allow custom image placeholders.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.32.2",
+  "version": "3.33.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.2",
+  "version": "3.33.0",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/__tests__/components/__snapshots__/ProductImages.test.js.snap
+++ b/react/__tests__/components/__snapshots__/ProductImages.test.js.snap
@@ -26,44 +26,51 @@ exports[`<ProductImages /> should match the snapshot with no images 1`] = `
   <div
     class="content w-100"
   >
-    <svg
-      fill="none"
-      height="100%"
-      viewBox="0 0 512 512"
-      width="100%"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="relative"
     >
-      <rect
-        fill="#F2F2F2"
-        height="512"
-        width="512"
+      <div
+        class="carouselImagePlaceholder absolute w-100 h-100 contain bg-center"
       />
-      <rect
-        height="150.474"
-        stroke="#CACBCC"
-        stroke-width="2"
-        width="144.286"
-        x="183.857"
-        y="180.2"
-      />
-      <path
-        d="M183.78 303.688H328.214"
-        stroke="#CACBCC"
-        stroke-width="2"
-      />
-      <path
-        d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
-        stroke="#CACBCC"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-      />
-      <path
-        d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
-        stroke="#CACBCC"
-        stroke-width="2"
-      />
-    </svg>
+      <svg
+        fill="none"
+        height="100%"
+        viewBox="0 0 512 512"
+        width="100%"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          fill="#F2F2F2"
+          height="512"
+          width="512"
+        />
+        <rect
+          height="150.474"
+          stroke="#CACBCC"
+          stroke-width="2"
+          width="144.286"
+          x="183.857"
+          y="180.2"
+        />
+        <path
+          d="M183.78 303.688H328.214"
+          stroke="#CACBCC"
+          stroke-width="2"
+        />
+        <path
+          d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
+          stroke="#CACBCC"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
+        <path
+          d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
+          stroke="#CACBCC"
+          stroke-width="2"
+        />
+      </svg>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -73,44 +80,51 @@ exports[`<ProductImages /> should match the snapshot with thumbnails in right po
   <div
     class="content w-100"
   >
-    <svg
-      fill="none"
-      height="100%"
-      viewBox="0 0 512 512"
-      width="100%"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="relative"
     >
-      <rect
-        fill="#F2F2F2"
-        height="512"
-        width="512"
+      <div
+        class="carouselImagePlaceholder absolute w-100 h-100 contain bg-center"
       />
-      <rect
-        height="150.474"
-        stroke="#CACBCC"
-        stroke-width="2"
-        width="144.286"
-        x="183.857"
-        y="180.2"
-      />
-      <path
-        d="M183.78 303.688H328.214"
-        stroke="#CACBCC"
-        stroke-width="2"
-      />
-      <path
-        d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
-        stroke="#CACBCC"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-      />
-      <path
-        d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
-        stroke="#CACBCC"
-        stroke-width="2"
-      />
-    </svg>
+      <svg
+        fill="none"
+        height="100%"
+        viewBox="0 0 512 512"
+        width="100%"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          fill="#F2F2F2"
+          height="512"
+          width="512"
+        />
+        <rect
+          height="150.474"
+          stroke="#CACBCC"
+          stroke-width="2"
+          width="144.286"
+          x="183.857"
+          y="180.2"
+        />
+        <path
+          d="M183.78 303.688H328.214"
+          stroke="#CACBCC"
+          stroke-width="2"
+        />
+        <path
+          d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
+          stroke="#CACBCC"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
+        <path
+          d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
+          stroke="#CACBCC"
+          stroke-width="2"
+        />
+      </svg>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/react/components/ProductImages/README.md
+++ b/react/components/ProductImages/README.md
@@ -64,5 +64,6 @@ Below, we describe the namespace that are defined in the `ProductImages`.
 | `carouselGaleryThumbs`    | The container of Thumbs area                                                            | [Carousel](/react/components/ProductImages/components/Carousel/index.js)           |
 | `carouselThumbBorder`     | Define the border of Thumb area                                                         | [Carousel](/react/components/ProductImages/components/Carousel/index.js)           |
 | `carouselGaleryCursor`    | Define the svg icon that will show when hover the `Carousel`                            | [Carousel](/react/components/ProductImages/components/Carousel/index.js)           |
+| `carouselImageUploader`   | Define the icon that will show when the user wants a custom placeholder                 | [ImagePlaceholder](/react/components/ProductImages/components/Carousel/ImagePlaceholder.js)       |
 | `imageBlur30`             | Blur of the Image                                                                       | [BlurredLoader](/react/components/ProductImages/components/BlurredLoader/index.js) |
 | `imageTransitionOpacity`  | Time transition between images                                                          | [BlurredLoader](/react/components/ProductImages/components/BlurredLoader/index.js) |

--- a/react/components/ProductImages/components/Carousel/ImagePlaceholder.js
+++ b/react/components/ProductImages/components/Carousel/ImagePlaceholder.js
@@ -1,36 +1,44 @@
 import React from 'react'
+import style from '../../styles.css'
 
 export default function ImagePlaceholder() {
   return (
-    <svg
-      width="100%"
-      height="100%"
-      viewBox="0 0 512 512"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <rect width="512" height="512" fill="#F2F2F2" />
-      <rect
-        x="183.857"
-        y="180.2"
-        width="144.286"
-        height="150.474"
-        stroke="#CACBCC"
-        strokeWidth="2"
+    <div className="relative">
+      <div
+        className={`${
+          style.carouselImagePlaceholder
+        } absolute w-100 h-100 contain bg-center`}
       />
-      <path d="M183.78 303.688H328.214" stroke="#CACBCC" strokeWidth="2" />
-      <path
-        d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
-        stroke="#CACBCC"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
-        stroke="#CACBCC"
-        strokeWidth="2"
-      />
-    </svg>
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 512 512"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect width="512" height="512" fill="#F2F2F2" />
+        <rect
+          x="183.857"
+          y="180.2"
+          width="144.286"
+          height="150.474"
+          stroke="#CACBCC"
+          strokeWidth="2"
+        />
+        <path d="M183.78 303.688H328.214" stroke="#CACBCC" strokeWidth="2" />
+        <path
+          d="M205.082 279.563L223.599 240.507L242.116 260.035L269.892 220.979L306.926 279.563H205.082Z"
+          stroke="#CACBCC"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M252.225 213.939C252.225 219.822 247.66 224.52 242.114 224.52C236.569 224.52 232.004 219.822 232.004 213.939C232.004 208.057 236.569 203.359 242.114 203.359C247.66 203.359 252.225 208.057 252.225 213.939Z"
+          stroke="#CACBCC"
+          strokeWidth="2"
+        />
+      </svg>
+    </div>
   )
 }

--- a/react/components/ProductImages/styles.css
+++ b/react/components/ProductImages/styles.css
@@ -39,3 +39,5 @@
 .carouselCursorDefault:hover{
   cursor: default;
 }
+
+.carouselImagePlaceholder { }


### PR DESCRIPTION
…ceholder

#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

Now setting the `background-image` in the `carouselImagePlaceholder` class in the ProductImages, the users can change the image placeholder

#### How should this be manually tested?

[Access the workspace](https://placeholder--invictastores.myvtex.com/invicta-watch-case-dc3grey-grn/p)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/57373950-12f78d00-7170-11e9-8c81-016c77f39d00.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
