### PR TITLE
Store-components - Update newsletter send infos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.37.3] - 2019-05-22
+### Added
+- Add optional first name field the newsletter
+
 ## [3.37.2] - 2019-05-21
 ### Fixed
 - Removed `w-100` from `DiscountBadge` to avoid it to pass the image width. 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.37.2",
+  "version": "3.37.3",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/messages/context.json
+++ b/messages/context.json
@@ -56,6 +56,8 @@
   "admin/editor.newsletter.placeholder": "Placeholder of the email input",
   "admin/editor.newsletter.submit": "Label of the submit button",
   "admin/editor.newsletter.hideLabel": "Hide label",
+  "admin/editor.newsletter.renderFirstName": "Show First Name?",
+  "admin/editor.newsletter.namePlaceholder": "Placeholder of the name input",
   "admin/editor.categoriesHighlighted.title": "admin/editor.categoriesHighlighted.title",
   "admin/editor.categoriesHighlighted.description": "admin/editor.categoriesHighlighted.description",
   "admin/editor.categoriesHighlighted.item.categoryName": "admin/editor.categoriesHighlighted.item.categoryName",

--- a/messages/context.json
+++ b/messages/context.json
@@ -44,6 +44,7 @@
   "store/availability-subscriber.error-message": "availability-subscriber.error-message",
   "store/newsletter.label": "Sign up for exclusive deals",
   "store/newsletter.placeholder": "Email address",
+  "store/newsletter.placeholderName": "Name",
   "store/newsletter.submit": "Sign up",
   "store/newsletter.invalidEmail": "Please enter a valid email.",
   "store/newsletter.confirmationTitle": "Thank you!",

--- a/messages/en.json
+++ b/messages/en.json
@@ -56,6 +56,8 @@
   "admin/editor.newsletter.placeholder": "Placeholder of the email input",
   "admin/editor.newsletter.submit": "Label of the submit button",
   "admin/editor.newsletter.hideLabel": "Hide label",
+  "admin/editor.newsletter.renderFirstName": "Show First Name?",
+  "admin/editor.newsletter.namePlaceholder": "Placeholder of the name input",
   "admin/editor.categoriesHighlighted.title": "Categories Highlighted",
   "admin/editor.categoriesHighlighted.description": "Categories Highlighted of the Department",
   "admin/editor.categoriesHighlighted.item.categoryName": "Category Name",

--- a/messages/en.json
+++ b/messages/en.json
@@ -44,6 +44,7 @@
   "store/availability-subscriber.error-message": "Failed, please try again",
   "store/newsletter.label": "Subscribe to our newsletter",
   "store/newsletter.placeholder": "Enter your email address",
+  "store/newsletter.placeholderName": "Enter your name",
   "store/newsletter.submit": "Sign up",
   "store/newsletter.invalidEmail": "Please, enter a valid email.",
   "store/newsletter.confirmationTitle": "Thank you!",

--- a/messages/es.json
+++ b/messages/es.json
@@ -56,6 +56,8 @@
   "admin/editor.newsletter.placeholder": "Placeholder de la entrada de correo electrónico",
   "admin/editor.newsletter.submit": "Texto del botón",
   "admin/editor.newsletter.hideLabel": "Ocultar título",
+  "admin/editor.newsletter.renderFirstName": "Mostrar Nombre?",
+  "admin/editor.newsletter.namePlaceholder": "Placeholder de la entrada de el nombre",
   "admin/editor.categoriesHighlighted.title": "Categorías destacadas",
   "admin/editor.categoriesHighlighted.description": "Categorias destacadas de este departamento",
   "admin/editor.categoriesHighlighted.item.categoryName": "Nombre de la categoría",

--- a/messages/es.json
+++ b/messages/es.json
@@ -44,6 +44,7 @@
   "store/availability-subscriber.error-message": "No se pudo registrar, inténtelo de nuevo",
   "store/newsletter.label": "Suscríbete a nuestro boletín",
   "store/newsletter.placeholder": "Inserte su email",
+  "store/newsletter.placeholderName": "Inserte su nombre",
   "store/newsletter.submit": "Enviar",
   "store/newsletter.invalidEmail": "Por favor, ingrese un correo electrónico válido.",
   "store/newsletter.confirmationTitle": "Gracias!",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -56,6 +56,8 @@
   "admin/editor.newsletter.placeholder": "Placeholder do input de email",
   "admin/editor.newsletter.submit": "Texto do botão",
   "admin/editor.newsletter.hideLabel": "Esconder título",
+  "admin/editor.newsletter.renderFirstName": "Mostrar Primeiro Nome?",
+  "admin/editor.newsletter.namePlaceholder": "Placeholder do input de nome",
   "admin/editor.categoriesHighlighted.title": "Categorias em Destaque",
   "admin/editor.categoriesHighlighted.description": "Categorias em destaque do Departamento",
   "admin/editor.categoriesHighlighted.item.categoryName": "Nome da Categoria",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -44,6 +44,7 @@
   "store/availability-subscriber.error-message": "Falha ao se cadastrar, tente novamente",
   "store/newsletter.label": "Inscreva-se na nossa newsletter",
   "store/newsletter.placeholder": "Insira seu email",
+  "store/newsletter.placeholderName": "Insira seu nome",
   "store/newsletter.submit": "Enviar",
   "store/newsletter.invalidEmail": "Por favor, insira um email válido.",
   "store/newsletter.confirmationTitle": "Obrigado!",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.37.2",
+  "version": "3.37.3",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/components/Newsletter/README.md
+++ b/react/components/Newsletter/README.md
@@ -41,6 +41,8 @@ Through the Storefront, you can change the `Newsletter`'s behavior and interface
 | `label` | `String` | Label of the form used by the component | `Subscribe to our newsletter` (translated text) |
 | `placeholder` | `String` | Placeholder of the email input | `Enter your email address` (translated text) |
 | `submit` | `String` | Label of the submit button | `Sign up` (translated text) |
+| `renderFirstName` | `Boolean` | Show FirstName | `false` |
+| `namePlaceholder` | `String` | Placeholder of the name input | `Enter your name` (translated text) |
 | `hideLabel` | `Boolean` | Hide label | `false` |
 
 ### Styles API

--- a/react/components/Newsletter/index.js
+++ b/react/components/Newsletter/index.js
@@ -172,6 +172,7 @@ class Newsletter extends Component {
 Newsletter.defaultProps = {
   hideLabel: false,
   showTerms: false,
+  renderFirstName: false
 }
 
 Newsletter.propTypes = {
@@ -180,6 +181,8 @@ Newsletter.propTypes = {
   label: PropTypes.string,
   placeholder: PropTypes.string,
   submit: PropTypes.string,
+  renderFirstName: PropTypes.bool,
+  namePlaceholder: PropTypes.string,
   subscribeNewsletter: PropTypes.func.isRequired,
   intl: intlShape,
 }
@@ -204,6 +207,17 @@ Newsletter.getSchema = () => {
       placeholder: {
         type: 'string',
         title: 'admin/editor.newsletter.placeholder',
+        isLayout: false,
+      },
+      renderFirstName: {
+        type: 'boolean',
+        title: 'admin/editor.newsletter.renderFirstName',
+        default: false,
+        isLayout: false,
+      },
+      namePlaceholder: {
+        type: 'string',
+        title: 'admin/editor.newsletter.namePlaceholder',
         isLayout: false,
       },
       submit: {

--- a/react/components/Newsletter/index.js
+++ b/react/components/Newsletter/index.js
@@ -15,6 +15,7 @@ class Newsletter extends Component {
     error: null,
     success: null,
     invalidEmail: false,
+    firstName: ''
   }
 
   inputRef = React.createRef()
@@ -33,10 +34,9 @@ class Newsletter extends Component {
     }
   }
 
-  handleChangeEmail = e => {
-    this.setState({ email: e.target.value })
-  }
+  handleChange = ({target}) => this.setState({ [target.name]: target.value });
 
+  
   validateEmail = () => {
     return EMAIL_REGEX.test(this.state.email)
   }
@@ -59,7 +59,7 @@ class Newsletter extends Component {
     })
 
     this.props
-      .subscribeNewsletter({ variables: { email: this.state.email } })
+      .subscribeNewsletter({ variables: this.props.renderFirstName ? { firstName: this.state.firstName, email: this.state.email } : { email: this.state.email } })
       .then(() => {
         this.safeSetState({ success: true, loading: false })
       })
@@ -73,9 +73,13 @@ class Newsletter extends Component {
       placeholder = this.props.intl.formatMessage({
         id: 'store/newsletter.placeholder',
       }),
+      namePlaceholder = this.props.intl.formatMessage({
+        id: 'store/newsletter.placeholderName',
+      }),
       submit = this.props.intl.formatMessage({ id: 'store/newsletter.submit' }),
       label = this.props.intl.formatMessage({ id: 'store/newsletter.label' }),
       hideLabel,
+      renderFirstName
     } = this.props
 
     return (
@@ -109,6 +113,19 @@ class Newsletter extends Component {
                 {label}
               </label>
               <div className={`${style.inputGroup} flex-ns pt5`}>
+                {
+                  renderFirstName &&
+                  <div className="mr4-m mt4 mt0-l">
+                    <Input
+                      ref={this.inputRef}
+                      id="newsletter-input--firstName"
+                      placeholder={namePlaceholder}
+                      name="firstName"
+                      value={this.state.firstName}
+                      onChange={this.handleChange}
+                    />
+                  </div>
+                }
                 <Input
                   ref={this.inputRef}
                   id="newsletter-input"
@@ -120,9 +137,9 @@ class Newsletter extends Component {
                       : null
                   }
                   placeholder={placeholder}
-                  name="newsletter"
+                  name="email"
                   value={this.state.email}
-                  onChange={this.handleChangeEmail}
+                  onChange={this.handleChange}
                 />
                 <div
                   className={`${

--- a/react/components/Newsletter/mutations/subscribeNewsletter.graphql
+++ b/react/components/Newsletter/mutations/subscribeNewsletter.graphql
@@ -1,3 +1,3 @@
-mutation subscribeNewsletter($email: String) {
-  subscribeNewsletter(email: $email)
+mutation subscribeNewsletter($email: String, $firstName: String) {
+  subscribeNewsletter(email: $email, firstName: $firstName)
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add to the app the possibility of sending the field firstName in the newsletter.

#### What problem is this solving?
Name the registered customer for future communication.

#### How should this be manually tested?
Sending the props renderFirstName to true and along with the change in mutation of subscribeNewsletter in store-graphql to send the newsletter.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.