### PR TITLE
Add i18n via vtex.native-types in DiscountBadge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.39.0] - 2019-05-27
 ### Added
 - i18n using `vtex.native-types` to allow `DiscountBadge` to respond properly to content i18n.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- i18n using `vtex.native-types` to allow `DiscountBadge` to respond properly to content i18n.
 
 ## [3.38.1] - 2019-05-26
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.38.1",
+  "version": "3.39.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
+    "vtex.native-types": "0.x",
     "vtex.shipping-estimate-translator": "2.x",
     "vtex.store-graphql": "2.x",
     "vtex.store-resources": "0.x",

--- a/react/__mocks__/vtex.native-types/index.js
+++ b/react/__mocks__/vtex.native-types/index.js
@@ -1,0 +1,5 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+
+export const IOMessage = props =>
+  props.id ? <FormattedMessage {...props} /> : null

--- a/react/__tests__/components/__snapshots__/DiscountBadge.test.js.snap
+++ b/react/__tests__/components/__snapshots__/DiscountBadge.test.js.snap
@@ -11,7 +11,10 @@ exports[`<DiscountBadge /> component should match snapshot with label 1`] = `
       <span>
         10%
       </span>
-       LABEL
+        
+      <span>
+        LABEL
+      </span>
     </div>
     Test
   </div>

--- a/react/components/DiscountBadge/index.js
+++ b/react/components/DiscountBadge/index.js
@@ -23,8 +23,7 @@ class DiscountBadge extends Component {
         {percent ? (
           <div className="t-mini white absolute right-0 pv2 ph3 bg-emphasis">
             {label === '' && '-'}
-            <FormattedNumber value={percent} style="percent" />
-            {label && ' '}
+            <FormattedNumber value={percent} style="percent" /> {label && ' '}
             <IOMessage id={label} />
           </div>
         ) : null}

--- a/react/components/DiscountBadge/index.js
+++ b/react/components/DiscountBadge/index.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import { FormattedNumber } from 'react-intl'
 import PropTypes from 'prop-types'
 
+import { IOMessage } from 'vtex.native-types'
+
 import styles from './styles.css'
 
 /**
@@ -21,7 +23,9 @@ class DiscountBadge extends Component {
         {percent ? (
           <div className="t-mini white absolute right-0 pv2 ph3 bg-emphasis">
             {label === '' && '-'}
-            <FormattedNumber value={percent} style="percent" /> {label}
+            <FormattedNumber value={percent} style="percent" />
+            {label && ' '}
+            <IOMessage id={label} />
           </div>
         ) : null}
         {this.props.children}


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

`DiscountBadge` should respond properly when passed an i18n content label.

#### How should this be manually tested?

[Workspace](https://summary--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage

##### EN

![image](https://user-images.githubusercontent.com/15948386/58431904-4a2dcf80-8086-11e9-8ddc-5001de35549d.png)


##### PT

![image](https://user-images.githubusercontent.com/15948386/58431851-1a7ec780-8086-11e9-9e10-87e44a979743.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
