### PR TITLE
Add product price props to contentSchemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.41.2] - 2019-05-28
 ### Added
 - Content schema to `ProductPrice`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Content schema to `ProductPrice`.
 
 ## [3.41.1] - 2019-05-28
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.41.1",
+  "version": "3.41.2",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.41.1",
+  "version": "3.41.2",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/__tests__/components/ProductPrice.test.js
+++ b/react/__tests__/components/ProductPrice.test.js
@@ -44,6 +44,8 @@ describe('<ProductPrice />', () => {
       listPrice: 50,
       showLabels: true,
       showListPrice: true,
+      labelSellingPrice: 'To',
+      labelListPrice: 'From'
     }
     const { getByText } = renderComponent(customProps)
     expect(getByText('From')).toBeDefined()
@@ -57,6 +59,8 @@ describe('<ProductPrice />', () => {
       listPrice: 50,
       showLabels: false,
       showListPrice: true,
+      labelSellingPrice: 'To',
+      labelListPrice: 'From'
     }
     const { getByText, queryByText } = renderComponent(customProps)
     expect(queryByText('From')).toBeNull()

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -150,7 +150,7 @@ class ProductPrice extends Component {
                   'dib ph2 t-small-ns t-mini'
                 )}
               >
-                {!isNil(labelListPrice) ? (labelListPrice ) : <IOMessage id="store/pricing.from" />}
+                <IOMessage id={labelListPrice} />
               </div>
             )}
             <Price
@@ -182,7 +182,7 @@ class ProductPrice extends Component {
                 sellingPriceLabelClass
               )}
             >
-              {!isNil(labelSellingPrice) ? (labelSellingPrice ) : <IOMessage id="store/pricing.to" />}
+              <IOMessage id={labelSellingPrice} />
             </div>
           )}
           <Price

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { isNil, head, last, sort, equals } from 'ramda'
 import ContentLoader from 'react-content-loader'
 import { FormattedMessage, injectIntl } from 'react-intl'
+import { IOMessage } from 'vtex.native-types'
 
 import PricePropTypes from './propTypes'
 import Installments from './Installments'
@@ -149,7 +150,7 @@ class ProductPrice extends Component {
                   'dib ph2 t-small-ns t-mini'
                 )}
               >
-                {!isNil(labelListPrice) ? (labelListPrice ) : <FormattedMessage id="store/pricing.from" />}
+                {!isNil(labelListPrice) ? (labelListPrice ) : <IOMessage id="store/pricing.from" />}
               </div>
             )}
             <Price
@@ -181,7 +182,7 @@ class ProductPrice extends Component {
                 sellingPriceLabelClass
               )}
             >
-              {!isNil(labelSellingPrice) ? (labelSellingPrice ) : <FormattedMessage id="store/pricing.to" />}
+              {!isNil(labelSellingPrice) ? (labelSellingPrice ) : <IOMessage id="store/pricing.to" />}
             </div>
           )}
           <Price
@@ -293,18 +294,6 @@ priceWithIntl.schema = {
   description: 'admin/editor.productPrice.description',
   type: 'object',
   properties: {
-    labelSellingPrice: {
-      type: 'string',
-      title: 'admin/editor.productPrice.labelSellingPrice',
-      default: ProductPrice.defaultProps.labelSellingPrice,
-      isLayout: false,
-    },
-    labelListPrice: {
-      type: 'string',
-      title: 'admin/editor.productPrice.labelListPrice',
-      default: ProductPrice.defaultProps.labelListPrice,
-      isLayout: false,
-    },
     showSellingPriceRange: {
       type: 'boolean',
       title: 'admin/editor.productPrice.showSellingPriceRange',

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -50,13 +50,11 @@
       "properties": {
         "labelSellingPrice": {
           "title": "admin/editor.productPrice.labelSellingPrice",
-          "$ref": "app:vtex.native-types#/definitions/text",
-          "default": null
+          "$ref": "app:vtex.native-types#/definitions/text"
         },
         "labelListPrice": {
           "title": "admin/editor.productPrice.labelListPrice",
-          "$ref": "app:vtex.native-types#/definitions/text",
-          "default": null
+          "$ref": "app:vtex.native-types#/definitions/text"
         }
       }
     }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -50,11 +50,13 @@
       "properties": {
         "labelSellingPrice": {
           "title": "admin/editor.productPrice.labelSellingPrice",
-          "$ref": "app:vtex.native-types#/definitions/text"
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/pricing.to"
         },
         "labelListPrice": {
           "title": "admin/editor.productPrice.labelListPrice",
-          "$ref": "app:vtex.native-types#/definitions/text"
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/pricing.from"
         }
       }
     }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -45,6 +45,20 @@
           "default": null
         }
       }
+    },
+    "ProductPrice": {
+      "properties": {
+        "labelSellingPrice": {
+          "title": "admin/editor.productPrice.labelSellingPrice",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": null
+        },
+        "labelListPrice": {
+          "title": "admin/editor.productPrice.labelListPrice",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": null
+        }
+      }
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -15,7 +15,10 @@
     "component": "ProductImages"
   },
   "product-price": {
-    "component": "ProductPrice"
+    "component": "ProductPrice",
+    "content": {
+      "$ref": "#/definitions/ProductPrice"
+    }
   },
   "product-description": {
     "component": "ProductDescription"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `labelSellingPrice` and `labelListPrice` to` contentSchemas.json`.

Depends on: https://github.com/vtex-apps/product-summary/pull/162

#### How should this be manually tested?
[Workspace](https://thaye--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
