### PR TITLE
Add i18n content edition support through CMS for NewLetter component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.43.1] - 2019-06-07
 ### Fixed
 - Fix bad release of 3.43.0 (no real change in code).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bad release of 3.43.0 (no real change in code).
+
+## [3.43.0] - 2019-06-06
+
 ### Added
 
 - i18n using `vtex.native-types` to allow `NewsLetter` to respond properly to content i18n.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- i18n using `vtex.native-types` to allow `NewsLetter` to respond properly to content i18n.
 
 ## [3.42.8] - 2019-06-06
 
@@ -18,17 +21,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bug where the product images thumbnail gallery would scroll infinitely.
 
 ## [3.42.5] - 2019-06-05
+
 ### Fixed
+
 - Hides SKU selector when there are no variations to be selected.
 - `BuyButton`: use given props over context, if set.
 
 ## [3.42.4] - 2019-06-05
+
 ### Fixed
 
 - Use props as default value instead of context.
 
 ## [3.42.3] - 2019-06-05
+
 ### Fixed
+
 - Remove `showProductPrice` rule from `ProductPrice` wrapper.
 
 ## [3.42.2] - 2019-06-05

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.43.0",
+  "version": "3.43.1",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.42.8",
+  "version": "3.43.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.42.8",
+  "version": "3.43.1",
   "scripts": {
     "lint:locales": "intl-equalizer"
   },

--- a/react/__tests__/components/Newsletter.test.js
+++ b/react/__tests__/components/Newsletter.test.js
@@ -3,21 +3,39 @@ import { render, fireEvent, waitForElement } from '@vtex/test-tools/react'
 import Newsletter from '../../components/Newsletter'
 import subscribeNewsletter from '../../components/Newsletter/mutations/subscribeNewsletter.graphql'
 
-test('should have label, input and submit', () => {
-  const { getByLabelText, getByText } = render(<Newsletter />)
+const placeholderTextId = 'store/newsletter.placeholder'
+const labelTextId = 'store/newsletter.label'
+const submitTextId = 'store/newsletter.submit'
+const thanksTextId = 'store/newsletter.confirmationTitle'
+const errorTextId = 'store/newsletter.error'
 
-  const input = getByLabelText(/subscribe to our newsletter/i)
-  const submit = getByText(/sign up/i)
+test('should have label, input and submit', () => {
+  const { getByLabelText, getByText } = render(
+    <Newsletter
+      placeholder={placeholderTextId}
+      label={labelTextId}
+      submit={submitTextId}
+    />
+  )
+
+  const input = getByLabelText(labelTextId)
+  const submit = getByText(submitTextId)
 
   expect(input).toBeTruthy()
   expect(submit).toBeTruthy()
 })
 
 test('should add error message when user types wrong email', () => {
-  const { getByLabelText, getByText } = render(<Newsletter />)
+  const { getByLabelText, getByText } = render(
+    <Newsletter
+      placeholder={placeholderTextId}
+      label={labelTextId}
+      submit={submitTextId}
+    />
+  )
 
-  const mockedInput = getByLabelText(/subscribe to our newsletter/i)
-  const submit = getByText(/sign up/i)
+  const mockedInput = getByLabelText(labelTextId)
+  const submit = getByText(submitTextId)
 
   const wrongEmail = 'foobar'
   fireEvent.change(mockedInput, { target: { value: wrongEmail } })
@@ -42,17 +60,24 @@ test('should call mutation', async () => {
     },
   ]
 
-  const { getByLabelText, getByText } = render(<Newsletter />, {
-    graphql: { mocks, addTypename: false },
-  })
+  const { getByLabelText, getByText } = render(
+    <Newsletter
+      placeholder={placeholderTextId}
+      label={labelTextId}
+      submit={submitTextId}
+    />,
+    {
+      graphql: { mocks, addTypename: false },
+    }
+  )
 
-  const input = getByLabelText(/subscribe to our newsletter/i)
-  const submit = getByText(/sign up/i)
+  const input = getByLabelText(labelTextId)
+  const submit = getByText(submitTextId)
 
   fireEvent.change(input, { target: { value: email } })
   fireEvent.click(submit)
 
-  const thanks = await waitForElement(() => getByText(/thank you/i))
+  const thanks = await waitForElement(() => getByText(thanksTextId))
 
   expect(thanks).toBeTruthy()
 })
@@ -69,17 +94,24 @@ test('should handle mutation error', async () => {
     },
   ]
 
-  const { getByLabelText, getByText } = render(<Newsletter />, {
-    graphql: { mocks, addTypename: false },
-  })
+  const { getByLabelText, getByText } = render(
+    <Newsletter
+      placeholder={placeholderTextId}
+      label={labelTextId}
+      submit={submitTextId}
+    />,
+    {
+      graphql: { mocks, addTypename: false },
+    }
+  )
 
-  const input = getByLabelText(/subscribe to our newsletter/i)
-  const submit = getByText(/sign up/i)
+  const input = getByLabelText(labelTextId)
+  const submit = getByText(submitTextId)
 
   fireEvent.change(input, { target: { value: email } })
   fireEvent.click(submit)
 
-  const error = await waitForElement(() => getByText(/something went wrong/i))
+  const error = await waitForElement(() => getByText(errorTextId))
 
   expect(error).toBeTruthy()
 })

--- a/react/components/Newsletter/index.js
+++ b/react/components/Newsletter/index.js
@@ -5,6 +5,7 @@ import { injectIntl, intlShape } from 'react-intl'
 import { Input, Button } from 'vtex.styleguide'
 import SUBSCRIBE_NEWSLETTER from './mutations/subscribeNewsletter.graphql'
 import style from './style.css'
+import { formatIOMessage } from 'vtex.native-types'
 
 const EMAIL_REGEX = /^[A-z0-9+_-]+(?:\.[A-z0-9+_-]+)*@(?:[A-z0-9](?:[A-z0-9-]*[A-z0-9])?\.)+[A-z0-9](?:[A-z0-9-]*[A-z0-9])?$/
 
@@ -69,14 +70,10 @@ class Newsletter extends Component {
   }
 
   render() {
-    const {
-      placeholder = this.props.intl.formatMessage({
-        id: 'store/newsletter.placeholder',
-      }),
-      submit = this.props.intl.formatMessage({ id: 'store/newsletter.submit' }),
-      label = this.props.intl.formatMessage({ id: 'store/newsletter.label' }),
-      hideLabel,
-    } = this.props
+    const { hideLabel, intl, submit, label, placeholder } = this.props
+    const submitText = formatIOMessage({ id: submit, intl })
+    const labelText = formatIOMessage({ id: label, intl })
+    const placeholderText = formatIOMessage({ id: placeholder, intl })
 
     return (
       <div
@@ -88,13 +85,15 @@ class Newsletter extends Component {
           {this.state.success ? (
             <Fragment>
               <div className={`${style.confirmationTitle} t-heading-3 pb4 tc`}>
-                {this.props.intl.formatMessage({
+                {formatIOMessage({
                   id: 'store/newsletter.confirmationTitle',
+                  intl,
                 })}
               </div>
               <div className={`${style.confirmationText} t-body tc`}>
-                {this.props.intl.formatMessage({
+                {formatIOMessage({
                   id: 'store/newsletter.confirmationText',
+                  intl,
                 })}
               </div>
             </Fragment>
@@ -106,7 +105,7 @@ class Newsletter extends Component {
                 }`}
                 htmlFor="newsletter-input"
               >
-                {label}
+                {labelText}
               </label>
               <div className={`${style.inputGroup} flex-ns pt5`}>
                 <Input
@@ -114,12 +113,13 @@ class Newsletter extends Component {
                   id="newsletter-input"
                   errorMessage={
                     this.state.invalidEmail
-                      ? this.props.intl.formatMessage({
+                      ? formatIOMessage({
                           id: 'store/newsletter.invalidEmail',
+                          intl,
                         })
                       : null
                   }
-                  placeholder={placeholder}
+                  placeholder={placeholderText}
                   name="newsletter"
                   value={this.state.email}
                   onChange={this.handleChangeEmail}
@@ -135,13 +135,16 @@ class Newsletter extends Component {
                     onClick={this.handleSubmit}
                     isLoading={this.state.loading}
                   >
-                    {submit}
+                    {submitText}
                   </Button>
                 </div>
               </div>
               {this.state.error && (
                 <div className={`${style.error} c-danger t-body pt5`}>
-                  {this.props.intl.formatMessage({ id: 'store/newsletter.error' })}
+                  {formatIOMessage({
+                    id: 'store/newsletter.error',
+                    intl,
+                  })}
                 </div>
               )}
             </form>
@@ -178,21 +181,6 @@ Newsletter.getSchema = () => {
         title: 'admin/editor.newsletter.hideLabel',
         default: false,
         isLayout: true,
-      },
-      label: {
-        type: 'string',
-        title: 'admin/editor.newsletter.label',
-        isLayout: false,
-      },
-      placeholder: {
-        type: 'string',
-        title: 'admin/editor.newsletter.placeholder',
-        isLayout: false,
-      },
-      submit: {
-        type: 'string',
-        title: 'admin/editor.newsletter.submit',
-        isLayout: false,
       },
     },
   }

--- a/react/components/Newsletter/index.js
+++ b/react/components/Newsletter/index.js
@@ -74,6 +74,22 @@ class Newsletter extends Component {
     const submitText = formatIOMessage({ id: submit, intl })
     const labelText = formatIOMessage({ id: label, intl })
     const placeholderText = formatIOMessage({ id: placeholder, intl })
+    const confirmationTitle = formatIOMessage({
+      id: 'store/newsletter.confirmationTitle',
+      intl,
+    })
+    const confirmationText = formatIOMessage({
+      id: 'store/newsletter.confirmationText',
+      intl,
+    })
+    const invalidEmailText = formatIOMessage({
+      id: 'store/newsletter.invalidEmail',
+      intl,
+    })
+    const errorMsg = formatIOMessage({
+      id: 'store/newsletter.error',
+      intl,
+    })
 
     return (
       <div
@@ -85,16 +101,10 @@ class Newsletter extends Component {
           {this.state.success ? (
             <Fragment>
               <div className={`${style.confirmationTitle} t-heading-3 pb4 tc`}>
-                {formatIOMessage({
-                  id: 'store/newsletter.confirmationTitle',
-                  intl,
-                })}
+                {confirmationTitle}
               </div>
               <div className={`${style.confirmationText} t-body tc`}>
-                {formatIOMessage({
-                  id: 'store/newsletter.confirmationText',
-                  intl,
-                })}
+                {confirmationText}
               </div>
             </Fragment>
           ) : (
@@ -112,12 +122,7 @@ class Newsletter extends Component {
                   ref={this.inputRef}
                   id="newsletter-input"
                   errorMessage={
-                    this.state.invalidEmail
-                      ? formatIOMessage({
-                          id: 'store/newsletter.invalidEmail',
-                          intl,
-                        })
-                      : null
+                    this.state.invalidEmail ? invalidEmailText : null
                   }
                   placeholder={placeholderText}
                   name="newsletter"
@@ -141,10 +146,7 @@ class Newsletter extends Component {
               </div>
               {this.state.error && (
                 <div className={`${style.error} c-danger t-body pt5`}>
-                  {formatIOMessage({
-                    id: 'store/newsletter.error',
-                    intl,
-                  })}
+                  {errorMsg}
                 </div>
               )}
             </form>

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -59,6 +59,25 @@
           "default": "store/pricing.from"
         }
       }
+    },
+    "Newsletter": {
+      "properties": {
+        "placeholder": {
+          "title": "admin/editor.newsletter.placeholder",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/newsletter.placeholder"
+        },
+        "label": {
+          "title": "admin/editor.newsletter.label",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/newsletter.label"
+        },
+        "submit": {
+          "title": "admin/editor.newsletter.submit",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/newsletter.submit"
+        }
+      }
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -58,7 +58,10 @@
     "component": "ProductServices"
   },
   "newsletter": {
-    "component": "Newsletter"
+    "component": "Newsletter",
+    "content": {
+      "$ref": "app:vtex.store-components#/definitions/Newsletter"
+    }
   },
   "notification": {},
   "notification.inline": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Moved schema of content properties from components to contentSchemas.json
Using the new vtex.native-types to support i18n content insertion through Storefront

#### How should this be manually tested?
[Workspace](https://spaceodyssey--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### EN
![Captura de tela de 2019-05-28 15-19-58](https://user-images.githubusercontent.com/13472668/58502435-df9b9300-815c-11e9-8b82-4a28fc780e91.png)

#### PT
![Captura de tela de 2019-05-28 15-23-28](https://user-images.githubusercontent.com/13472668/58502461-ef1adc00-815c-11e9-8a27-66417cce07f0.png)

#### ES
![Captura de tela de 2019-05-28 15-24-29](https://user-images.githubusercontent.com/13472668/58502520-0b1e7d80-815d-11e9-8752-0dd9bc2b34b0.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
