### PR TITLE
Hide sku selector if there are no variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Hides SKU selector when there are no variations to be selected.
 
 ## [3.42.4] - 2019-06-05
 ### Fixed

--- a/react/components/SKUSelector/Wrapper.js
+++ b/react/components/SKUSelector/Wrapper.js
@@ -17,7 +17,12 @@ const SKUSelectorWrapper = props => {
       ? props.skuSelected
       : valuesFromContext.selectedItem
 
-  if (skuItems.length === 0) {
+  if (
+    skuItems.length <= 1 ||
+    !skuSelected ||
+    !skuSelected.variations ||
+    skuSelected.variations.length === 0
+  ) {
     return null
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Hides SKU selector when there are no choices.

Before: https://storecomponents.myvtex.com/long-sleeve-shirt/p

After: 
https://lbebber--storecomponents.myvtex.com/long-sleeve-shirt/p
https://lbebber--storecomponents.myvtex.com/classic-shoes/p (with variations)

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
