### PR TITLE
Fix/product images thumbs infinite scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bug where the product images thumbnail gallery would scroll infinitely.
 
 ## [3.42.5] - 2019-06-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.42.6] - 2019-06-05
 ### Fixed
 - Bug where the product images thumbnail gallery would scroll infinitely.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.42.5",
+  "version": "3.42.6",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from 'react'
 import { ProductContext } from 'vtex.product-context'
-import { path, isEmpty, values, map } from 'ramda'
+import { path, values, map } from 'ramda'
 
 import ProductImages from './index'
 import generateImageConfig from './utils/generateImageConfig'

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import debounce from 'debounce'
 import classNames from 'classnames'
 import { path, equals } from 'ramda'
+import ReactResizeDetector from 'react-resize-detector'
 
 import { IconCaret } from 'vtex.store-icons'
 import { NoSSR } from 'vtex.render-runtime'
@@ -328,13 +329,15 @@ class Carousel extends Component {
           </Swiper>
         </div>
         <div className={imageClasses}>
-          <Swiper {...this.galleryParams} rebuildOnUpdate>
-            {slides.map((slide, i) => (
-              <div key={i} className="swiper-slide center-all">
-                {this.renderSlide(slide, i)}
-              </div>
-            ))}
-          </Swiper>
+          <ReactResizeDetector handleHeight onResize={this.updateSwiperSize}>
+            <Swiper {...this.galleryParams} rebuildOnUpdate>
+              {slides.map((slide, i) => (
+                <div key={i} className="swiper-slide center-all">
+                  {this.renderSlide(slide, i)}
+                </div>
+              ))}
+            </Swiper>
+          </ReactResizeDetector>
           {zoomType === 'gallery' && (
             <NoSSR>
               <Gallery


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes bug where the product images thumbnail gallery would scroll infinitely.

Before: https://samsungar.myvtex.com/galaxy-s10e/p (try scrolling the thumbnail gallery besides the product image. If it works properly, try clearing the cache and refreshing)

After: https://lbebber--samsungar.myvtex.com/galaxy-s10e/p

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
