### PR TITLE
Fix/mobile search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue on the SearchBar suggestions where the user couldn't select items, on mobile devices.
 
 ## [3.43.4] - 2019-06-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.43.5] - 2019-06-10
 ### Fixed
 - Issue on the SearchBar suggestions where the user couldn't select items, on mobile devices.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.43.4",
+  "version": "3.43.5",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/SearchBar/components/ResultsList.js
+++ b/react/components/SearchBar/components/ResultsList.js
@@ -17,6 +17,7 @@ const ResultsList = ({
   closeMenu,
   onClearInput,
   getItemProps,
+  getMenuProps,
 }) => {
   const items = data.autocomplete ? data.autocomplete.itemsReturned : []
   const {
@@ -25,7 +26,7 @@ const ResultsList = ({
 
   const listClassNames = classnames(
     styles.resultsList,
-    'z-max w-100 pb4 bl-ns bb br-ns bw1 b--muted-4 bg-white f5 left-0',
+    'z-max w-100 pb4 bl-ns bb br-ns bw1 b--muted-4 bg-white f5 left-0 list',
     mobile ? 'fixed' : 'absolute'
   )
 
@@ -84,45 +85,49 @@ const ResultsList = ({
   }
 
   return (
-    <div className={listClassNames}>
-      <Link
-        {...getItemProps({
-          item: 'ft',
-          onClick: handleItemClick,
-        })}
-        page="store.search"
-        params={{ term: inputValue }}
-        query="map=ft"
-        className={listItemClassNames}
-      >
-        {inputValue}
-      </Link>
+    <ul className={listClassNames} {...getMenuProps()}>
+      <li>
+        <Link
+          {...getItemProps({
+            item: 'ft',
+            onClick: handleItemClick,
+          })}
+          page="store.search"
+          params={{ term: inputValue }}
+          query="map=ft"
+          className={listItemClassNames}
+        >
+          {inputValue}
+        </Link>
+      </li>
 
       {items.map((item, index) => {
         return (
           <Fragment key={item.name + index}>
             <hr className="o-05 ma0 w-90 center" />
-            <Link
-              {...getItemProps({
-                item,
-                onClick: handleItemClick,
-              })}
-              {...getLinkProps(item)}
-              className={listItemClassNames}
-            >
-              {item.thumb && (
-                <img
-                  alt=""
-                  className={`${styles.resultsItemImage} mr4`}
-                  src={getImageUrl(item.thumb)}
-                />
-              )}
-              <div className="flex justify-start items-center">{item.name}</div>
-            </Link>
+            <li>
+              <Link
+                {...getItemProps({
+                  item,
+                  onClick: handleItemClick,
+                })}
+                {...getLinkProps(item)}
+                className={listItemClassNames}
+              >
+                {item.thumb && (
+                  <img
+                    alt=""
+                    className={`${styles.resultsItemImage} mr4`}
+                    src={getImageUrl(item.thumb)}
+                  />
+                )}
+                <div className="flex justify-start items-center">{item.name}</div>
+              </Link>
+            </li>
           </Fragment>
         )
       })}
-    </div>
+    </ul>
   )
 }
 

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import AutocompleteInput from './AutocompleteInput'
 import ResultsLists from './ResultsList'
-import DownshiftComponent from 'downshift'
+import Downshift from 'downshift'
 import { NoSSR } from 'vtex.render-runtime'
 import { Overlay } from 'vtex.react-portal'
 
@@ -52,7 +52,7 @@ export default class SearchBar extends Component {
         }}
       >
         <NoSSR onSSR={fallback}>
-          <DownshiftComponent>
+          <Downshift>
             {({
               getInputProps,
               getItemProps,
@@ -107,7 +107,7 @@ export default class SearchBar extends Component {
                 ) : null}
               </div>
             )}
-          </DownshiftComponent>
+          </Downshift>
         </NoSSR>
       </div>
     )

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -56,6 +56,7 @@ export default class SearchBar extends Component {
             {({
               getInputProps,
               getItemProps,
+              getMenuProps,
               selectedItem,
               highlightedIndex,
               isOpen,
@@ -93,6 +94,7 @@ export default class SearchBar extends Component {
                     >
                       <ResultsLists
                         {...{
+                          getMenuProps,
                           inputValue,
                           getItemProps,
                           selectedItem,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue on the SearchBar suggestions where the user couldn't select items, on mobile devices.

In order to test, go to https://lbebber--alssports.myvtex.com/ on mobile mode, search for something (e.g. `shoes`) and tap on an item. It should go to the correct page. Contrast with https://alssports.myvtex.com/, where doing the same would just close the search results.


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
