### PR TITLE
Fix/discount sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bug with vanishing `-` sign on DiscountLabel when it had empty labels.
 
 ## [3.45.1] - 2019-06-18
 ### Changed

--- a/react/__mocks__/vtex.native-types/index.js
+++ b/react/__mocks__/vtex.native-types/index.js
@@ -10,6 +10,9 @@ export const IOMessage = props => {
   if (props['data-testid']) {
     return <div>{props['data-testid']}</div>
   }
+  if (props.children) {
+    return props.children(null)
+  }
   return null
 }
   

--- a/react/components/DiscountBadge/index.js
+++ b/react/components/DiscountBadge/index.js
@@ -22,9 +22,15 @@ class DiscountBadge extends Component {
       <div className={`${styles.discountContainer} relative dib`}>
         {percent ? (
           <div className="t-mini white absolute right-0 pv2 ph3 bg-emphasis">
-            {label === '' && '-'}
-            <FormattedNumber value={percent} style="percent" /> {label && ' '}
-            <IOMessage id={label} />
+            <IOMessage id={label}>
+              {labelValue => (
+                <>
+                  {!labelValue && '-'}
+                  <FormattedNumber value={percent} style="percent" /> {labelValue && ' '}
+                  {labelValue}
+                </>
+              )}
+            </IOMessage>
           </div>
         ) : null}
         {this.props.children}

--- a/react/components/DiscountBadge/index.js
+++ b/react/components/DiscountBadge/index.js
@@ -27,7 +27,7 @@ class DiscountBadge extends Component {
                 <>
                   {!labelValue && '-'}
                   <FormattedNumber value={percent} style="percent" /> {labelValue && ' '}
-                  {labelValue}
+                  {labelValue && <span>{labelValue}</span>}
                 </>
               )}
             </IOMessage>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes bug with vanishing `-` sign on DiscountLabel when it had empty labels.

https://lbebber--parquedpedro.myvtex.com/ 

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
