### PR TITLE
Improve readme availability-subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Fixed read me of Availability subscriber. Explain that it doesn't warn users.
-- Adapted default text of component to make it less misleading.
+- Read me of Availability subscriber. Explain that it doesn't warn users.
+- Default text of component to make it less misleading.
 
 ## [3.47.5] - 2019-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed read me of Availability subscriber. Explain that it doesn't warn users.
+- Adapted default text of component to make it less misleading.
+
 ## [3.47.5] - 2019-06-27
 
 ### Fixed

--- a/messages/en.json
+++ b/messages/en.json
@@ -39,7 +39,7 @@
   "store/buybutton.see-cart": "View cart",
   "store/technicalspecifications.title": "Technical Specifications",
   "store/availability-subscriber.title": "This product isn't available right now",
-  "store/availability-subscriber.subscribe-label": "I want to know when this product is available again",
+  "store/availability-subscriber.subscribe-label": "I want to know when this product becomes available",
   "store/availability-subscriber.email-placeholder": "Email",
   "store/availability-subscriber.name-placeholder": "Name",
   "store/availability-subscriber.send-label": "Send",

--- a/messages/en.json
+++ b/messages/en.json
@@ -39,7 +39,7 @@
   "store/buybutton.see-cart": "View cart",
   "store/technicalspecifications.title": "Technical Specifications",
   "store/availability-subscriber.title": "This product isn't available right now",
-  "store/availability-subscriber.subscribe-label": "Let me know when this product is available again",
+  "store/availability-subscriber.subscribe-label": "I want to know when this product is available again",
   "store/availability-subscriber.email-placeholder": "Email",
   "store/availability-subscriber.name-placeholder": "Name",
   "store/availability-subscriber.send-label": "Send",

--- a/messages/es.json
+++ b/messages/es.json
@@ -39,7 +39,7 @@
   "store/buybutton.see-cart": "Ver carrito",
   "store/technicalspecifications.title": "Especificaciones Tecnicas",
   "store/availability-subscriber.title": "Este producto no está disponible actualmente",
-  "store/availability-subscriber.subscribe-label": "Me avisa cuando este producto está disponible",
+  "store/availability-subscriber.subscribe-label": "Quiero saber cuando este producto está disponible",
   "store/availability-subscriber.email-placeholder": "E-mail",
   "store/availability-subscriber.name-placeholder": "Nombre",
   "store/availability-subscriber.send-label": "Enviar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -39,7 +39,7 @@
   "store/buybutton.see-cart": "Ver carrinho",
   "store/technicalspecifications.title": "Especificações Técnicas",
   "store/availability-subscriber.title": "Este produto não está disponível no momento",
-  "store/availability-subscriber.subscribe-label": "Avise-me quando estiver disponível",
+  "store/availability-subscriber.subscribe-label": "Quero saber quando estiver disponível",
   "store/availability-subscriber.email-placeholder": "E-mail",
   "store/availability-subscriber.name-placeholder": "Nome",
   "store/availability-subscriber.send-label": "Enviar",

--- a/react/components/AvailabilitySubscriber/README.md
+++ b/react/components/AvailabilitySubscriber/README.md
@@ -4,6 +4,10 @@
 
 `AvailabilitySubscriber` is a VTEX Component that shows the availability subscriber form that is shown when the product isn't available. This Component can be imported and used by any VTEX App.
 
+**Attention:**
+This component only **creates a list** of the users that subscribe to this product. Currently it **doesn't send an automatic email** to these users when the product becomes available. It only collects the emails of the users that show interest on the products.
+
+
 :loudspeaker: **Disclaimer:** Don't fork this project, use, contribute, or open issue with your feature request.
 
 ## Table of Contents
@@ -19,6 +23,20 @@
 You should follow the usage instruction in the main [README](/README.md#usage).
 
 Then, add `availability-subscriber` block into your app theme, as we do in our [Product Details app](https://github.com/vtex-apps/product-details/blob/master/store/blocks.json). 
+
+In order to collect the emails correctly, this feature needs a special configurantion on **Master Data** as it is detailed below:
+
+The form is submitted to Master Data on the Entity: `AS`
+
+| Prop name          | Description                                                                            |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| `skuId`            | The id of the product sku to which will be watched for changes in the product quantity |
+| `name`             | The name of the user                                                                   |
+| `email`            | The email of the user                                                                 |
+| `notificationSend` | If the notification has been sent already                                              |
+| `createdAt`        | When the document was created                                                          |
+| `sendAt`           | When the user was notificated                                                          |
+
 
 ### Blocks API
 
@@ -57,16 +75,3 @@ Below, we describe the namespace that are defined in the `AvailabilitySubscriber
 | `submit` | `AvailabilitySubscriber` form submit button | [index](/react/components/AvailabilitySubscriber/index.js) |
 | `success` | `AvailabilitySubscriber` success feedback message | [index](/react/components/AvailabilitySubscriber/index.js) |
 | `error` | `AvailabilitySubscriber` error feedback message | [index](/react/components/AvailabilitySubscriber/index.js) |
-
-## Data
-
-The form is submitted to Master Data on the Entity: `AS`
-
-| Prop name          | Description                                                                            |
-| ------------------ | -------------------------------------------------------------------------------------- |
-| `skuId`            | The id of the product sku to which will be watched for changes in the product quantity |
-| `name`             | The name of the user                                                                   |
-| `email`            | The email of the user                                                                 |
-| `notificationSend` | If the notification has been sent already                                              |
-| `createdAt`        | When the document was created                                                          |
-| `sendAt`           | When the user was notificated                                                          |


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Improved read-me of availability-subscriber component.
Improved default text of component to make it less misleading.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Users usually believe that this component warn the users when a product become available. However it only makes a list on Master Data of users that subscribe to that product.

#### How should this be manually tested?
---

#### Screenshots or example usage
---

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
