### PR TITLE
Fix/min sized search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Sets min width to search results box.
 
 ## [3.47.1] - 2019-06-24
 ### Changed

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -10,6 +10,8 @@ import { useRuntime } from 'vtex.render-runtime'
 
 import styles from '../styles.css'
 
+const MIN_RESULTS_WIDTH = 400
+
 const SearchBar = ({
   placeholder,
   onMakeSearch,
@@ -29,7 +31,10 @@ const SearchBar = ({
 
   const menuStyle = useMemo(
     () => ({
-      width: container.current && container.current.offsetWidth,
+      width: Math.max(
+        MIN_RESULTS_WIDTH,
+        container.current && container.current.offsetWidth
+      ),
     }),
     [container.current]
   )
@@ -117,7 +122,7 @@ const SearchBar = ({
                   onChange: onInputChange,
                 })}
               />
-              <Overlay>
+              <Overlay alignment="right">
                 <div style={menuStyle}>
                   <ResultsLists
                     {...{

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -10,7 +10,7 @@ import { useRuntime } from 'vtex.render-runtime'
 
 import styles from '../styles.css'
 
-const MIN_RESULTS_WIDTH = 400
+const MIN_RESULTS_WIDTH = 320
 
 const SearchBar = ({
   placeholder,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Sets min width to search result box.
https://lbebber--alssports.myvtex.com/clothing/shorts
<img width="736" alt="Screen Shot 2019-06-24 at 20 27 34" src="https://user-images.githubusercontent.com/5691711/60058632-807b6080-96bf-11e9-9894-846c9cc2d96f.png">


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
