### PR TITLE
`attemptPageTypeSearch` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `attemptPageTypeSearch` on `search-bar`; if `true`, Uses the term the user has inputted to try to navigate to the proper page type (e.g. a department, a brand, a category)
 
 ## [3.47.5] - 2019-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Prop `attemptPageTypeSearch` on `search-bar`; if `true`, Uses the term the user has inputted to try to navigate to the proper page type (e.g. a department, a brand, a category)
+- Prop `attemptPageTypeSearch` on `search-bar`; if `true`, uses the term the user has inputted to try to navigate to the proper page type (e.g. a department, a brand, a category)
 
 ## [3.47.5] - 2019-06-27
 

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -115,6 +115,7 @@ const SearchBar = ({
                     // have any item highlighted in the menu options
                     if (event.key === 'Enter' && highlightedIndex === null) {
                       onGoToSearchPage()
+                      closeMenu()
                     }
                   },
                   placeholder,

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -33,7 +33,7 @@ const SearchBar = ({
     () => ({
       width: Math.max(
         MIN_RESULTS_WIDTH,
-        container.current && container.current.offsetWidth || 0
+        (container.current && container.current.offsetWidth) || 0
       ),
     }),
     [container.current]

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -28,6 +28,11 @@ class SearchBarContainer extends Component {
   handleGoToSearchPage = () => {
     const search = this.state.inputValue
 
+    if (this.props.attemptPageTypeSearch) {
+      window.location.href = `/${search}`
+      return
+    }
+
     this.setState({ inputValue: '' })
     this.context.navigate({
       page: 'store.search',
@@ -107,6 +112,10 @@ SearchBarContainer.propTypes = {
   autoFocus: PropTypes.bool,
   /** Max width of the search bar */
   maxWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Uses the term the user has inputted to try to navigate to the proper
+   * page type (e.g. a department, a brand, a category)
+   */
+  attemptPageTypeSearch: PropTypes.bool,
 }
 
 export default injectIntl(SearchBarContainer)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds prop `attemptPageTypeSearch` on `search-bar`; if `true`, uses the term the user has inputted to try to navigate to the proper page type (e.g. a department, a brand, a category)

To test, go to https://lbebber--storecomponents.myvtex.com and search for "Kawasaki". Type `__RUNTIME__.page` on the resulting page, and it should return `"store.search#brand"`

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
