### PR TITLE
Feat/hide show more btn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ProductDescription` - Add `showShowMoreButton` prop.
 
 ## [3.48.0] - 2019-06-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `ProductDescription` - Add `showShowMoreButton` prop.
+- `ProductDescription` - Add `collapseContent` prop.
 
 ## [3.48.0] - 2019-06-27
 ### Added

--- a/react/__tests__/components/ProductDescription.test.js
+++ b/react/__tests__/components/ProductDescription.test.js
@@ -17,7 +17,14 @@ describe('<ProductDescription />', () => {
   })
 
   it('should match the snapshot with description', () => {
-    const { asFragment } = renderComponent()
+    const { asFragment, getByText } = renderComponent()
     expect(asFragment()).toMatchSnapshot()
+    getByText('Show more')
+  })
+
+  it('should not show show more button', () => {
+    const { debug, queryByText } = renderComponent({ collapseContent: false })
+    debug()
+    expect(queryByText('Show more')).toBeNull()
   })
 })

--- a/react/components/ProductDescription/README.md
+++ b/react/components/ProductDescription/README.md
@@ -8,6 +8,7 @@ This Component can be imported and used by any VTEX App.
 :loudspeaker: **Disclaimer:** Don't fork this project, use, contribute, or open issue with your feature request.
 
 ## Table of Contents
+
 - [Usage](#usage)
   - [Blocks API](#blocks-api)
   - [Configuration](#configuration)
@@ -17,7 +18,7 @@ This Component can be imported and used by any VTEX App.
 
 You should follow the usage instruction in the main [README](https://github.com/vtex-apps/store-components/blob/master/README.md#usage).
 
-Then, add `product-description` block into your app theme, as we do in our [Product Details app](https://github.com/vtex-apps/product-details/blob/master/store/blocks.json). 
+Then, add `product-description` block into your app theme, as we do in our [Product Details app](https://github.com/vtex-apps/product-details/blob/master/store/blocks.json).
 
 ### Blocks API
 
@@ -33,9 +34,9 @@ This component has an interface that describes which rules must be implemented b
 
 Through the Storefront, you can change the `ProductDescription`'s behavior and interface. However, you also can make in your theme app, as Dreamstore does.
 
-| Prop name                | Type       | Description          |
-| ------------------------ | ---------- |--------------------- |
-| `description`            | `String`   | Product description  |
+| Prop name     | Type     | Description         |
+| ------------- | -------- | ------------------- |
+| `description` | `String` | Product description |
 
 Content API
 
@@ -43,16 +44,16 @@ You can customize your `product-description` block inside your product page by p
 
 Here are the props for this component:
 
-| Prop name                | Type       | Description          | Default          |
-| ------------------------ | ---------- |--------------------- |--------------------- |
-| `showShowMoreButton`            | `Boolean`   | If true, whenever the product description is too big, it will collapse and show a "Show More" button. When false, it will never collapse and will always show the whole description.  |  `True`  |
+| Prop name         | Type      | Description                                                                                                                                                                          | Default |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `collapseContent` | `Boolean` | If true, whenever the product description is too big, it will collapse and show a "Show More" button. When false, it will never collapse and will always show the whole description. | `True`  |
 
 ### Styles API
+
 You should follow the Styles API instruction in the main [README](https://github.com/vtex-apps/store-components/blob/master/README.md#styles-api).
 
 Below, we describe the tokens, their explanation and the component where it is located.
 
-| Token name | Component | Description |
-| ---------- | --------- |------------ |
+| Token name                    | Component                                                                                                                    | Description                                |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
 | `productDescriptionContainer` | [ProductDescription](https://github.com/vtex-apps/store-components/blob/master/react/components/ProductDescription/index.js) | The main container of `ProductDescription` |
-

--- a/react/components/ProductDescription/README.md
+++ b/react/components/ProductDescription/README.md
@@ -37,6 +37,16 @@ Through the Storefront, you can change the `ProductDescription`'s behavior and i
 | ------------------------ | ---------- |--------------------- |
 | `description`            | `String`   | Product description  |
 
+Content API
+
+You can customize your `product-description` block inside your product page by passing available props in your `blocks.json` file.
+
+Here are the props for this component:
+
+| Prop name                | Type       | Description          | Default          |
+| ------------------------ | ---------- |--------------------- |--------------------- |
+| `showShowMoreButton`            | `Boolean`   | If true, whenever the product description is too big, it will collapse and show a "Show More" button. When false, it will never collapse and will always show the whole description.  |  `True`  |
+
 ### Styles API
 You should follow the Styles API instruction in the main [README](https://github.com/vtex-apps/store-components/blob/master/README.md#styles-api).
 

--- a/react/components/ProductDescription/Wrapper.js
+++ b/react/components/ProductDescription/Wrapper.js
@@ -6,9 +6,17 @@ import ProductDescription from './index'
 
 const ProductDescriptionWrapper = props => {
   const valuesFromContext = useContext(ProductContext)
-  const description = props.description != null ? props.description : path(['product', 'description'], valuesFromContext)
+  const description =
+    props.description != null
+      ? props.description
+      : path(['product', 'description'], valuesFromContext)
 
-  return <ProductDescription description={description} showShowMoreButton={props.showShowMoreButton} />
+  return (
+    <ProductDescription
+      description={description}
+      showShowMoreButton={props.showShowMoreButton}
+    />
+  )
 }
 
 ProductDescriptionWrapper.defaultProps = {

--- a/react/components/ProductDescription/Wrapper.js
+++ b/react/components/ProductDescription/Wrapper.js
@@ -14,13 +14,13 @@ const ProductDescriptionWrapper = props => {
   return (
     <ProductDescription
       description={description}
-      showMoreVisible={props.showShowMoreButton}
+      collapseContent={props.collapseContent}
     />
   )
 }
 
 ProductDescriptionWrapper.defaultProps = {
-  showShowMoreButton: true,
+  collapseContent: true,
 }
 
 export default ProductDescriptionWrapper

--- a/react/components/ProductDescription/Wrapper.js
+++ b/react/components/ProductDescription/Wrapper.js
@@ -14,7 +14,7 @@ const ProductDescriptionWrapper = props => {
   return (
     <ProductDescription
       description={description}
-      showShowMoreButton={props.showShowMoreButton}
+      showMoreVisible={props.showShowMoreButton}
     />
   )
 }

--- a/react/components/ProductDescription/Wrapper.js
+++ b/react/components/ProductDescription/Wrapper.js
@@ -8,7 +8,11 @@ const ProductDescriptionWrapper = props => {
   const valuesFromContext = useContext(ProductContext)
   const description = props.description != null ? props.description : path(['product', 'description'], valuesFromContext)
 
-  return <ProductDescription description={description} />
+  return <ProductDescription description={description} showShowMoreButton={props.showShowMoreButton} />
+}
+
+ProductDescriptionWrapper.defaultProps = {
+  showShowMoreButton: true,
 }
 
 export default ProductDescriptionWrapper

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -11,7 +11,7 @@ import styles from './styles.css'
  * Product Description Component.
  * Render the description of a product
  */
-const ProductDescription = ({ description, showShowMoreButton }) => {
+const ProductDescription = ({ description, showMoreVisible }) => {
   if (!description) {
     return null
   }
@@ -27,7 +27,7 @@ const ProductDescription = ({ description, showShowMoreButton }) => {
       </FormattedMessage>
 
       <div className="c-muted-1">
-        {showShowMoreButton ? (
+        {showMoreVisible ? (
           <GradientCollapse collapseHeight={220}>
             {descriptionParsed}
           </GradientCollapse>
@@ -42,6 +42,7 @@ const ProductDescription = ({ description, showShowMoreButton }) => {
 ProductDescription.propTypes = {
   /** Product description string */
   description: PropTypes.string,
+  showMoreVisible: PropTypes.bool,
 }
 
 export default memo(ProductDescription)

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -16,7 +16,9 @@ const ProductDescription = ({ description, showShowMoreButton }) => {
     return null
   }
 
-  const descriptionParsed = useMemo(() => HtmlParser(description), [description])
+  const descriptionParsed = useMemo(() => HtmlParser(description), [
+    description,
+  ])
 
   return (
     <div className={styles.productDescriptionContainer}>
@@ -26,13 +28,11 @@ const ProductDescription = ({ description, showShowMoreButton }) => {
 
       <div className="c-muted-1">
         {showShowMoreButton ? (
-        <GradientCollapse collapseHeight={220}>
-          {descriptionParsed}
-        </GradientCollapse>
-        ) : (
-          <Fragment>
+          <GradientCollapse collapseHeight={220}>
             {descriptionParsed}
-          </Fragment>
+          </GradientCollapse>
+        ) : (
+          descriptionParsed
         )}
       </div>
     </div>

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -1,4 +1,4 @@
-import React, { Component, memo, useMemo, Fragment } from 'react'
+import React, { memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import HtmlParser from 'react-html-parser'
@@ -11,7 +11,7 @@ import styles from './styles.css'
  * Product Description Component.
  * Render the description of a product
  */
-const ProductDescription = ({ description, showMoreVisible }) => {
+const ProductDescription = ({ description, collapseContent }) => {
   if (!description) {
     return null
   }
@@ -27,7 +27,7 @@ const ProductDescription = ({ description, showMoreVisible }) => {
       </FormattedMessage>
 
       <div className="c-muted-1">
-        {showMoreVisible ? (
+        {collapseContent ? (
           <GradientCollapse collapseHeight={220}>
             {descriptionParsed}
           </GradientCollapse>
@@ -42,7 +42,7 @@ const ProductDescription = ({ description, showMoreVisible }) => {
 ProductDescription.propTypes = {
   /** Product description string */
   description: PropTypes.string,
-  showMoreVisible: PropTypes.bool,
+  collapseContent: PropTypes.bool,
 }
 
 export default memo(ProductDescription)

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react'
+import React, { Component, memo, useMemo, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 import HtmlParser from 'react-html-parser'
 
 import GradientCollapse from '../GradientCollapse/index'
@@ -11,10 +11,12 @@ import styles from './styles.css'
  * Product Description Component.
  * Render the description of a product
  */
-const ProductDescription = ({ description }) => {
+const ProductDescription = ({ description, showShowMoreButton }) => {
   if (!description) {
     return null
   }
+
+  const descriptionParsed = useMemo(() => HtmlParser(description), [description])
 
   return (
     <div className={styles.productDescriptionContainer}>
@@ -23,9 +25,15 @@ const ProductDescription = ({ description }) => {
       </FormattedMessage>
 
       <div className="c-muted-1">
+        {showShowMoreButton ? (
         <GradientCollapse collapseHeight={220}>
-          {HtmlParser(description)}
+          {descriptionParsed}
         </GradientCollapse>
+        ) : (
+          <Fragment>
+            {descriptionParsed}
+          </Fragment>
+        )}
       </div>
     </div>
   )
@@ -34,8 +42,6 @@ const ProductDescription = ({ description }) => {
 ProductDescription.propTypes = {
   /** Product description string */
   description: PropTypes.string,
-  /** Intl object to provides internationalization */
-  intl: intlShape.isRequired,
 }
 
-export default injectIntl(ProductDescription)
+export default memo(ProductDescription)


### PR DESCRIPTION
#### What problem is this solving?

Add prop so user can always show the whole description and not collapse it.

#### How should this be manually tested?

https://fiddesc--alssports.myvtex.com/northf-pant-summit-l1-climb/p

See that it is showing the description as a whole

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
