### PR TITLE
Add htmlId prop on InfoCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `htmlId` prop on InfoCard
 
 ## [3.50.1] - 2019-07-03
 ### Removed

--- a/react/components/InfoCard/README.md
+++ b/react/components/InfoCard/README.md
@@ -52,7 +52,8 @@ Through the Storefront, you can change the `InfoCard`'s behavior and interface. 
 | `callToActionUrl` | `String` | URL to be redirected when CTA component is clicked | `""` |
 | `imageUrl` | `String` | URL of the image to be used on desktop | `""` |
 | `mobileImageUrl` | `String` |  URL of the image to be used on desktop. If you do not provide any, the desktop image url will be used | `null` |
-| `blockClass` | `String` | Adds an extra class name to ease styling | `null`
+| `blockClass` | `String` | Adds an extra class name to ease styling | `null` |
+| `htmlId` | `String` | Adds an id to the container element | `null` |
 
 
 Here are the possible values of `TextPostionEnum`

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -85,6 +85,7 @@ const InfoCard = ({
   mobileImageUrl,
   imageActionUrl,
   intl,
+  htmlId
 }) => {
   const {
     hints: { mobile },
@@ -167,6 +168,7 @@ const InfoCard = ({
         className={containerClasses}
         style={containerStyle}
         data-testid="container"
+        id={htmlId}
       >
         <div className={textContainerClasses}>
           {headline && (
@@ -223,6 +225,7 @@ MemoizedInfoCard.propTypes = {
   textAlignment: oneOf(getEnumValues(textAlignmentTypes)),
   imageActionUrl: string,
   intl: intlShape,
+  htmlId: string
 }
 
 MemoizedInfoCard.defaultProps = {


### PR DESCRIPTION
#### What problem is this solving?
Add prop `htmlId` similar to the same prop on [rich-text](https://github.com/vtex-apps/rich-text). It's necessary because I need to add a menu with links to scroll to an anchor on the page where each info-card is.

#### How should this be manually tested?
Some info-cards on this page are already configured with `htmlId`, search for `info-card-home` on the rendered HTML
https://storehome--eriksbikeshop.myvtex.com/

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes
I tried adding a test to check if the id is being rendered, but trying to run `lint.sh` gives an error: Error: Cannot find module 'babel-eslint'. Are there any global dependencies required to properly run the tests?
