### PR TITLE
added types of props on availability subscriber docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Types of props on Availability Subscriber documentation.
+
 ## [3.51.3] - 2019-07-05
 
 ### Added

--- a/react/components/AvailabilitySubscriber/README.md
+++ b/react/components/AvailabilitySubscriber/README.md
@@ -28,14 +28,14 @@ In order to collect the emails correctly, this feature needs a special configura
 
 The form is submitted to Master Data on the Entity: `AS`
 
-| Prop name          | Description                                                                            |
-| ------------------ | -------------------------------------------------------------------------------------- |
-| `skuId`            | The id of the product sku to which will be watched for changes in the product quantity |
-| `name`             | The name of the user                                                                   |
-| `email`            | The email of the user                                                                 |
-| `notificationSend` | If the notification has been sent already                                              |
-| `createdAt`        | When the document was created                                                          |
-| `sendAt`           | When the user was notificated                                                          |
+| Prop name | Type | Description|
+| ------| ------ | ------ |
+| `skuId`            | String | The id of the product sku to which will be watched for changes in the product quantity |
+| `name`             | String | The name of the user                                                                   |
+| `email`            | String | The email of the user                                                                 |
+| `notificationSend` | Boolean | If the notification has been sent already                                              |
+| `createdAt`        | String - ISO format | When the document was created  Ex.: ISO (2011-10-05T14:48:00.000Z)                                                     |
+| `sendAt`           | String - ISO format | When the user was notificated  Ex.: ISO (2011-10-05T14:48:00.000Z)                                                        |
 
 
 ### Blocks API


### PR DESCRIPTION
#### What problem is this solving?
Types of props to set configuration of Availability Subscriber on Master Data were missing.

#### Checklist/Reminders

- [X] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->


