### PR TITLE
Internal url with Product ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Uses product id as internal url
 
 ### Added
 - Types of props on Availability Subscriber documentation.

--- a/react/components/SearchBar/components/ResultsList.js
+++ b/react/components/SearchBar/components/ResultsList.js
@@ -25,9 +25,7 @@ const getImageUrl = image => {
 
 const getLinkProps = element => {
   let page = 'store.product'
-  // WARNING: this enables links with translatable slugs
-  // let params = { slug: element.slug, id: element.productId }
-  let params = { slug: element.slug }
+  let params = { slug: element.slug, id: element.productId }
   let query = ''
   const terms = element.slug.split('/')
 

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -57,8 +57,7 @@ const SearchBar = ({
       let page = 'store.product'
       let params = { 
         slug: element.slug, 
-        // WARNING: this enables links with translatable slugs
-        // id: element.productId
+        id: element.productId
       }
       let query = ''
       const terms = element.slug.split('/')


### PR DESCRIPTION
#### What problem is this solving?
This adds the product id to the store search. This should be safe since product routes have now the `/:slug/p` canonical url

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
