### PR TITLE
Feat/assemblies buy button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for adding to cart Assembly Options in buy button.
+- Add prop to show total price on buy button.
 
 ## [3.52.3] - 2019-07-11
 ### Fixed

--- a/react/__tests__/components/BuyButton.test.js
+++ b/react/__tests__/components/BuyButton.test.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { render, fireEvent, waitForElement } from '@vtex/test-tools/react'
+import { render, fireEvent } from '@vtex/test-tools/react'
 import { MockedProvider } from 'react-apollo/test-utils'
 
-import BuyButton, { ADD_TO_CART_MUTATION } from '../../BuyButton'
+import BuyButton from '../../BuyButton'
 
 describe('<BuyButton />', () => {
   const renderComponent = (customProps, text = 'Test') => {

--- a/react/__tests__/components/BuyButton.test.js
+++ b/react/__tests__/components/BuyButton.test.js
@@ -64,4 +64,58 @@ describe('<BuyButton />', () => {
     }
     expect.assertions(assertions)
   })
+
+  it('should show items prices', () => {
+    const skuItems = [
+      {
+        skuId: '1',
+        quantity: 2,
+        seller: '1',
+        name: 'Item',
+        price: 100,
+        options: [
+          { assemblyId: '1', id: '2', quantity: 2, seller: '1' },
+          { assemblyId: '1', id: '3', quantity: 1, seller: '1' },
+        ],
+        assemblyOptions: {
+          added: [
+            {
+              normalizedQuantity: 2,
+              extraQuantity: 2,
+              choiceType: 'MULTIPLE',
+              item: {
+                name: 'Assembly One',
+                sellingPrice: 5,
+                quantity: 2,
+                id: '1',
+              },
+            },
+            {
+              normalizedQuantity: 1,
+              extraQuantity: 1,
+              choiceType: 'MULTIPLE',
+              item: {
+                name: 'Assembly Two',
+                sellingPrice: 3,
+                quantity: 1,
+                id: '2',
+              },
+            },
+          ],
+          removed: [],
+          parentPrice: 100,
+        },
+      },
+    ]
+    const { getByText } = renderComponent(
+      {
+        available: true,
+        skuItems,
+        showItemsPrice: true,
+      },
+      null
+    )
+    const priceRegex = /226.00/
+    getByText(priceRegex)
+  })
 })

--- a/react/components/BuyButton/README.md
+++ b/react/components/BuyButton/README.md
@@ -7,6 +7,7 @@
 :loudspeaker: **Disclaimer:** Don't fork this project, use, contribute, or open issue with your feature request.
 
 ## Table of Contents
+
 - [Usage](#usage)
   - [Blocks API](#blocks-api)
     - [Configuration](#configuration)
@@ -17,7 +18,7 @@
 
 You should follow the usage instruction in the main [README](/README.md#usage).
 
-Then, add `buy-button` block into your app theme, as we do in our [Product Details app](https://github.com/vtex-apps/product-details/blob/master/store/blocks.json). 
+Then, add `buy-button` block into your app theme, as we do in our [Product Details app](https://github.com/vtex-apps/product-details/blob/master/store/blocks.json).
 
 ### Blocks API
 
@@ -35,13 +36,14 @@ For now this block does not have any required or optional blocks.
 
 Through the Storefront, you can change the `BuyButton`'s behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name | Type | Description | Default value |
-| --------- | ---- | ----------- | ------------- |
-| `isOneClickBuy` | `Boolean` | Should redirect to the checkout page or not | false |
-| `shouldOpenMinicart` | `Boolean` | Should open the Minicart after clicking the button | false |
-| `large` | `Boolean` | Sets button to large style, filling whole width (like a `block`) | - |
-| `available` | `Boolean` | If component is available or not | true |
-| `showToast` | `Boolean` | If toast with feedback should be shown after add item request is processed | - |
+| Prop name            | Type      | Description                                                                | Default value |
+| -------------------- | --------- | -------------------------------------------------------------------------- | ------------- |
+| `isOneClickBuy`      | `Boolean` | Should redirect to the checkout page or not                                | false         |
+| `shouldOpenMinicart` | `Boolean` | Should open the Minicart after clicking the button                         | false         |
+| `large`              | `Boolean` | Sets button to large style, filling whole width (like a `block`)           | -             |
+| `available`          | `Boolean` | If component is available or not                                           | true          |
+| `showToast`          | `Boolean` | If toast with feedback should be shown after add item request is processed | -             |
+| `showItemsPrice`     | `Boolean` | If you want to show the total price of items to be added to cart           | false         |
 
 ### Styles API
 

--- a/react/components/BuyButton/assemblyUtils.js
+++ b/react/components/BuyButton/assemblyUtils.js
@@ -1,0 +1,63 @@
+import { filter, isEmpty } from 'ramda'
+
+const filterAssembliesWithItem = filter(items => items.length > 0)
+
+export const transformAssemblyOptions = (assemblyOptions, parentPrice) => {
+  const cleanAssemblies = filterAssembliesWithItem(assemblyOptions)
+  if (isEmpty(cleanAssemblies)) {
+    return {}
+  }
+  const assembliesKeys = Object.keys(cleanAssemblies)
+  const options = [] // contains options sent as arguments to graphql mutation
+  const added = [] // array with added assemblies data to show in minicart optimistic preview
+  const removed = [] // array with removed assemblies data to show in minicart optimistic preview
+  for (const groupId of assembliesKeys) {
+    const items = cleanAssemblies[groupId]
+    for (const item of items) {
+      const {
+        id,
+        quantity,
+        seller,
+        initialQuantity,
+        choiceType,
+        name,
+        price,
+      } = item
+      options.push({
+        assemblyId: groupId,
+        id,
+        quantity,
+        seller,
+      })
+
+      if (quantity > initialQuantity) {
+        added.push({
+          normalizedQuantity: quantity,
+          extraQuantity: quantity - initialQuantity,
+          choiceType,
+          item: {
+            name,
+            sellingPrice: price,
+            quantity,
+            id,
+          },
+        })
+      }
+      if (quantity <= initialQuantity) {
+        removed.push({
+          name,
+          initialQuantity,
+          removedQuantity: initialQuantity - quantity,
+        })
+      }
+    }
+  }
+  return {
+    options,
+    assemblyOptions: {
+      added,
+      removed,
+      parentPrice,
+    },
+  }
+}

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -39,8 +39,6 @@ export const BuyButton = ({
     intl,
   ])
 
-  console.log('teste skuItems: ', skuItems)
-
   const skuItemToMinicartItem = ({
     skuId: id,
     variant: skuName,
@@ -97,7 +95,6 @@ export const BuyButton = ({
     let showToastMessage
     try {
       const minicartItems = skuItems.map(skuItemToMinicartItem)
-      console.log('teste minicartItems: ', minicartItems)
       const {
         data: { addToCart: linkStateItems },
       } = await addToCart(minicartItems)

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -39,6 +39,8 @@ export const BuyButton = ({
     intl,
   ])
 
+  console.log('teste skuItems: ', skuItems)
+
   const skuItemToMinicartItem = ({
     skuId: id,
     variant: skuName,
@@ -59,6 +61,7 @@ export const BuyButton = ({
           'options',
           'listPrice',
           'brand',
+          'assemblyOptions',
         ],
         restSkuItem
       ),
@@ -73,9 +76,9 @@ export const BuyButton = ({
 
     const action = success
       ? {
-        label: translateMessage(CONSTANTS.SEE_CART_ID),
-        href: '/checkout/#/cart',
-      }
+          label: translateMessage(CONSTANTS.SEE_CART_ID),
+          href: '/checkout/#/cart',
+        }
       : undefined
 
     showToast({ message, action })
@@ -94,6 +97,7 @@ export const BuyButton = ({
     let showToastMessage
     try {
       const minicartItems = skuItems.map(skuItemToMinicartItem)
+      console.log('teste minicartItems: ', minicartItems)
       const {
         data: { addToCart: linkStateItems },
       } = await addToCart(minicartItems)

--- a/react/components/BuyButton/mutations/addToCart.gql
+++ b/react/components/BuyButton/mutations/addToCart.gql
@@ -1,0 +1,3 @@
+mutation addToCart($items: [MinicartItem]) {
+  addToCart(items: $items) @client
+}

--- a/react/components/BuyButton/mutations/setOpenMinicart.gql
+++ b/react/components/BuyButton/mutations/setOpenMinicart.gql
@@ -1,0 +1,3 @@
+mutation setMinicartOpen($isOpen: Boolean!) {
+  setMinicartOpen(isOpen: $isOpen) @client
+}


### PR DESCRIPTION
#### What problem is this solving?

Be able to add items with assembly options ( for delivery )

Add prop `showItemsPrice` that shows on buy button the total price of items being passed to it (with assembly options prices).

#### How should this be manually tested?

https://fidelis--delivery.myvtex.com/pizza-pepperoni/p

Also, go to other products pages (without assembly options and make sure it adds with no problems)

![image](https://user-images.githubusercontent.com/4925068/61055700-77310a00-a3c8-11e9-8ea9-d4dbdc78425b.png)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
