### PR TITLE
Use vtex.format-currency to format currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Format currency based on sales channel configuration.
 
 ## [3.53.1] - 2019-07-11
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
     "vtex.modal": "0.x",
     "vtex.react-portal": "0.x",
     "vtex.address-form": "4.x",
-    "vtex.product-context": "0.x"
+    "vtex.product-context": "0.x",
+    "vtex.format-currency": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/__mocks__/vtex.format-currency.js
+++ b/react/__mocks__/vtex.format-currency.js
@@ -1,0 +1,29 @@
+import React, { Fragment } from 'react'
+import { useRuntime } from 'vtex.render-runtime'
+import { injectIntl } from 'react-intl'
+
+export function formatCurrency({ intl, culture, value }) {
+  return intl.formatNumber(value, {
+    style: 'currency',
+    currency: culture.currency,
+    ...(culture.customCurrencyDecimalDigits != null
+      ? { minimumFractionDigits: culture.customCurrencyDecimalDigits }
+      : {}),
+  })
+}
+
+function BaseFormattedCurrency({ value, intl }) {
+  const { culture } = useRuntime()
+
+  const number = intl.formatNumber(value, {
+    style: 'currency',
+    currency: culture.currency,
+    ...(culture.customCurrencyDecimalDigits != null
+      ? { minimumFractionDigits: culture.customCurrencyDecimalDigits }
+      : {}),
+  })
+
+  return <Fragment>{number}</Fragment>
+}
+
+export const FormattedCurrency = injectIntl(BaseFormattedCurrency)

--- a/react/components/ProductPrice/Installments.js
+++ b/react/components/ProductPrice/Installments.js
@@ -1,8 +1,11 @@
 import React, { Fragment } from 'react'
+import { useRuntime } from 'vtex.render-runtime'
+import { injectIntl } from 'react-intl'
 import classNames from 'classnames'
 import { isEmpty } from 'ramda'
 import { FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
+import { formatCurrency } from 'vtex.format-currency'
 
 import PricePropTypes from './propTypes'
 
@@ -11,13 +14,14 @@ import productPrice from './styles.css'
 /** Installments component */
 const Installments = ({
   showLabels,
-  formatNumber,
   installments = [],
-  currencyOptions,
   className,
   installmentClass,
   interestRateClass,
+  intl,
 }) => {
+  const { culture } = useRuntime()
+
   if (
     !installments ||
     isEmpty(
@@ -47,10 +51,11 @@ const Installments = ({
       : current
   )
 
-  const formattedInstallmentPrice = formatNumber(
-    installment.Value,
-    currencyOptions
-  )
+  const formattedInstallmentPrice = formatCurrency({
+    intl,
+    culture,
+    value: installment.Value,
+  })
 
   const [installmentsElement, installmentPriceElement, timesElement] = [
     installment.NumberOfInstallments,
@@ -104,15 +109,6 @@ Installments.propTypes = {
   installments: PricePropTypes.installments,
   /** Pages editor config to display labels */
   showLabels: PropTypes.bool.isRequired,
-  /** react-intl function to format the prices*/
-  formatNumber: PropTypes.func.isRequired,
-  /** Options to be passe to the formatNumber function*/
-  currencyOptions: PropTypes.shape({
-    style: PropTypes.string.isRequired,
-    currency: PropTypes.string.isRequired,
-    minimumFractionDigits: PropTypes.number.isRequired,
-    maximumFractionDigits: PropTypes.number.isRequired,
-  }).isRequired,
 }
 
-export default Installments
+export default injectIntl(Installments)

--- a/react/components/ProductPrice/Price.js
+++ b/react/components/ProductPrice/Price.js
@@ -1,10 +1,20 @@
 import React from 'react'
 import { map, join } from 'ramda'
 import { injectIntl } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
+import { FormattedCurrency, formatCurrency } from 'vtex.format-currency'
 
 const isValidPriceRange = priceRange => {
   const [lowPrice, highPrice] = priceRange
   return priceRange.length === 2 && lowPrice !== highPrice
+}
+
+const formatPriceRange = (intl, culture, rawPriceRange) => {
+  const priceRangeFormatted = (rawPriceRange || []).map(value =>
+    formatCurrency({ intl, culture, value })
+  )
+
+  return priceRangeFormatted.join(' - ')
 }
 
 const Price = ({
@@ -13,30 +23,24 @@ const Price = ({
   price,
   rangeContainerClasses,
   singleContainerClasses,
-  intl: { formatNumber },
-  currencyOptions,
+  intl,
 }) => {
-  const mustShowPriceRange = showPriceRange && priceRange && isValidPriceRange(priceRange)
+  const { culture } = useRuntime()
 
-  const formatPrice = rawPrice => {
-    return formatNumber(rawPrice, currencyOptions)
-  }
-
-  const formatPriceRange = rawPriceRange => {
-    const priceRangeFormatted = map(formatPrice, rawPriceRange || [])
-    return join(' - ', priceRangeFormatted)
-  }
+  const mustShowPriceRange =
+    showPriceRange && priceRange && isValidPriceRange(priceRange)
 
   if (mustShowPriceRange) {
     return (
       <span className={rangeContainerClasses}>
-        {formatPriceRange(priceRange)}
+        {formatPriceRange(intl, culture, priceRange)}
       </span>
     )
   }
+
   return (
     <span className={singleContainerClasses}>
-      {formatPrice(price)}
+      <FormattedCurrency value={price} />
     </span>
   )
 }

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -5,6 +5,7 @@ import { isNil, head, last, sort, equals } from 'ramda'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { IOMessage } from 'vtex.native-types'
 import { useRuntime } from 'vtex.render-runtime'
+import { formatCurrency } from 'vtex.format-currency'
 
 import ProductPriceLoader from './Loader'
 import PricePropTypes from './propTypes'
@@ -59,22 +60,6 @@ const canShowListPrice = props => {
   return !equals(listPriceToShow, sellingPriceToShow)
 }
 
-const useCurrencyOptions = () => {
-  const {
-    culture: { currency },
-  } = useRuntime()
-
-  return useMemo(
-    () => ({
-      style: 'currency',
-      currency,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }),
-    [currency]
-  )
-}
-
 /**
  * The Price component. Shows the prices information of the Product Summary.
  */
@@ -109,12 +94,12 @@ const ProductPrice = (props, context) => {
     interestRateClass,
     installmentContainerClass,
     styles,
-    intl: { formatNumber },
+    intl,
   } = props
 
-  let { classes } = props
+  const { culture } = useRuntime()
 
-  const currencyOptions = useCurrencyOptions()
+  let { classes } = props
 
   // avoiding undefined verifications
   classes = {
@@ -163,7 +148,6 @@ const ProductPrice = (props, context) => {
               productPrice.listPriceValue,
               listPriceClass
             )}
-            currencyOptions={currencyOptions}
           />
         </div>
       )}
@@ -195,15 +179,12 @@ const ProductPrice = (props, context) => {
             productPrice.sellingPrice,
             sellingPriceClass
           )}
-          currencyOptions={currencyOptions}
         />
       </div>
       {showInstallments && (
         <Installments
           installments={installments}
           showLabels={showLabels}
-          formatNumber={formatNumber}
-          currencyOptions={currencyOptions}
           className={installmentContainerClass}
           interestRateClass={interestRateClass}
           installmentClass={installmentClass}
@@ -222,10 +203,11 @@ const ProductPrice = (props, context) => {
             <FormattedMessage
               id="store/pricing.savings"
               values={{
-                savings: formatNumber(
-                  listPrice - sellingPrice,
-                  currencyOptions
-                ),
+                savings: formatCurrency({
+                  intl,
+                  culture,
+                  value: listPrice - sellingPrice,
+                }),
               }}
             />
           </div>

--- a/react/components/ShippingSimulator/components/ShippingTableRow.js
+++ b/react/components/ShippingSimulator/components/ShippingTableRow.js
@@ -4,14 +4,11 @@ import { intlShape, injectIntl } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
 import TranslateEstimate from 'vtex.shipping-estimate-translator/TranslateEstimate'
 import classNames from 'classnames'
+import { FormattedCurrency } from 'vtex.format-currency'
 
 import styles from '../shippingSimulator.css'
 
 const ShippingTableRow = ({ name, shippingEstimate, price, intl }) => {
-  const {
-    culture: { currency },
-  } = useRuntime()
-
   const etaClassName = classNames(
     `${styles.shippingTableCell} pv1 ph3 t-small c-muted-2`,
     {
@@ -33,13 +30,7 @@ const ShippingTableRow = ({ name, shippingEstimate, price, intl }) => {
   } else if (price === 0) {
     valueText = intl.formatMessage({ id: 'store/shipping.free' })
   } else {
-    // TODO: get Fraction digits from segment when data is available
-    valueText = intl.formatNumber(price / 100, {
-      style: 'currency',
-      currency,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    })
+    valueText = <FormattedCurrency value={price / 100} />
   }
 
   return (


### PR DESCRIPTION
#### What problem is this solving?

Render the right decimal digits when displaying currency information based on the sales policy configuration.

#### How should this be manually tested?

[Workspace](https://breno--samsungco.myvtex.com/galaxys10-sm-g973fzwjcoo/p)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/61335678-c5993b00-a804-11e9-96a2-4b02536a5a8d.png) | ![image](https://user-images.githubusercontent.com/284515/61335590-6affdf00-a804-11e9-9bba-a8797de3e6b8.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
