### PR TITLE
Fix/variations update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where going back to a product with variations would render empty variations.
 
 ## [3.54.0] - 2019-07-17
 ### Added

--- a/react/components/SKUSelector/index.js
+++ b/react/components/SKUSelector/index.js
@@ -103,11 +103,11 @@ const SKUSelectorContainer = ({
   }
 
   useEffect(() => {
-    const initalVariations = skuSelected
+    const initialVariations = skuSelected
       ? selectedVariationFromItem(parseSku(skuSelected), variations)
       : buildEmptySelectedVariation(variations)
-    setSelectedVariations(initalVariations)
-  }, [])
+    setSelectedVariations(initialVariations)
+  }, [variations, skuSelected])
 
   const imagesMap = useImagesMap(parsedItems, variations)
 

--- a/react/components/SKUSelector/index.js
+++ b/react/components/SKUSelector/index.js
@@ -107,7 +107,7 @@ const SKUSelectorContainer = ({
       ? selectedVariationFromItem(parseSku(skuSelected), variations)
       : buildEmptySelectedVariation(variations)
     setSelectedVariations(initialVariations)
-  }, [variations, skuSelected])
+  }, [variations])
 
   const imagesMap = useImagesMap(parsedItems, variations)
 


### PR DESCRIPTION
#### What problem is this solving?
Fixes issue where going back to a product with variations would render empty variations.

To test, go to https://lbebber2--alssports.myvtex.com/colums-short-anytime-outdoor-long-ws/p?skuId=428295&__disableSSR, click on the first item on the shelf below, and then click on the "Back" button of the browser. Notice that the variations are working.

Compare with https://alssports.myvtex.com/colums-short-anytime-outdoor-long-ws/p?skuId=428295&__disableSSR, where doing the same would render empty "Size" values.

<!--- What is the motivation and context for this change? -->


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
