### PR TITLE
Add more data to addToCart function to fulfill analytics events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Pass more data down to Minicart addToCart to fulfill analytics data.
 
 ## [3.54.2] - 2019-07-19
 ### Fixed

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -15,6 +15,29 @@ const CONSTANTS = {
   TOAST_TIMEOUT: 3000,
 }
 
+const skuItemToMinicartItem = item => {
+  return {
+    // Important for the mutation
+    id: item.skuId,
+    seller: item.seller,
+    options: item.options,
+    quantity: item.quantity,
+
+    // Fields for optmistic cart
+    sellingPrice: item.price,
+    skuName: item.variant,
+    detailUrl: item.detailUrl,
+    imageUrl: item.imageUrl,
+    name: item.name,
+    listPrice: item.listPrice,
+    assemblyOptions: item.assemblyOptions,
+    // Fields for Analytics
+    brand: item.brand,
+    category: item.category,
+    productRefId: item.productRefId,
+  }
+}
+
 /**
  * BuyButton Component.
  * Adds a list of sku items to the cart.
@@ -38,34 +61,6 @@ export const BuyButton = ({
   const translateMessage = useCallback(id => intl.formatMessage({ id: id }), [
     intl,
   ])
-
-  const skuItemToMinicartItem = ({
-    skuId: id,
-    variant: skuName,
-    price: sellingPrice,
-    ...restSkuItem
-  }) => {
-    return {
-      id,
-      sellingPrice,
-      skuName,
-      ...pick(
-        [
-          'detailUrl',
-          'imageUrl',
-          'quantity',
-          'seller',
-          'name',
-          'options',
-          'listPrice',
-          'brand',
-          'assemblyOptions',
-        ],
-        restSkuItem
-      ),
-      index: 1,
-    }
-  }
 
   const toastMessage = success => {
     const message = success
@@ -104,14 +99,12 @@ export const BuyButton = ({
         // minicart does not have link state implemented, calling graphql directly
         const variables = {
           orderFormId: orderFormContext.orderForm.orderFormId,
-          items: skuItems.map(skuItem => {
-            const { skuId } = skuItem
-            return {
-              id: parseInt(skuId),
-              index: 1,
-              ...pick(['quantity', 'seller', 'options'], skuItem),
-            }
-          }),
+          items: skuItems.map(item => ({
+            id: item.skuId,
+            seller: item.seller,
+            options: item.options,
+            quantity: item.quantity,
+          })),
         }
         const mutationRes = await orderFormContext.addItem({ variables })
         const { items } = mutationRes.data.addItem


### PR DESCRIPTION
#### What problem is this solving?

We need `productRefId`, `category` and `brand` info get to MiniCart so it can trigger those data to `addToCart` and `removeFromCart` events.

#### How should this be manually tested?


[Store Component](https://breno--storecomponents.myvtex.com/)
[Invicta](https://breno--invictastores.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
n/a

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Related PR: https://github.com/vtex-apps/product-summary/pull/173
<!-- Put any relevant information that doesn't fit in the other sections here. -->
