### PR TITLE
Link fix for Image component readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Below we have a README for each component of this project that explains how to u
 - [Discount Badge](/react/components/DiscountBadge/README.md)
 - [Gradient Collapse](/react/components/GradientCollapse/README.md)
 - [Greeting](/react/components/Greeting/README.md)
-- [Image](//react/components/Image/README.md)
+- [Image](/react/components/Image/README.md)
 - [InfoCard](/react/components/InfoCard/README.md)
 - [Logo](/react/components/Logo/README.md)
 - [Newsletter](/react/components/Newsletter/README.md)


### PR DESCRIPTION
Currently clicking on the image component documentation does not point to the correct location, which is:

`https://github.com/vtex-apps/store-components/blob/master/react/components/Image/README.md`

is pointed to:

`https://react/components/Image/README.md`

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
