### PR TITLE
Feature/product thumbnails arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **ProductImages:** Prop `displayThumbnailsArrows`.
 
 ## [3.55.0] - 2019-07-23
 ### Added

--- a/react/components/ProductImages/README.md
+++ b/react/components/ProductImages/README.md
@@ -44,6 +44,7 @@ Specification:
 | ---------- | ---------------- | ----------------------------------------------------- | ------------- |
 | `images`   | `Array(Images)!` | An array of Images                                    | []            |
 | `position` | `Enum`           | Set the position of the thumbnails(`left` or `right`) | `left`        |
+| `displayThumbnailsArrows` | `boolean` | Displays navigation arrows on the thumbnails if there are enough thumbnails for them to scroll | `false` |
 
 ### Styles API
 

--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -30,6 +30,7 @@ const ProductImagesWrapper = props => {
     <ProductImages
       zoomProps={props.zoomProps}
       position={props.position || props.thumbnailPosition}
+      displayThumbnailsArrows={props.displayThumbnailsArrows}
       images={images}
     />
   )

--- a/react/components/ProductImages/components/Carousel/global.css
+++ b/react/components/ProductImages/components/Carousel/global.css
@@ -639,3 +639,7 @@ button.swiper-pagination-bullet {
 .translate--50y{
   transform: translate(0, -50%);
 }
+
+.pointer-events-none {
+  pointer-events: none;
+}

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -247,26 +247,17 @@ class Carousel extends Component {
     }
   }
 
-  render() {
-    const { thumbsLoaded, isGalleryOpen, selectedIndex, gallerySwiper } = this.state
-
+  get thumbnailsParams() {
     const {
-      slides,
-      position,
       displayThumbnailsArrows,
-      zoomProps: { zoomType, bgOpacity },
     } = this.props
-
-    if (!thumbsLoaded || Swiper == null) {
-      return <Loader slidesAmount={slides ? slides.length : 0} />
-    }
 
     const caretSize = 24
     const caretClassName =
       'absolute z-2 left-0 pointer c-action-primary w-100 flex justify-center pv2'
     const caretStyle = { transition: 'opacity 200ms' }
 
-    const thumbnailParams = {
+    return {
       modules: [SwiperModules.Navigation],
       ...(displayThumbnailsArrows && {
         navigation: {
@@ -325,6 +316,21 @@ class Carousel extends Component {
       slidesPerGroup: displayThumbnailsArrows ? 4 : 1,
       getSwiper: swiper => this.setState({ thumbSwiper: swiper }),
     }
+  }
+
+  render() {
+    const { thumbsLoaded, isGalleryOpen, selectedIndex, gallerySwiper } = this.state
+
+    const {
+      slides,
+      position,
+      zoomProps: { zoomType, bgOpacity },
+    } = this.props
+
+    if (!thumbsLoaded || Swiper == null) {
+      return <Loader slidesAmount={slides ? slides.length : 0} />
+    }
+
 
     const galleryCursor = {
       gallery: !isGalleryOpen && 'pointer',
@@ -352,7 +358,7 @@ class Carousel extends Component {
     return (
       <div className="relative overflow-hidden w-100" aria-hidden="true">
         <div className={thumbClasses}>
-          <Swiper {...thumbnailParams} rebuildOnUpdate>
+          <Swiper {...this.thumbnailsParams} rebuildOnUpdate>
             {slides.map((slide, i) => (
               <div
                 key={i}

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -268,11 +268,13 @@ class Carousel extends Component {
       freeMode: false,
       direction: 'vertical',
       slidesPerView: 'auto',
-      touchRatio: 0.4,
-      mousewheel: true,
+      touchRatio: 1,
+      mousewheel: false,
       preloadImages: true,
       shouldSwiperUpdate: true,
       zoom: false,
+      threshold: 8,
+      slidesPerGroup: 4,
       getSwiper: swiper => this.setState({ thumbSwiper: swiper }),
     }
 

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -265,7 +265,7 @@ class Carousel extends Component {
       containerClass: 'swiper-container h-100',
       watchSlidesVisibility: true,
       watchSlidesProgress: true,
-      freeMode: true,
+      freeMode: false,
       direction: 'vertical',
       slidesPerView: 'auto',
       touchRatio: 0.4,

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -260,7 +260,18 @@ class Carousel extends Component {
       return <Loader slidesAmount={slides ? slides.length : 0} />
     }
 
+    const iconSize = 24
+    const caretClassName =
+      'absolute z-2 left-0 pointer c-action-primary w-100 flex justify-center pv2'
+
     const thumbnailParams = {
+      modules: [SwiperModules.Navigation],
+      navigation: {
+        prevEl: '.swiper-thumbnails-caret-prev',
+        nextEl: '.swiper-thumbnails-caret-next',
+        disabledClass: `c-disabled o-0 pointer-events-none ${styles.carouselCursorDefault}`,
+        hiddenClass: 'dn',
+      },
       observer: true,
       containerClass: 'swiper-container h-100',
       watchSlidesVisibility: true,
@@ -276,6 +287,24 @@ class Carousel extends Component {
       threshold: 8,
       slidesPerGroup: 4,
       getSwiper: swiper => this.setState({ thumbSwiper: swiper }),
+      renderNextButton: () => (
+        <span className={`swiper-thumbnails-caret-next bottom-0 pt7 ${caretClassName} ${styles.gradientBaseBottom}`} style={{ transition: 'opacity 200ms' }}>
+          <IconCaret
+            orientation="down"
+            size={iconSize}
+            className={styles.carouselIconCaretRight}
+          />
+        </span>
+      ),
+      renderPrevButton: () => (
+        <span className={`swiper-thumbnails-caret-prev top-0 pb7 ${caretClassName} ${styles.gradientBaseTop}`} style={{ transition: 'opacity 200ms'}}>
+          <IconCaret
+            orientation="up"
+            size={iconSize}
+            className={styles.carouselIconCaretLeft}
+          />
+        </span>
+      ),
     }
 
     const galleryCursor = {

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -253,6 +253,7 @@ class Carousel extends Component {
     const {
       slides,
       position,
+      displayThumbnailsArrows,
       zoomProps: { zoomType, bgOpacity },
     } = this.props
 
@@ -260,18 +261,51 @@ class Carousel extends Component {
       return <Loader slidesAmount={slides ? slides.length : 0} />
     }
 
-    const iconSize = 24
+    const caretSize = 24
     const caretClassName =
       'absolute z-2 left-0 pointer c-action-primary w-100 flex justify-center pv2'
+    const caretStyle = { transition: 'opacity 200ms' }
 
     const thumbnailParams = {
       modules: [SwiperModules.Navigation],
-      navigation: {
-        prevEl: '.swiper-thumbnails-caret-prev',
-        nextEl: '.swiper-thumbnails-caret-next',
-        disabledClass: `c-disabled o-0 pointer-events-none ${styles.carouselCursorDefault}`,
-        hiddenClass: 'dn',
-      },
+      ...(displayThumbnailsArrows && {
+        navigation: {
+          prevEl: '.swiper-thumbnails-caret-prev',
+          nextEl: '.swiper-thumbnails-caret-next',
+          disabledClass: `c-disabled o-0 pointer-events-none ${
+            styles.carouselCursorDefault
+          }`,
+          hiddenClass: 'dn',
+        },
+        renderNextButton: () => (
+          <span
+            className={`swiper-thumbnails-caret-next bottom-0 pt7 ${caretClassName} ${
+              styles.gradientBaseBottom
+            }`}
+            style={caretStyle}
+          >
+            <IconCaret
+              orientation="down"
+              size={caretSize}
+              className={styles.carouselIconCaretRight}
+            />
+          </span>
+        ),
+        renderPrevButton: () => (
+          <span
+            className={`swiper-thumbnails-caret-prev top-0 pb7 ${caretClassName} ${
+              styles.gradientBaseTop
+            }`}
+            style={caretStyle}
+          >
+            <IconCaret
+              orientation="up"
+              size={caretSize}
+              className={styles.carouselIconCaretLeft}
+            />
+          </span>
+        ),
+      }),
       observer: true,
       containerClass: 'swiper-container h-100',
       watchSlidesVisibility: true,
@@ -285,26 +319,11 @@ class Carousel extends Component {
       shouldSwiperUpdate: true,
       zoom: false,
       threshold: 8,
-      slidesPerGroup: 4,
+      /* Slides are grouped when thumbnails arrows are enabled
+       * so that clicking on next/prev will scroll more than 
+       * one thumbnail */
+      slidesPerGroup: displayThumbnailsArrows ? 4 : 1,
       getSwiper: swiper => this.setState({ thumbSwiper: swiper }),
-      renderNextButton: () => (
-        <span className={`swiper-thumbnails-caret-next bottom-0 pt7 ${caretClassName} ${styles.gradientBaseBottom}`} style={{ transition: 'opacity 200ms' }}>
-          <IconCaret
-            orientation="down"
-            size={iconSize}
-            className={styles.carouselIconCaretRight}
-          />
-        </span>
-      ),
-      renderPrevButton: () => (
-        <span className={`swiper-thumbnails-caret-prev top-0 pb7 ${caretClassName} ${styles.gradientBaseTop}`} style={{ transition: 'opacity 200ms'}}>
-          <IconCaret
-            orientation="up"
-            size={iconSize}
-            className={styles.carouselIconCaretLeft}
-          />
-        </span>
-      ),
     }
 
     const galleryCursor = {
@@ -399,6 +418,7 @@ Carousel.propTypes = {
       bestUrlIndex: PropTypes.number,
     })
   ),
+  displayThumbnailsArrows: PropTypes.bool,
 }
 
 export default Carousel

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -19,7 +19,7 @@ const getBestUrlIndex = thresholds => {
 
 const ProductImages = props => {
   const [_, setState] = useState(0)
-  const { position, zoomProps } = props
+  const { position, zoomProps, displayThumbnailsArrows } = props
 
   const debouncedGetBestUrl = debounce(() => {
     // force update
@@ -54,7 +54,7 @@ const ProductImages = props => {
 
   return (
     <div className={`${styles.content} w-100`}>
-      <Carousel slides={slides} position={position} zoomProps={zoomProps} />
+      <Carousel slides={slides} position={position} displayThumbnailsArrows={displayThumbnailsArrows} zoomProps={zoomProps} />
     </div>
   )
 }

--- a/react/components/ProductImages/styles.css
+++ b/react/components/ProductImages/styles.css
@@ -47,3 +47,13 @@
 .figure {
   margin: 0;
 }
+
+.gradientBaseBottom {
+  /** TODO: use the actual bg-base token instead of a hardcoded color */
+  background: linear-gradient(transparent, white)
+}
+
+.gradientBaseTop {
+  /** TODO: use the actual bg-base token instead of a hardcoded color */
+  background: linear-gradient(white, transparent)
+}


### PR DESCRIPTION
#### What problem is this solving?
Adds prop `displayThumbnailsArrows` to the `product-images` block.

Closes https://github.com/vtex-apps/store-discussion/issues/57 and https://github.com/vtex-apps/store-components/issues/371

Test on https://lbebber--storecomponents.myvtex.com/jobs-notebook/p

![product-images-arrows](https://user-images.githubusercontent.com/5691711/61738199-21614800-ad60-11e9-86b3-06d89394db1a.gif)


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
