### PR TITLE
Add toast message in BuyButton when an item is added offline to minicart.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Toast message in `BuyButton` when an item is added offline to minicart.
 
 ## [3.57.3] - 2019-07-30
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -36,6 +36,7 @@
   "store/buy-button.add-to-cart": "Add to cart",
   "store/buybutton.buy-success": "buybutton.buy-success",
   "store/buybutton.add-failure": "buybutton.add-failure",
+  "store/buybutton.buy-offline-success": "buybutton.buy-offline-success",
   "store/buybutton.see-cart": "Button label on the notification that pops up when the user adds an item to the cart, prompting the user to see said cart",
   "store/technicalspecifications.title": "technicalspecifications.title",
   "store/availability-subscriber.title": "availability-subscriber.title",

--- a/messages/en.json
+++ b/messages/en.json
@@ -36,7 +36,7 @@
   "store/buy-button.add-to-cart": "Add to cart",
   "store/buybutton.buy-success": "Item added to your cart",
   "store/buybutton.add-failure": "Something went wrong and the item wasn't added to your cart!",
-  "store/buybutton.buy-offline-success": "Item added offline to your cart",
+  "store/buybutton.buy-offline-success": "Item added to your offline cart",
   "store/buybutton.see-cart": "View cart",
   "store/technicalspecifications.title": "Technical Specifications",
   "store/availability-subscriber.title": "This product isn't available right now",

--- a/messages/en.json
+++ b/messages/en.json
@@ -36,6 +36,7 @@
   "store/buy-button.add-to-cart": "Add to cart",
   "store/buybutton.buy-success": "Item added to your cart",
   "store/buybutton.add-failure": "Something went wrong and the item wasn't added to your cart!",
+  "store/buybutton.buy-offline-success": "Item added offline to your cart",
   "store/buybutton.see-cart": "View cart",
   "store/technicalspecifications.title": "Technical Specifications",
   "store/availability-subscriber.title": "This product isn't available right now",

--- a/messages/es.json
+++ b/messages/es.json
@@ -36,7 +36,7 @@
   "store/buy-button.add-to-cart": "Incluir items en el carrito",
   "store/buybutton.buy-success": "Ítem agregado a su carrito",
   "store/buybutton.add-failure": "¡Algo salió mal y el artículo no se agregó a tu carrito!",
-  "store/buybutton.buy-offline-success": "Ítem agregado offline a su carrito",
+  "store/buybutton.buy-offline-success": "Ítem agregado a su carrito offline",
   "store/buybutton.see-cart": "Ver carrito",
   "store/technicalspecifications.title": "Especificaciones Tecnicas",
   "store/availability-subscriber.title": "Este producto no está disponible actualmente",

--- a/messages/es.json
+++ b/messages/es.json
@@ -36,6 +36,7 @@
   "store/buy-button.add-to-cart": "Incluir items en el carrito",
   "store/buybutton.buy-success": "Ítem agregado a su carrito",
   "store/buybutton.add-failure": "¡Algo salió mal y el artículo no se agregó a tu carrito!",
+  "store/buybutton.buy-offline-success": "Ítem agregado offline a su carrito",
   "store/buybutton.see-cart": "Ver carrito",
   "store/technicalspecifications.title": "Especificaciones Tecnicas",
   "store/availability-subscriber.title": "Este producto no está disponible actualmente",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -36,7 +36,7 @@
   "store/buy-button.add-to-cart": "Adicionar ao carrinho",
   "store/buybutton.buy-success": "Item adicionado ao seu carrinho",
   "store/buybutton.add-failure": "Algo deu errado e o item não pode ser adicionado ao seu carrinho!",
-  "store/buybutton.buy-offline-success": "Item adicionado offline ao seu cart",
+  "store/buybutton.buy-offline-success": "Item adicionado ao seu carrinho offline.",
   "store/buybutton.see-cart": "Ver carrinho",
   "store/technicalspecifications.title": "Especificações Técnicas",
   "store/availability-subscriber.title": "Este produto não está disponível no momento",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -36,6 +36,7 @@
   "store/buy-button.add-to-cart": "Adicionar ao carrinho",
   "store/buybutton.buy-success": "Item adicionado ao seu carrinho",
   "store/buybutton.add-failure": "Algo deu errado e o item não pode ser adicionado ao seu carrinho!",
+  "store/buybutton.buy-offline-success": "Item adicionado offline ao seu cart",
   "store/buybutton.see-cart": "Ver carrinho",
   "store/technicalspecifications.title": "Especificações Técnicas",
   "store/availability-subscriber.title": "Este produto não está disponível no momento",

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -8,6 +8,7 @@ import { Button, ToastContext } from 'vtex.styleguide'
 
 const CONSTANTS = {
   SUCCESS_MESSAGE_ID: 'store/buybutton.buy-success',
+  OFFLINE_BUY_MESSAGE_ID: 'store/buybutton.buy-offline-success',
   ERROR_MESSAGE_ID: 'store/buybutton.add-failure',
   SEE_CART_ID: 'store/buybutton.see-cart',
   CHECKOUT_URL: '/checkout/#/cart',
@@ -65,8 +66,11 @@ export const BuyButton = ({
   ])
 
   const toastMessage = success => {
+    const isOnline = window && window.navigator && window.navigator.onLine
     const message = success
-      ? translateMessage(CONSTANTS.SUCCESS_MESSAGE_ID)
+      ? ( isOnline ? translateMessage(CONSTANTS.SUCCESS_MESSAGE_ID)
+          : translateMessage(CONSTANTS.OFFLINE_BUY_MESSAGE_ID)
+      )
       : translateMessage(CONSTANTS.ERROR_MESSAGE_ID)
 
     const action = success

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -66,9 +66,9 @@ export const BuyButton = ({
   ])
 
   const toastMessage = success => {
-    const isOnline = window && window.navigator && window.navigator.onLine
+    const isOffline = window && window.navigator && !window.navigator.onLine
     const message = success
-      ? ( isOnline ? translateMessage(CONSTANTS.SUCCESS_MESSAGE_ID)
+      ? ( !isOffline ? translateMessage(CONSTANTS.SUCCESS_MESSAGE_ID)
           : translateMessage(CONSTANTS.OFFLINE_BUY_MESSAGE_ID)
       )
       : translateMessage(CONSTANTS.ERROR_MESSAGE_ID)


### PR DESCRIPTION
#### What problem is this solving?
Our minicart can add items offline and online, it's important to show different messages for each behavior.

#### How should this be manually tested?

[Workspace](https://alerts--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
