### PR TITLE
Fix ResultList size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The `ResultList` now have the correct size when the `SearchBar` is bigger than 320px
 
 ## [3.59.0] - 2019-08-05
 ### Added

--- a/react/components/SearchBar/components/ResultsList.js
+++ b/react/components/SearchBar/components/ResultsList.js
@@ -86,79 +86,81 @@ const ResultsList = ({
   }
 
   return (
-    <ul className={listClassNames} {...getMenuProps()}>
-      {isOpen ? (
-        data.loading ? (
-          <div className={listItemClassNames}>
-            <WrappedSpinner />
-          </div>
-        ) : (
-          <Fragment>
-            <li
-              {...getItemProps({
-                key: 'ft' + inputValue,
-                item: { term: inputValue },
-                index: 0,
-                onClick: handleItemClick,
-              })}
-            >
-              <Link
-                page="store.search"
-                params={{ term: inputValue }}
-                query="map=ft"
-                className={`${listItemClassNames} pointer db w-100 ${highlightClass(
-                  highlightedIndex,
-                  0
-                )}`}
+    <div style={listStyle}>
+      <ul className={listClassNames} {...getMenuProps()}>
+        {isOpen ? (
+          data.loading ? (
+            <div className={listItemClassNames}>
+              <WrappedSpinner />
+            </div>
+          ) : (
+            <Fragment>
+              <li
+                {...getItemProps({
+                  key: 'ft' + inputValue,
+                  item: { term: inputValue },
+                  index: 0,
+                  onClick: handleItemClick,
+                })}
               >
-                <FormattedMessage
-                  id="store/search.searchFor"
-                  values={{
-                    term: (
-                      <span className={styles.searchTerm}> "{inputValue}"</span>
-                    ),
-                  }}
-                />
-              </Link>
-            </li>
-
-            {items.map((item, index) => {
-              return (
-                <li
-                  {...getItemProps({
-                    key: item.name + index,
-                    index: index + 1,
-                    item,
-                    onClick: handleItemClick,
-                  })}
+                <Link
+                  page="store.search"
+                  params={{ term: inputValue }}
+                  query="map=ft"
+                  className={`${listItemClassNames} pointer db w-100 ${highlightClass(
+                    highlightedIndex,
+                    0
+                  )}`}
                 >
-                  <Link
-                    {...getLinkProps(item)}
-                    className={`${listItemClassNames} pointer ${highlightClass(
-                      highlightedIndex,
-                      index + 1
-                    )} ${item.thumb ? 'flex justify-start' : ' db w-100'}`}
+                  <FormattedMessage
+                    id="store/search.searchFor"
+                    values={{
+                      term: (
+                        <span className={styles.searchTerm}> "{inputValue}"</span>
+                      ),
+                    }}
+                  />
+                </Link>
+              </li>
+
+              {items.map((item, index) => {
+                return (
+                  <li
+                    {...getItemProps({
+                      key: item.name + index,
+                      index: index + 1,
+                      item,
+                      onClick: handleItemClick,
+                    })}
                   >
-                    {item.thumb && (
-                      <img
-                        width={50}
-                        height={50}
-                        alt={item.name}
-                        className={`${styles.resultsItemImage} mr4`}
-                        src={getImageUrl(item.thumb)}
-                      />
-                    )}
-                    <div className="flex justify-start items-center">
-                      {item.name}
-                    </div>
-                  </Link>
-                </li>
-              )
-            })}
-          </Fragment>
-        )
-      ) : null}
-    </ul>
+                    <Link
+                      {...getLinkProps(item)}
+                      className={`${listItemClassNames} pointer ${highlightClass(
+                        highlightedIndex,
+                        index + 1
+                      )} ${item.thumb ? 'flex justify-start' : ' db w-100'}`}
+                    >
+                      {item.thumb && (
+                        <img
+                          width={50}
+                          height={50}
+                          alt={item.name}
+                          className={`${styles.resultsItemImage} mr4`}
+                          src={getImageUrl(item.thumb)}
+                        />
+                      )}
+                      <div className="flex justify-start items-center">
+                        {item.name}
+                      </div>
+                    </Link>
+                  </li>
+                )
+              })}
+            </Fragment>
+          )
+        ) : null}
+      </ul>
+    </div>
   )
 }
 

--- a/react/components/SearchBar/components/ResultsList.js
+++ b/react/components/SearchBar/components/ResultsList.js
@@ -68,6 +68,8 @@ const ResultsList = ({
         (parentContainer.current && parentContainer.current.offsetWidth) || 0
       ),
     }),
+    /* with the isOpen here this will be called 
+    only when you open or close the ResultList */
     [parentContainer.current, isOpen]
   )
 

--- a/react/components/SearchBar/components/ResultsList.js
+++ b/react/components/SearchBar/components/ResultsList.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useMemo } from 'react'
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
@@ -9,6 +9,8 @@ import { Link, useRuntime } from 'vtex.render-runtime'
 import autocomplete from '../queries/autocomplete.gql'
 
 import styles from '../styles.css'
+
+const MIN_RESULTS_WIDTH = 320
 
 const WrappedSpinner = () => (
   <div className="w-100 flex justify-center">
@@ -44,6 +46,7 @@ const highlightClass = (highlightedIndex, index) => {
 
 /** List of search results to be displayed*/
 const ResultsList = ({
+  parentContainer,
   isOpen,
   data = {}, // when inputValue is '', query is skipped and value is undefined
   inputValue,
@@ -57,6 +60,16 @@ const ResultsList = ({
   const {
     hints: { mobile },
   } = useRuntime()
+
+  const listStyle = useMemo(
+    () => ({
+      width: Math.max(
+        MIN_RESULTS_WIDTH,
+        (parentContainer.current && parentContainer.current.offsetWidth) || 0
+      ),
+    }),
+    [parentContainer.current, isOpen]
+  )
 
   const listClassNames = classnames(
     styles.resultsList,

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -10,8 +10,6 @@ import { useRuntime } from 'vtex.render-runtime'
 
 import styles from '../styles.css'
 
-const MIN_RESULTS_WIDTH = 320
-
 const SearchBar = ({
   placeholder,
   onMakeSearch,
@@ -28,16 +26,6 @@ const SearchBar = ({
 }) => {
   const container = useRef()
   const { navigate } = useRuntime()
-
-  const menuStyle = useMemo(
-    () => ({
-      width: Math.max(
-        MIN_RESULTS_WIDTH,
-        (container.current && container.current.offsetWidth) || 0
-      ),
-    }),
-    [container.current]
-  )
 
   const onSelect = useCallback(
     element => {
@@ -127,20 +115,19 @@ const SearchBar = ({
                 })}
               />
               <Overlay alignment="right">
-                <div style={menuStyle}>
-                  <ResultsLists
-                    {...{
-                      isOpen,
-                      getMenuProps,
-                      inputValue,
-                      getItemProps,
-                      selectedItem,
-                      highlightedIndex,
-                      closeMenu,
-                      onClearInput,
-                    }}
-                  />
-                </div>
+                <ResultsLists
+                  parentContainer={container}
+                  {...{
+                    isOpen,
+                    getMenuProps,
+                    inputValue,
+                    getItemProps,
+                    selectedItem,
+                    highlightedIndex,
+                    closeMenu,
+                    onClearInput,
+                  }}
+                />
               </Overlay>
             </div>
           )}

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -116,6 +116,7 @@ const SearchBar = ({
               />
               <Overlay alignment="right">
                 <ResultsLists
+                  key={inputValue || 'x'}
                   parentContainer={container}
                   {...{
                     isOpen,

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -116,7 +116,6 @@ const SearchBar = ({
               />
               <Overlay alignment="right">
                 <ResultsLists
-                  key={inputValue || 'x'}
                   parentContainer={container}
                   {...{
                     isOpen,


### PR DESCRIPTION
#### What problem is this solving?
The `ResultList` of the `SearchBar`'s autocomplete wasn't expanding in size when the `SearchBar`'s size could change dynamically

![image](https://user-images.githubusercontent.com/8443580/62392922-20d66780-b53f-11e9-95ea-2a205e6071d8.png)


#### How should this be manually tested?

[Workspace](https://iaronaraujo--samsungar.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/62392977-4499ad80-b53f-11e9-8bec-20ed0d084f35.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

