### PR TITLE
Fix Product Price sellingPrice classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Product Price classes in sellingPrice. Added `sellingPriceRangeValue` and `sellingPriceValue` to value element. Also added `sellingPriceContainer` as a replacement to the `sellingPrice` in the parent element.
 
 ## [3.58.0] - 2019-08-01
 ### Added

--- a/react/__tests__/components/__snapshots__/ProductPrice.test.js.snap
+++ b/react/__tests__/components/__snapshots__/ProductPrice.test.js.snap
@@ -6,10 +6,10 @@ exports[`<ProductPrice /> should match snapshot 1`] = `
     class="priceContainer"
   >
     <div
-      class="sellingPrice"
+      class="sellingPrice sellingPriceContainer"
     >
       <span
-        class="sellingPrice"
+        class="sellingPrice sellingPriceValue"
       >
         $40.00
       </span>

--- a/react/components/ProductPrice/README.md
+++ b/react/components/ProductPrice/README.md
@@ -8,6 +8,7 @@ This Component can be imported and used by any VTEX app.
 :loudspeaker: **Disclaimer:** Don't fork this project, use, contribute, or open issue with your feature request.
 
 ## Table of Contents
+
 - [Usage](#usage)
   - [Blocks API](#blocks-api)
     - [Configuration](#configuration)
@@ -18,7 +19,7 @@ This Component can be imported and used by any VTEX app.
 
 You should follow the usage instruction in the main [README](/README.md#usage).
 
-Then, add `product-price` block into your app theme, as we do in our [Product Details app](https://github.com/vtex-apps/product-details/blob/master/store/blocks.json). 
+Then, add `product-price` block into your app theme, as we do in our [Product Details app](https://github.com/vtex-apps/product-details/blob/master/store/blocks.json).
 
 ### Blocks API
 
@@ -36,40 +37,44 @@ For now this block does not have any required or optional blocks.
 
 Through the Storefront, you can change the `ProductPrice`'s behavior and interface. However, you also can make in your theme app, as Store theme does. However, you also can make in your theme app, as Store theme does.
 
-| Prop name | Type | Description | Default value |
-| --------- | ---- | ----------- | ------------- |
-| `labelSellingPrice` | `String` | Product selling price label | null |
-| `labelListPrice` | `String` | Product list price label | null |
-| `showListPrice` | `Boolean` | Set visibility of list price | true |
-| `sellingPrices` | `Array` | Product list of selling prices | [] |
-| `showSellingPriceRange` | `Boolean` | Set visibility of selling price range | false |
-| `showListPriceRange` | `Boolean` | Set visibility of list price range | false |
-| `showLabels` | `Boolean` | Set visibility of labels | true |
-| `showInstallments` | `Boolean` | Set visibility of installments | false |
-| `showSavings` | `Boolean` | Set visibility of savings | false |
+| Prop name               | Type      | Description                           | Default value |
+| ----------------------- | --------- | ------------------------------------- | ------------- |
+| `labelSellingPrice`     | `String`  | Product selling price label           | null          |
+| `labelListPrice`        | `String`  | Product list price label              | null          |
+| `showListPrice`         | `Boolean` | Set visibility of list price          | true          |
+| `sellingPrices`         | `Array`   | Product list of selling prices        | []            |
+| `showSellingPriceRange` | `Boolean` | Set visibility of selling price range | false         |
+| `showListPriceRange`    | `Boolean` | Set visibility of list price range    | false         |
+| `showLabels`            | `Boolean` | Set visibility of labels              | true          |
+| `showInstallments`      | `Boolean` | Set visibility of installments        | false         |
+| `showSavings`           | `Boolean` | Set visibility of savings             | false         |
 
 ### Styles API
+
 You should follow the Styles API instruction in the main [README](/README.md#styles-api).
 
 #### CSS Namespaces
+
 Below, we describe the namespace that are defined in the `ProductPrice`.
 
-| Class name | Description | Component Source |
-| ---------- | ----------- | ---------------- |
-| `priceContainer` | The main container of `ProductPrice` | [index](/react/components/ProductPrice/index.js) |
-| `listPrice` | The list price container | [index](/react/components/ProductPrice/index.js) |
-| `listPriceLabel` | The list price label | [index](/react/components/ProductPrice/index.js) | 
-| `listPriceValue` | The list price value | [index](/react/components/ProductPrice/index.js) |
-| `sellingPrice` | The selling price container | [index](/react/components/ProductPrice/index.js) | 
-| `sellingPriceLabel` | The selling price label | [index](/react/components/ProductPrice/index.js) |
-| `sellingPriceValue` | The selling price value | [index](/react/components/ProductPrice/index.js) |
-| `savingPrice` | The saving price container | [index](/react/components/ProductPrice/index.js) |
-| `savingPriceValue` | The saving price value | [index](/react/components/ProductPrice/index.js) |
-| `installmentsPrice` | The installments price container | [Installments](/react/components/ProductPrice/Installments.js) | 
-| `interestRatePrice` | The interest rate price | [Installments](/react/components/ProductPrice/Installments.js) |
-| `priceLoaderContainer` | The container of the `ProductPrice` loader | [index](/react/components/ProductPrice/index.js) |
-| `listPriceLoader` | The list price loader | [index](/react/components/ProductPrice/index.js) |
-| `sellingPriceLabelLoader` | The selling price loader label | [index](/react/components/ProductPrice/index.js) |
-| `sellingPriceLoader` | The selling price loader | [index](/react/components/ProductPrice/index.js) |
-| `installmentsPriceLoader` | The installments price loader | [index](/react/components/ProductPrice/index.js) |
-| `savingsPriceLoader` | The savings price loader | [index](/react/components/ProductPrice/index.js) |
+| Class name                 | Description                                         | Component Source                                               |
+| -------------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
+| `priceContainer`           | The main container of `ProductPrice`                | [index](/react/components/ProductPrice/index.js)               |
+| `listPrice`                | The list price container                            | [index](/react/components/ProductPrice/index.js)               |
+| `listPriceLabel`           | The list price label                                | [index](/react/components/ProductPrice/index.js)               |
+| `listPriceValue`           | The list price value                                | [index](/react/components/ProductPrice/index.js)               |
+| `sellingPrice`             | **DEPRECATED** Use `sellingPriceContainer` instead  | [index](/react/components/ProductPrice/index.js)               |
+| `sellingPriceContainer`    | The selling price container                         | [index](/react/components/ProductPrice/index.js)               |
+| `sellingPriceLabel`        | The selling price label                             | [index](/react/components/ProductPrice/index.js)               |
+| `sellingPriceValue`        | The selling price value                             | [index](/react/components/ProductPrice/index.js)               |
+| `sellingPriceValue--range` | Class added when is showing the selling price range | [index](/react/components/ProductPrice/index.js)               |
+| `savingPrice`              | The saving price container                          | [index](/react/components/ProductPrice/index.js)               |
+| `savingPriceValue`         | The saving price value                              | [index](/react/components/ProductPrice/index.js)               |
+| `installmentsPrice`        | The installments price container                    | [Installments](/react/components/ProductPrice/Installments.js) |
+| `interestRatePrice`        | The interest rate price                             | [Installments](/react/components/ProductPrice/Installments.js) |
+| `priceLoaderContainer`     | The container of the `ProductPrice` loader          | [index](/react/components/ProductPrice/index.js)               |
+| `listPriceLoader`          | The list price loader                               | [index](/react/components/ProductPrice/index.js)               |
+| `sellingPriceLabelLoader`  | The selling price loader label                      | [index](/react/components/ProductPrice/index.js)               |
+| `sellingPriceLoader`       | The selling price loader                            | [index](/react/components/ProductPrice/index.js)               |
+| `installmentsPriceLoader`  | The installments price loader                       | [index](/react/components/ProductPrice/index.js)               |
+| `savingsPriceLoader`       | The savings price loader                            | [index](/react/components/ProductPrice/index.js)               |

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -154,6 +154,7 @@ const ProductPrice = (props, context) => {
       <div
         className={classNames(
           productPrice.sellingPrice,
+          productPrice.sellingPriceContainer,
           sellingPriceContainerClass
         )}
       >
@@ -173,10 +174,13 @@ const ProductPrice = (props, context) => {
           price={sellingPrice}
           rangeContainerClasses={classNames(
             productPrice.sellingPrice,
+            productPrice.sellingPriceValue,
+            productPrice['sellingPriceValue--range'],
             sellingPriceRangeClass
           )}
           singleContainerClasses={classNames(
             productPrice.sellingPrice,
+            productPrice.sellingPriceValue,
             sellingPriceClass
           )}
         />

--- a/react/components/ProductPrice/styles.css
+++ b/react/components/ProductPrice/styles.css
@@ -6,9 +6,11 @@
 .listPriceLabel {}
 .listPriceValue {}
 
-.sellingPrice {}
+.sellingPriceContainer {}
+.sellingPrice {} /* deprecated */
 .sellingPriceLabel {}
 .sellingPriceValue {}
+.sellingPriceValue--range {}
 
 .savingPrice {}
 .savingPriceValue {}


### PR DESCRIPTION
#### What problem is this solving?

Selling Price have a wrong CSS classes applied to it, see that it is using `sellingPrice` instead of `sellingPriceValue`:

![image](https://user-images.githubusercontent.com/284515/62395427-9134b700-b546-11e9-8ebe-6be61fa35b17.png)

Compare it with listPrice which is correct:

![image](https://user-images.githubusercontent.com/284515/62395447-a14c9680-b546-11e9-81fd-1c779aaaf495.png)

**The solution** was to add a new class to the parent `sellingPrice` and the child `sellingPrice` so it's possible to differentiate them in a backwards compatible way:

![image](https://user-images.githubusercontent.com/284515/62395496-cfca7180-b546-11e9-9543-9fbc0a05a01d.png)


#### How should this be manually tested?

[Workspace](https://breno--alssports.myvtex.com/patagn-shirt-fitz-roy-horizons-resp/p)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
