### PR TITLE
Changed `addToAvailabilitySubscriberMutation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `addToAvailabilitySubscriberMutation`'s mutation to `createDocument`
+
 ## [3.60.0] - 2019-08-06
 ### Added
 - `discountInsideContainer` class to DiscountBadge.

--- a/react/components/AvailabilitySubscriber/mutations/addToAvailabilitySubscriberMutation.gql
+++ b/react/components/AvailabilitySubscriber/mutations/addToAvailabilitySubscriberMutation.gql
@@ -1,5 +1,5 @@
 mutation availabilitySubscribe($acronym: String!, $document: DocumentInput) {
-  updateDocument(acronym: $acronym, document: $document) {
+  createDocument(acronym: $acronym, document: $document) {
     cacheId
     id
     href


### PR DESCRIPTION
#### What problem is this solving?

When a user wanted to subscribe to be notified when an unavailable product got available, they would get an error. Now, this was fixed and the user subscription is saved in the master data.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/rustic-striped-vase/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/62725412-7ac9a800-b9eb-11e9-9128-179e04e2b9ab.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
