### PR TITLE
buybutton: call graphql directly when isOneClickBuy is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `BuyButton`: if isOneClickBuy, call graphql directly, skip optimistic add.
 
 ## [3.61.0] - 2019-08-12
 

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -68,9 +68,9 @@ export const BuyButton = ({
   const toastMessage = success => {
     const isOffline = window && window.navigator && !window.navigator.onLine
     const message = success
-      ? ( !isOffline ? translateMessage(CONSTANTS.SUCCESS_MESSAGE_ID)
-          : translateMessage(CONSTANTS.OFFLINE_BUY_MESSAGE_ID)
-      )
+      ? !isOffline
+        ? translateMessage(CONSTANTS.SUCCESS_MESSAGE_ID)
+        : translateMessage(CONSTANTS.OFFLINE_BUY_MESSAGE_ID)
       : translateMessage(CONSTANTS.ERROR_MESSAGE_ID)
 
     const action = success
@@ -96,13 +96,15 @@ export const BuyButton = ({
     let showToastMessage
     try {
       const minicartItems = skuItems.map(skuItemToMinicartItem)
-      const {
-        data: { addToCart: linkStateItems },
-      } = await addToCart(minicartItems)
+      const localStateMutationResult = !isOneClickBuy
+        ? await addToCart(minicartItems)
+        : null
+      const linkStateItems =
+        localStateMutationResult && localStateMutationResult.data.addToCart
+      const callOrderFormDirectly = !linkStateItems
 
       let success = null
-      if (!linkStateItems) {
-        // minicart does not have link state implemented, calling graphql directly
+      if (callOrderFormDirectly) {
         const variables = {
           orderFormId: orderFormContext.orderForm.orderFormId,
           items: skuItems.map(item => ({


### PR DESCRIPTION
#### What problem is this solving?

The optimistic add with isOneClickBuy true can cause issues if the redirect to the cart happens before the add to cart request is done. This caused the minicart to appearr empty after the redirect.

This PR makes the buy button call graphql directly and bypass the optimistic minicart when isOneClickBuy is true.

Sidenote: this may cause problems if, lets say, a user is modifying an item to its cart (happening optimistic) and then presses the buy button with `isOneClickBuy: true`. Something weird will probably happen.

#### How should this be manually tested?

https://fidbut--samsungar.myvtex.com/galaxy-j6/p (has isOneClickBuy set to true)
https://fidbut--exitocol.myvtex.com/banano-criollo-a-granel-x-330gr-276701/p (works ok)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
