### PR TITLE
Show install prompt when BuyButton is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Show install prompt when clicking `buyButton`.
 
 ## [3.60.0] - 2019-08-06
 ### Added

--- a/react/__mocks__/vtex.store-resources/PWAContext.js
+++ b/react/__mocks__/vtex.store-resources/PWAContext.js
@@ -1,3 +1,3 @@
 export const usePWA = () => {
-  return { showInstallPrompt: jest.fn() }
+  return { showInstallPrompt: jest.fn(), settings: { addToHomeScreenPrompt: "disable"} }
 }

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -62,7 +62,7 @@ export const BuyButton = ({
   const [isAddingToCart, setAddingToCart] = useState(false)
   const { showToast } = useContext(ToastContext)
   const { settings: { addToHomeScreenPrompt }, showInstallPrompt } = usePWA()	
-  console.log(addToHomeScreenPrompt)
+
   const translateMessage = useCallback(id => intl.formatMessage({ id: id }), [
     intl,
   ])
@@ -129,6 +129,7 @@ export const BuyButton = ({
             skuItem => !!linkStateItems.find(({ id }) => id === skuItem.skuId)
           ))
       
+      /* PWA */
       if (addToHomeScreenPrompt === "addToCart")   
         showInstallPrompt()
 

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -3,7 +3,7 @@ import React, { useContext, useCallback, useState, Fragment } from 'react'
 import { intlShape, FormattedMessage } from 'react-intl'
 import ContentLoader from 'react-content-loader'
 import { useRuntime } from 'vtex.render-runtime'
-
+import { usePWA } from 'vtex.store-resources/PWAContext'	
 import { Button, ToastContext } from 'vtex.styleguide'
 
 const CONSTANTS = {
@@ -61,6 +61,8 @@ export const BuyButton = ({
 }) => {
   const [isAddingToCart, setAddingToCart] = useState(false)
   const { showToast } = useContext(ToastContext)
+  const { settings: { addToHomeScreenPrompt }, showInstallPrompt } = usePWA()	
+  console.log(addToHomeScreenPrompt)
   const translateMessage = useCallback(id => intl.formatMessage({ id: id }), [
     intl,
   ])
@@ -126,6 +128,9 @@ export const BuyButton = ({
           skuItems.filter(
             skuItem => !!linkStateItems.find(({ id }) => id === skuItem.skuId)
           ))
+      
+      if (addToHomeScreenPrompt === "addToCart")   
+        showInstallPrompt()
 
       showToastMessage = () => toastMessage(success && success.length >= 1)
       shouldOpenMinicart && !isOneClickBuy && setMinicartOpen(true)

--- a/react/components/BuyButton/prompt.code-workspace
+++ b/react/components/BuyButton/prompt.code-workspace
@@ -1,0 +1,16 @@
+{
+  "folders": [
+    {
+      "path": "/Users/user/dev/vtex/store-components"
+    },
+    {
+      "path": "/Users/user/dev/vtex/store"
+    },
+    {
+      "path": "/Users/user/dev/vtex/store-resources"
+    },
+    {
+      "path": "/Users/user/dev/vtex/pwa-graphql"
+    }
+  ]
+}


### PR DESCRIPTION
#### What problem is this solving?
In the store settings, you can choose to show the [install prompt](https://developers.google.com/web/fundamentals/app-install-banners/promoting-install-mobile) when the first item is added to cart. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://promptbutton--storecomponents.myvtex.com/)

Note: This prompt is showed only once, if you want to test more times, go to `chrome://flags/#enable-app-banners` in your chrome, and change this flag to **enabled**
#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

