### PR TITLE
Fix search bar placeholder not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `SearchBar`: the `placeholder` property was not working
 
 ## [3.62.1] - 2019-08-13
 ### Changed

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -68,13 +68,12 @@ class SearchBarContainer extends Component {
       iconClasses,
       autoFocus,
       maxWidth,
+      placeholder = intl.formatMessage({
+        id: 'store/search.placeholder',
+      }),
     } = this.props
 
     const { shouldSearch, inputValue } = this.state
-
-    const placeholder = intl.formatMessage({
-      id: 'store/search.placeholder',
-    })
 
     return (
       <SearchBar


### PR DESCRIPTION
#### What problem is this solving?
Trying to customize the search bar input placeholder was never working.

The placeholder prop from search bar was exposed as a customizable prop
but was never being used by the component.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Workspace](https://diego--c2v02.myvtex.com)

This workspace is changing the default text of the search bar
placeholder.

1. Go to this workspace without linking this PR, you will see "Buscar"
as placeholder

2. Link this PR and you will see the searchbar placeholder change

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

####### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->