### PR TITLE
Add CSS handle to searchbar icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add CSS Handle to target the search bar icon (`searchBarIcon`).
 
 ## [3.64.0] - 2019-08-21
 ### Added

--- a/react/__mocks__/vtex.store-icons.js
+++ b/react/__mocks__/vtex.store-icons.js
@@ -1,23 +1,26 @@
 import React from 'react'
 
-const iconMock = (orientation, size, className, name) => {
+const iconMock = ({orientation = '', size, className = '', name}) => {
   return (
     <svg
-      classNames={`${orientation}-oritentation-mock ${className} ${name}`}
+      className={`${orientation} ${className} ${name}`}
       width={size}
       height={size}
     >
       <rect
         width={size}
         height={size}
-        style="fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"
+        style={{fill: 'rgb(0,0,255)', strokeWidth: 3, stroke: 'rgb(0,0,0)'}}
       />
     </svg>
   )
 }
 
 export const IconClose = ({ orientation, size, className }) =>
-  iconMock(orientation, size, className, 'IconClose')
+  iconMock({orientation, size, className, name: 'IconClose'})
 
 export const IconSearch = ({ orientation, size, className }) =>
-  iconMock(orientation, size, className, 'IconSearch')
+  iconMock({orientation, size, className, name: 'IconSearch'})
+
+export const IconCaret = ({ orientation, size, className }) =>
+  iconMock({orientation, size, className, name: 'IconCaret'})

--- a/react/__mocks__/vtex.styleguide.js
+++ b/react/__mocks__/vtex.styleguide.js
@@ -22,12 +22,13 @@ export function Spinner(props) {
 }
 
 export const Input = forwardRef(function Input(
-  { label, error, errorMessage, isLoading, ...props },
+  { label, error, errorMessage, isLoading, prefix, suffix, ...props },
   ref
 ) {
   return (
     <label>
       {label}
+      {prefix}
       <input
         data-isloading={isLoading}
         data-error={error}
@@ -35,13 +36,18 @@ export const Input = forwardRef(function Input(
         ref={ref}
         {...props}
       />
+      {suffix}
     </label>
   )
 })
 
-export const Button = jest.fn(({ isLoading, variation, children, ...props }) => {
+export const Button = jest.fn(({ isLoading, variation, block, children, ...props }) => {
   return (
-    <button data-variation={variation} data-isloading={isLoading} {...props}>
+    <button
+      data-variation={variation}
+      data-isloading={isLoading}
+      data-block={block}
+      {...props}>
       {children}
     </button>
   )

--- a/react/__tests__/components/SearchBar.test.js
+++ b/react/__tests__/components/SearchBar.test.js
@@ -32,4 +32,12 @@ describe('<SearchBar />', () => {
     const { asFragment } = renderComponent()
     expect(asFragment()).toMatchSnapshot()
   })
+
+  it('should have CSS handle searchBarIcon', () => {
+    const { container } = renderComponent()
+
+    const element = container.querySelector('.searchBarIcon')
+
+    expect(element).toBeTruthy()
+  })
 })

--- a/react/__tests__/components/__snapshots__/BuyButton.test.js.snap
+++ b/react/__tests__/components/__snapshots__/BuyButton.test.js.snap
@@ -11,6 +11,7 @@ exports[`<BuyButton /> should match snapshot loading 1`] = `
 exports[`<BuyButton /> should match snapshot normal 1`] = `
 <DocumentFragment>
   <button
+    data-block="true"
     data-isloading="false"
   >
     Test
@@ -21,6 +22,7 @@ exports[`<BuyButton /> should match snapshot normal 1`] = `
 exports[`<BuyButton /> should match snapshot unavailable 1`] = `
 <DocumentFragment>
   <button
+    data-block="true"
     data-isloading="false"
     disabled=""
   >

--- a/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
+++ b/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
@@ -28,9 +28,19 @@ exports[`<SearchBar /> should match snapshot 1`] = `
                 autocomplete="off"
                 id="downshift-1-input"
                 placeholder="Search"
-                suffix="[object Object]"
                 value=""
               />
+              <span
+                class=" searchBarIcon flex items-center pointer"
+              >
+                <svg
+                  class="  IconSearch"
+                >
+                  <rect
+                    style="fill: rgb(0,0,255); stroke-width: 3; stroke: rgb(0,0,0);"
+                  />
+                </svg>
+              </span>
             </label>
           </div>
         </div>

--- a/react/__tests__/components/__snapshots__/ShippingSimulator.test.js.snap
+++ b/react/__tests__/components/__snapshots__/ShippingSimulator.test.js.snap
@@ -18,6 +18,7 @@ exports[`<ShippingSimulator /> component should match snapshot with skuId and se
     </div>
     <button
       class="shippingCTA"
+      data-block="true"
       data-isloading="false"
       disabled=""
       type="submit"

--- a/react/components/SearchBar/README.md
+++ b/react/components/SearchBar/README.md
@@ -4,15 +4,13 @@
 
 `Search Bar` is a VTEX Component that shows a search bar with autocomplete options and displays the matching products as well. This component can be imported and used by any VTEX App.
 
-:loudspeaker: **Disclaimer:** Don't fork this project, use, contribute, or open issue with your feature request.
+:loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, or open issue with your feature request.
 
 ## Table of Contents
 
 - [Usage](#usage)
-  - [Blocks API](#blocks-api)
-    - [Configuration](#configuration)
-  - [Styles API](#styles-api)
-    - [CSS Namespaces](#css-namespaces)
+  - [Props](#props)
+  - [CSS Handles](#css-handles)
 
 ## Usage
 
@@ -20,36 +18,19 @@ You should follow the usage instruction in the main [README](https://github.com/
 
 Then, add `search-bar` block into your app theme, as we do in our [Store Header](https://github.com/vtex-apps/store-header/blob/master/store/blocks.json).
 
-### Blocks API
+### Props
 
-When implementing this component as a block, various inner blocks may be available. The following interface lists the available blocks within `SearchBar` and describes if they are required or optional.
+| Prop name          | Type      | Description                                                                              | Default value |
+| ------------------ | --------- | ---------------------------------------------------------------------------------------- | ------------- |
+| `placeholder`      | `String!` | Placeholder to be used on the input                                                      | -             |
+| `emptyPlaceholder` | `String!` | Shows a placeholder when the ResultList hasn't results to displayed                      | -             |
+| `compactMode`      | `Boolean` | Identify when to use the compact version of the component                                | -             |
+| `hasIconLeft`      | `Boolean` | Identify if the search icon is on left or right position                                 | -             |
+| `autoFocus`        | `Boolean` | Identify if the search input should autofocus or not                                     | -             |
+| ~`iconClasses`~    | `String`  | **DEPRECATED** ~Custom classes for the search icon~ Use the CSS handle `searchBarIcon`.  | -             |
 
-```json
-  "search-bar": {
-    "component": "SearchBar"
-  }
-```
 
-For now this block does not have any required or optional blocks.
-
-#### Configuration
-
-Through the Storefront, you can change the `SearchBar`'s behavior and interface. However, you also can make in your theme app, as Store theme does.
-
-| Prop name          | Type      | Description                                                         | Default value |
-| ------------------ | --------- | ------------------------------------------------------------------- | ------------- |
-| `placeholder`      | `String!` | Placeholder to be used on the input                                 | -             |
-| `emptyPlaceholder` | `String!` | Shows a placeholder when the ResultList hasn't results to displayed | -             |
-| `compactMode`      | `Boolean` | Identify when to use the compact version of the component           | -             |
-| `hasIconLeft`      | `Boolean` | Identify if the search icon is on left or right position            | -             |
-| `iconClasses`      | `String`  | Custom classes for the search icon                                  | -             |
-| `autoFocus`        | `Boolean` | Identify if the search input should autofocus or not                | -             |
-
-### Styles API
-
-You should follow the Styles API instruction in the main [README](/README.md#styles-api).
-
-#### CSS Namespaces
+### CSS Handles
 
 Below, we describe the namespace that are defined in the `SearchBar`.
 
@@ -60,3 +41,4 @@ Below, we describe the namespace that are defined in the `SearchBar`.
 | `resultsItemImage`   | The image from a product returned by the search                       | [ResultsList](/react/components/SearchBar/components/ResultsList.js)             |
 | `compactMode`        | Properties to be applied to the input when `compactMode` prop is true | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
 | `paddingInput`       | The padding of the `SearchBar` input                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarIcon`      | The class that targets the search bar icon                            | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -34,13 +34,14 @@ class AutocompleteInput extends Component {
       compactMode,
       value,
       hasIconLeft,
+      iconBlockClass,
       iconClasses,
       ...restProps
     } = this.props
 
     const suffix = (
       <span
-        className={`${iconClasses} flex items-center pointer`}
+        className={`${iconClasses || ''} ${styles.searchBarIcon} flex items-center pointer`}
         onClick={() => value && onClearInput()}
       >
         {value ? (
@@ -52,7 +53,7 @@ class AutocompleteInput extends Component {
     )
 
     const prefix = (
-      <span className={iconClasses}>
+      <span className={`${iconClasses} ${styles.searchBarIcon}`}>
         <IconSearch />
       </span>
     )
@@ -100,6 +101,8 @@ AutocompleteInput.propTypes = {
   hasIconLeft: PropTypes.bool,
   /** Custom classes for the search icon */
   iconClasses: PropTypes.string,
+  /** Block class for the search icon */
+  iconBlockClass: PropTypes.string,
   /** Identify if the search input should autofocus or not */
   autoFocus: PropTypes.bool,
 }

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -21,6 +21,7 @@ const SearchBar = ({
   compactMode,
   hasIconLeft,
   iconClasses,
+  iconBlockClass,
   autoFocus,
   maxWidth,
 }) => {
@@ -73,6 +74,7 @@ const SearchBar = ({
       inputValue={inputValue}
       hasIconLeft={hasIconLeft}
       iconClasses={iconClasses}
+      iconBlockClass={iconBlockClass}
     />
   )
 

--- a/react/components/SearchBar/styles.css
+++ b/react/components/SearchBar/styles.css
@@ -56,6 +56,9 @@
 .searchTerm {
 }
 
+.searchBarIcon {
+}
+
 @media only screen and (max-width: 49rem) {
   .searchBarContainer input {
     box-shadow: none;


### PR DESCRIPTION
#### What problem is this solving?

Add CSS handle to Search Bar icon.

#### How should this be manually tested?

[Workspace](breno--storecomponents.myvtex.com)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

**Before**
![image](https://user-images.githubusercontent.com/284515/63455746-c173c500-c423-11e9-9f2c-b8d4c62b552d.png)

**After**
![image](https://user-images.githubusercontent.com/284515/63455712-ae60f500-c423-11e9-8326-0c7c8fac8226.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->