### PR TITLE
Added brand props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- How `ProductBrand` can get the brand information. It is now possible to get this data through props, but if the props are `undefined` the value will still be obtained through the product context
+
 ## [3.62.2] - 2019-08-15
 ### Fixed
 - `SearchBar`: the `placeholder` property was not working

--- a/react/components/ProductBrand/README.md
+++ b/react/components/ProductBrand/README.md
@@ -37,6 +37,8 @@ This component has an interface that describes which rules must be implemented b
 | `height` | `Number` | It sets the logo height. It should only be used when displaymode is set to “logo”. |
 | `excludeBrands` | `Array` | The brand names or brand IDs that are listed in the array will never be displayed by the Brand component. It is usually useful to hide default brand names/logos or test brand names/logos on the store front. |
 | `logoWithLink` | `boolean` | If the brand logo will have a link that leads to the store's brand page |
+| `brandName` | `String` | The brand name. If this value is not passed, it will be obtained through the product context. |
+| `brandId` | `Number` | The brand id. If this value is not passed, it will be obtained through the product context. |
 
 
 ### Styles API

--- a/react/components/ProductBrand/index.js
+++ b/react/components/ProductBrand/index.js
@@ -28,6 +28,15 @@ const BrandContainer = ({ children, blockClass }) => (
   </div>
 )
 
+const useBrandInfoProps = (brandName, brandId) => {
+  const productContext = useContext(ProductContext)
+  const product = productContext && productContext.product
+  if ((brandName && brandId) || !product) {
+    return { brandName, brandId }
+  }
+  return { brandName: product.brand, brandId: product.brandId}
+ }
+
 const ProductBrand = ({
   displayMode = DISPLAY_MODE.LOGO,
   fallbackToText = true,
@@ -40,18 +49,13 @@ const ProductBrand = ({
   excludeBrands,
   blockClass,
   logoWithLink,
-  brandName,
-  brandId
+  brandName: brandNameProp,
+  brandId: brandIdProp,
 }) => {
-  const productContext = useContext(ProductContext)
 
-  if(!brandName || !brandId) {
-    if (!productContext || !productContext.product) {
-      return null
-    } else {
-      brandName = productContext.product.brand
-      brandId = productContext.product.brandId
-    }
+  const {brandName, brandId } = useBrandInfoProps(brandNameProp, brandIdProp)
+  if (!brandName || !brandId) {
+    return null
   }
 
   /** Certain brands (e.g. placeholder brands) can be filtered out via theme config */

--- a/react/components/ProductBrand/index.js
+++ b/react/components/ProductBrand/index.js
@@ -40,16 +40,19 @@ const ProductBrand = ({
   excludeBrands,
   blockClass,
   logoWithLink,
+  brandName,
+  brandId
 }) => {
   const productContext = useContext(ProductContext)
 
-  if (!productContext || !productContext.product) {
-    return null
+  if(!brandName || !brandId) {
+    if (!productContext || !productContext.product) {
+      return null
+    } else {
+      brandName = productContext.product.brand
+      brandId = productContext.product.brandId
+    }
   }
-
-  const {
-    product: { brand: brandName, brandId },
-  } = productContext
 
   /** Certain brands (e.g. placeholder brands) can be filtered out via theme config */
   if (shouldExcludeBrand(brandName, brandId, excludeBrands)) {
@@ -164,6 +167,8 @@ const ProductBrand = ({
 ProductBrand.propTypes = {
   /** Brand name */
   brandName: PropTypes.string,
+  /** Brand id */
+  brandId: PropTypes.number,
   /** Whether it should be displayed as a logo or as a text */
   displayMode: PropTypes.oneOf(Object.values(DISPLAY_MODE)),
   /** Whether the loading placeholder should have the size of the logo or the text */


### PR DESCRIPTION
#### What problem is this solving?

 It wasn't possible to use ProductBrand from another context (example: product summary) since it got its brand data from the product context. I've created two new props `brandName` and `brandId` that can be passed to this component if you want those data to come from an external source instead of the product context.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
