### PR TITLE
Prevent addToCart while orderForm is loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent addToCart while orderForm is loading.
+
 ## [3.66.0] - 2019-08-21
 
 ### Added

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -77,7 +77,7 @@ export const BuyButton = ({
       ? translateMessage(CONSTANTS.SUCCESS_MESSAGE_ID)
       : translateMessage(CONSTANTS.OFFLINE_BUY_MESSAGE_ID)
 
-    return checkForOffline 
+    return checkForOffline
   }
 
   const toastMessage = ({ success, isNewItem }) => {
@@ -149,7 +149,7 @@ export const BuyButton = ({
         success: success && success.length >= 1,
         isNewItem: !foundItem,
       })
-      
+
       shouldOpenMinicart && !isOneClickBuy && setMinicartOpen(true)
     } catch (err) {
       console.error(err)
@@ -173,7 +173,7 @@ export const BuyButton = ({
       ) : (
         <Button
           block={large}
-          disabled={disabled || !available}
+          disabled={disabled || !available || orderFormContext.loading}
           onClick={handleAddToCart}
           isLoading={isAddingToCart}
         >


### PR DESCRIPTION
#### What problem is this solving?

If the user clicks before the order form is loaded, the value will be null and the product will not be added in the cart.
```
const variables = {
          orderFormId: orderFormContext.orderForm.orderFormId,
          items: skuItems.map(item => ({
            id: item.skuId,
            seller: item.seller,
            options: item.options,
            quantity: item.quantity,
          })),
        }
```
You can notice more when in `isOneClickBuy`.

#### How should this be manually tested?

[Workspace](https://gustavo--qastore.mygocommerce.com/produto-celular/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
