### PR TITLE
Add logo href to documentation

### DIFF
--- a/react/components/Logo/README.md
+++ b/react/components/Logo/README.md
@@ -44,6 +44,7 @@ Through the Storefront, you can change the `Logo`'s behavior and interface. Howe
 | `width` | `Number` | The logo image width | `493` |
 | `height` | `Number` | The logo image height | `177` |
 | `url` | `String` | The image url | - |
+| `href` | `String` | Image link | - |
 
 ### Styles API
 You should follow the Styles API instruction in the main [README](/README.md#styles-api).


### PR DESCRIPTION
#### What problem is this solving?
Missing documentation on how to add link to logo
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
You can see it [implemented here](https://github.com/vtex-apps/store-components/blob/master/react/components/Logo/index.js#L65-L68), but not documented.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
