### PR TITLE
remove protection in list price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- `ProductPrice`: show list price even if selling price is a range and list price is not.
 
 ## [3.66.2] - 2019-08-27
 ### Fixed

--- a/react/components/ProductPrice/index.js
+++ b/react/components/ProductPrice/index.js
@@ -48,10 +48,6 @@ const canShowListPrice = props => {
   const showingListPriceRange =
     showListPriceRange && isValidPriceRange(listPriceRange)
 
-  if (showingSellingPriceRange && !showingListPriceRange) {
-    return false
-  }
-
   const sellingPriceToShow = showingSellingPriceRange
     ? sellingPriceRange
     : sellingPrice


### PR DESCRIPTION
#### What problem is this solving?

If the product had did not have a list price range, but only a list price, we would not display anything we will display a range price.

Remove this check

#### How should this be manually tested?

![image](https://user-images.githubusercontent.com/4925068/63807497-33e91700-c8f4-11e9-9811-efc123ba8922.png)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
