### PR TITLE
Added dangerouslySetInnerHTML in CallToAction link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Added feature to add any HTML in CallToAction link.
+
 
 ## [3.66.2] - 2019-08-27
 ### Fixed

--- a/react/components/InfoCard/CallToAction.js
+++ b/react/components/InfoCard/CallToAction.js
@@ -11,7 +11,7 @@ const ActionWrapper = ({ mode, text }) => {
   }
 
   // Mode is link
-  return <p className="link t-body b underline c-action-primary">{text}</p>
+  return <p className="link t-body b underline c-action-primary" dangerouslySetInnerHTML={{ __html: text }}></p>
 }
 
 const CallToAction = ({ mode, text, url }) => {


### PR DESCRIPTION
#### What problem is this solving?
Feature to add any HTML in CallToAction link

<!--- What is the motivation and context for this change? -->
Adding an icon to the link is an example of use.

#### How should this be manually tested?
Link in any workspace and add any html in callToAction property of info-card's component

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
