### PR TITLE
use formatIOMessage on Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Image`: properly use CMS translatable props with formatIOMessage.
 
-## [3.66.3] - 2019-08-28
 ### Changed
 
 - `ProductPrice`: show list price even if selling price is a range and list price is not.

--- a/react/components/Image/index.js
+++ b/react/components/Image/index.js
@@ -1,17 +1,19 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { generateBlockClass } from '@vtex/css-handles'
+import { injectIntl, intlShape } from 'react-intl'
+import { formatIOMessage } from 'vtex.native-types'
 
 import styles from './styles.css'
 
-const Image = ({ src, alt, maxWidth, maxHeight, srcSet, sizes, blockClass, link }) => {
-  const img = renderImg({src, alt, maxHeight, maxWidth, srcSet, sizes, blockClass})
+const Image = ({ src, alt, maxWidth, maxHeight, srcSet, sizes, blockClass, link, intl }) => {
+  const img = renderImg({src, alt, maxHeight, maxWidth, srcSet, sizes, blockClass, intl})
   return link ? (
     <a
-      href={link.url}
+      href={formatIOMessage({ id: link.url, intl })}
       rel={link.attributeNofollow ? 'nofollow' : ''}
       target={link.newTab ? '_blank' : ''}
-      title={link.attributeTitle}
+      title={formatIOMessage({ id: link.attributeTitle, intl })}
     >
       {img}
     </a>
@@ -20,15 +22,17 @@ const Image = ({ src, alt, maxWidth, maxHeight, srcSet, sizes, blockClass, link 
   )
 }
 
-const renderImg = ({src, alt, maxWidth, maxHeight, srcSet, sizes, blockClass}) => {
+const renderImg = ({src, alt, maxWidth, maxHeight, srcSet, sizes, blockClass, intl}) => {
   const classes = generateBlockClass(styles.imageElement, blockClass)
   const maxDimensions = {
     maxWidth: maxWidth,
     maxHeight: maxHeight,
   }
-  
+
+  const formattedSrc = formatIOMessage({ id: src, intl })
+  const formattedAlt = formatIOMessage({ id: alt, intl })
   return (
-    <img src={src} srcSet={srcSet} sizes={sizes} alt={alt} style={maxDimensions} className={classes} />
+    <img src={formattedSrc} srcSet={srcSet} sizes={sizes} alt={formattedAlt} style={maxDimensions} className={classes} />
   )
 }
 
@@ -41,6 +45,7 @@ Image.propTypes = {
   srcSet: PropTypes.string,
   sizes: PropTypes.string,
   blockClass: PropTypes.string,
+  intl: intlShape,
 }
 
 Image.defaultProps = {
@@ -65,4 +70,4 @@ Image.schema = {
   },
 }
 
-export default Image
+export default injectIntl(Image)


### PR DESCRIPTION
#### What problem is this solving?

We started using the translatable types from the CMS in the `Image` component but did not properly format them with the `formatIOMessage` method before using, causing problems.

#### How should this be manually tested?

https://image--storecomponents.myvtex.com/
https://image--invictastores.myvtex.com/

Navigate, see everything is OK

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
