### PR TITLE
show install prompt when buy button is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Show install prompt when clicking `buyButton`.
 
 ## [3.67.3] - 2019-08-29
 ### Fixed

--- a/react/__mocks__/vtex.store-resources/PWAContext.js
+++ b/react/__mocks__/vtex.store-resources/PWAContext.js
@@ -1,3 +1,3 @@
 export const usePWA = () => {
-  return { showInstallPrompt: jest.fn() }
+  return { showInstallPrompt: jest.fn(), settings: { promptOnCustomEvent: ""} }
 }

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -4,6 +4,7 @@ import { intlShape, FormattedMessage } from 'react-intl'
 import { path } from 'ramda'
 import ContentLoader from 'react-content-loader'
 import { useRuntime } from 'vtex.render-runtime'
+import { usePWA } from 'vtex.store-resources/PWAContext'
 
 import { Button, ToastContext } from 'vtex.styleguide'
 
@@ -63,6 +64,7 @@ export const BuyButton = ({
 }) => {
   const [isAddingToCart, setAddingToCart] = useState(false)
   const { showToast } = useContext(ToastContext)
+  const { settings: { promptOnCustomEvent }, showInstallPrompt } = usePWA()
   const translateMessage = useCallback(id => intl.formatMessage({ id: id }), [
     intl,
   ])
@@ -150,6 +152,11 @@ export const BuyButton = ({
         isNewItem: !foundItem,
       })
 
+      /* PWA */
+      if (promptOnCustomEvent === "addToCart") {
+        showInstallPrompt()
+      }
+  
       shouldOpenMinicart && !isOneClickBuy && setMinicartOpen(true)
     } catch (err) {
       console.error(err)


### PR DESCRIPTION
#### What problem is this solving?
In the store settings, you can choose to show the [install prompt](https://developers.google.com/web/fundamentals/app-install-banners/promoting-install-mobile) when the first item is added to cart. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://promptbutton--storecomponents.myvtex.com/)

_Obs_: This prompt is showed only once, if you want to test more times, go to `chrome://flags/#enable-app-banners` and `chrome://flags/#bypass-app-banner-engagement-checks` in your chrome, and change these flags to **enabled**
#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
