### PR TITLE
Fix/marcelao api click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `SearchBar`: Issue where clicking on the search term would not work properly when `attemptPageTypeSearch` is enabled.
 
 ## [3.67.2] - 2019-08-29
 ### Fixed

--- a/react/components/SearchBar/components/ResultsList.js
+++ b/react/components/SearchBar/components/ResultsList.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo, useCallback } from 'react'
+import React, { Fragment, useMemo } from 'react'
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
@@ -44,8 +44,9 @@ const getLinkProps = element => {
   return { page, params, query }
 }
 
-const getHighlightClass = (highlightedIndex, index) => {
-  return highlightedIndex === index ? 'bg-muted-5' : ''
+const getListItemClassNames = ({itemIndex = -1, highlightedIndex, hasThumb} = {}) => {
+  const highlightClass = highlightedIndex === itemIndex ? 'bg-muted-5' : ''
+  return `pointer pa4 outline-0 ${styles.resultsItem} ${highlightClass} ${hasThumb ? 'flex justify-start' : 'db w-100'}`
 }
 
 /** List of search results to be displayed*/
@@ -85,13 +86,6 @@ const ResultsList = ({
     { dn: !isOpen || !inputValue }
   )
 
-  const listItemClassNames = classnames(styles.resultsItem, 'pa4 outline-0')
-
-  const getListItemClassNames = useCallback(({itemIndex, highlightedIndex, hasThumb}) => {
-    const highlightClass = getHighlightClass(highlightedIndex, itemIndex)
-    return `pointer ${hasThumb ? 'flex justify-start' : 'db w-100'} ${highlightClass} ${listItemClassNames}`
-  }, [listItemClassNames])
-
   const handleItemClick = () => {
     onClearInput()
     closeMenu()
@@ -113,7 +107,7 @@ const ResultsList = ({
       <ul className={listClassNames} {...getMenuProps()}>
         {isOpen ? (
           data.loading ? (
-            <div className={listItemClassNames}>
+            <div className={getListItemClassNames()}>
               <WrappedSpinner />
             </div>
           ) : (

--- a/react/components/SearchBar/components/ResultsList.js
+++ b/react/components/SearchBar/components/ResultsList.js
@@ -128,7 +128,8 @@ const ResultsList = ({
               >
                 {attemptPageTypeSearch ? (
                   <a
-                    href={`/${inputValue}`}
+                    href="#"
+                    onClick={event => event.preventDefault()}
                     className={getListItemClassNames({
                       itemIndex: 0,
                       highlightedIndex,

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -37,6 +37,7 @@ const SearchBar = ({
 
       if (element.term) {
         if (attemptPageTypeSearch) {
+          window.location.href = `/${element.term}`
           return
         }
 

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -24,6 +24,7 @@ const SearchBar = ({
   iconBlockClass,
   autoFocus,
   maxWidth,
+  attemptPageTypeSearch,
 }) => {
   const container = useRef()
   const { navigate } = useRuntime()
@@ -35,6 +36,10 @@ const SearchBar = ({
       }
 
       if (element.term) {
+        if (attemptPageTypeSearch) {
+          return
+        }
+
         navigate({
           page: 'store.search',
           params: { term: element.term },
@@ -124,6 +129,7 @@ const SearchBar = ({
                 <ResultsLists
                   parentContainer={container}
                   {...{
+                    attemptPageTypeSearch,
                     isOpen,
                     getMenuProps,
                     inputValue,

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -72,6 +72,7 @@ class SearchBarContainer extends Component {
       iconClasses,
       autoFocus,
       maxWidth,
+      attemptPageTypeSearch,
       placeholder = intl.formatMessage({
         id: 'store/search.placeholder',
       }),
@@ -93,6 +94,7 @@ class SearchBarContainer extends Component {
         hasIconLeft={hasIconLeft}
         iconClasses={iconClasses}
         maxWidth={maxWidth}
+        attemptPageTypeSearch={attemptPageTypeSearch}
       />
     )
   }


### PR DESCRIPTION
#### What problem is this solving?
Fixes issue where clicking on the search term would not work properly when `attemptPageTypeSearch` is enabled.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Go to https://lbebber--storecomponents.myvtex.com, type "samsung" on the search bar, and press "Enter". Do it again, but this time clicking on the "Search for "samsung"" item. Both should work the same


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [X] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

https://app.clubhouse.io/vtex/story/18663/attemptpagetypesearch-prop-on-search-bar-is-not-working
<!-- Put any relevant information that doesn't fit in the other sections here. -->
