### PR TITLE
Add new customToastURL prop to BuyButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `customToastURL` prop to `BuyButton`.
 
 ## [3.69.0] - 2019-09-18
 ### Added

--- a/docs/BuyButton.md
+++ b/docs/BuyButton.md
@@ -36,14 +36,15 @@ For now this block does not have any required or optional blocks.
 
 Through the Storefront, you can change the `BuyButton`'s behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name            | Type      | Description                                                                | Default value |
-| -------------------- | --------- | -------------------------------------------------------------------------- | ------------- |
-| `isOneClickBuy`      | `Boolean` | Should redirect to the checkout page or not                                | false         |
-| `shouldOpenMinicart` | `Boolean` | Should open the Minicart after clicking the button                         | false         |
-| `large`              | `Boolean` | Sets button to large style, filling whole width (like a `block`)           | -             |
-| `available`          | `Boolean` | If component is available or not                                           | true          |
-| `showToast`          | `Boolean` | If toast with feedback should be shown after add item request is processed | -             |
-| `showItemsPrice`     | `Boolean` | If you want to show the total price of items to be added to cart           | false         |
+| Prop name            | Type      | Description                                                                       | Default value |
+| -------------------- | --------- | --------------------------------------------------------------------------        | ------------- |
+| `isOneClickBuy`      | `Boolean` | Should redirect to the checkout page or not                                       | false         |
+| `shouldOpenMinicart` | `Boolean` | Should open the Minicart after clicking the button                                | false         |
+| `large`              | `Boolean` | Sets button to large style, filling whole width (like a `block`)                  | -             |
+| `available`          | `Boolean` | If component is available or not                                                  | true          |
+| `showToast`          | `Boolean` | If toast with feedback should be shown after add item request is processed        | -             |
+| `showItemsPrice`     | `Boolean` | If you want to show the total price of items to be added to cart                  | false         |
+| `customToastURL`     | `String`  | Set the link associated with the Toast created when adding an item to your cart.  | `/checkout/#/cart` |
 
 ### Styles API
 

--- a/react/components/BuyButton/Wrapper.js
+++ b/react/components/BuyButton/Wrapper.js
@@ -53,6 +53,7 @@ const BuyButtonWrapper = ({
   skuItems: propSkuItems,
   large: propLarge,
   disabled: propDisabled,
+  customToastURL,
 }) => {
   const valuesFromContext = useProduct()
 
@@ -114,6 +115,7 @@ const BuyButtonWrapper = ({
       shouldOpenMinicart={shouldOpenMinicart}
       setMinicartOpen={setMinicartOpen}
       disabled={disabled}
+      customToastURL={customToastURL}
     >
       {children || (
         <BuyButtonMessage showItemsPrice={showItemsPrice} skuItems={skuItems} />

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -61,6 +61,7 @@ export const BuyButton = ({
   children,
   large,
   disabled,
+  customToastURL = CONSTANTS.CHECKOUT_URL,
 }) => {
   const [isAddingToCart, setAddingToCart] = useState(false)
   const { showToast } = useContext(ToastContext)
@@ -76,7 +77,7 @@ export const BuyButton = ({
     if (!isNewItem) return translateMessage(CONSTANTS.DUPLICATE_CART_ITEM_ID)
 
     const isOffline = window && window.navigator && !window.navigator.onLine
-    const checkForOffline = (!isOffline)
+    const checkForOffline = !isOffline
       ? translateMessage(CONSTANTS.SUCCESS_MESSAGE_ID)
       : translateMessage(CONSTANTS.OFFLINE_BUY_MESSAGE_ID)
 
@@ -89,7 +90,7 @@ export const BuyButton = ({
     const action = success
       ? {
           label: translateMessage(CONSTANTS.SEE_CART_ID),
-          href: '/checkout/#/cart',
+          href: customToastURL,
         }
       : undefined
 
@@ -138,9 +139,10 @@ export const BuyButton = ({
 
       const addedItem =
         (linkStateItems &&
-        skuItems.filter(
-          skuItem => !!linkStateItems.find(({ id }) => id === skuItem.skuId)
-        )) || success
+          skuItems.filter(
+            skuItem => !!linkStateItems.find(({ id }) => id === skuItem.skuId)
+          )) ||
+        success
 
       const foundItem =
         orderFormItems &&
@@ -148,16 +150,17 @@ export const BuyButton = ({
 
       success = addedItem
 
-      showToastMessage = () => toastMessage({
-        success: success && success.length >= 1,
-        isNewItem: !foundItem,
-      })
+      showToastMessage = () =>
+        toastMessage({
+          success: success && success.length >= 1,
+          isNewItem: !foundItem,
+        })
 
       /* PWA */
-      if (promptOnCustomEvent === "addToCart" && showInstallPrompt) {
+      if (promptOnCustomEvent === 'addToCart' && showInstallPrompt) {
         showInstallPrompt()
       }
-  
+
       shouldOpenMinicart && !isOneClickBuy && setMinicartOpen(true)
     } catch (err) {
       console.error(err)
@@ -181,7 +184,11 @@ export const BuyButton = ({
       ) : (
         <Button
           block={large}
-          disabled={disabled || !available || (orderFormContext && orderFormContext.loading)}
+          disabled={
+            disabled ||
+            !available ||
+            (orderFormContext && orderFormContext.loading)
+          }
           onClick={handleAddToCart}
           isLoading={isAddingToCart}
         >
@@ -255,6 +262,8 @@ BuyButton.propTypes = {
   orderFormContext: PropTypes.object,
   /** If the button is disabled or not */
   disabled: PropTypes.bool,
+  /** A custom URL for the `VIEW CART` button inside the toast */
+  customToastURL: PropTypes.string,
 }
 
 export default BuyButton


### PR DESCRIPTION
#### What problem is this solving?

This new prop enables the user to customize the link associated with the Toast created when adding an item to your cart.

#### How should this be manually tested?

Add this item to the cart and click the link inside of the Toast component. You should be taken to https://google.com.

[Workspace](https://minicarttoast--storecomponents.myvtex.com/everyday-necessaire/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
