### PR TITLE
Feat/skuselector visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Set SKUSelector visibility in product context.
 
 ## [3.70.1] - 2019-09-19
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "eslint-config-vtex": "^11.0.0",
     "eslint-config-vtex-react": "^5.0.1",
     "prettier": "^1.18.2",
-    "typescript": "^3.6.3"
+    "typescript": "^3.6.3",
+    "@vtex/tsconfig": "^0.2.0"
   },
   "dependencies": {
     "react": "^16.8.6"

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -46,6 +46,7 @@ interface Props {
 const SKUSelectorWrapper: StorefrontFC<Props> = props => {
   const valuesFromContext = useProduct()
   const dispatch = useProductDispatch()
+
   const skuItems =
     props.skuItems != null
       ? props.skuItems
@@ -67,7 +68,7 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
   useEffect(() => {
     if (!shouldNotShow && dispatch) {
       dispatch({
-        type: 'SKU_SELECTOR_IS_VISIBLE',
+        type: 'SKU_SELECTOR_SET_IS_VISIBLE',
         args: { isVisible: !shouldNotShow },
       })
     }

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useEffect } from 'react'
 import useProduct from 'vtex.product-context/useProduct'
 import { pathOr } from 'ramda'
+import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
 
 import SKUSelector from './index'
 import { ProductItem, Variations } from './types'
@@ -44,6 +45,7 @@ interface Props {
 
 const SKUSelectorWrapper: StorefrontFC<Props> = props => {
   const valuesFromContext = useProduct()
+  const dispatch = useProductDispatch()
   const skuItems =
     props.skuItems != null
       ? props.skuItems
@@ -61,6 +63,15 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
     skuSelected.variations.length === 0
 
   const variations = useVariations(skuItems, shouldNotShow)
+
+  useEffect(() => {
+    if (!shouldNotShow && dispatch) {
+      dispatch({
+        type: 'SKU_SELECTOR_IS_VISIBLE',
+        args: { isVisible: !shouldNotShow },
+      })
+    }
+  }, [shouldNotShow, dispatch])
 
   if (shouldNotShow) {
     return null

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -66,7 +66,7 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
   const variations = useVariations(skuItems, shouldNotShow)
 
   useEffect(() => {
-    if (!shouldNotShow && dispatch) {
+    if (dispatch) {
       dispatch({
         type: 'SKU_SELECTOR_SET_IS_VISIBLE',
         args: { isVisible: !shouldNotShow },


### PR DESCRIPTION
#### What problem is this solving?

This variable in state is used initially by the `pickup-availability`(it should wait for user to select a SKU before doing anything). So we need to know if the SKU Selector is being displayed, if it is, only do a query when it is everything selected, if not, then there is only one item and we can do a query for that SKU.

#### How should this be manually tested?

To test navigate to a product with no SKU Selector and see that the state has `isVisible: false`. Then go to classic-shoes/p and see that the state has `isVisible: true`

https://fidsku--storecomponents.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
