### PR TITLE
Dont push empty objects to options array in buy-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- dont add input value to options in add to cart, if object is empty.
 
 ## [3.71.1] - 2019-09-24
 ### Changed

--- a/react/components/BuyButton/assemblyUtils.test.ts
+++ b/react/components/BuyButton/assemblyUtils.test.ts
@@ -1,4 +1,8 @@
-import { transformAssemblyOptions, ItemOption, InputValuesOption } from './assemblyUtils'
+import {
+  transformAssemblyOptions,
+  ItemOption,
+  InputValuesOption,
+} from './assemblyUtils'
 import { customBell, comboPizza, starColor } from './__mocks__/assemblyOptions'
 
 test('should transform assemblyOptions', () => {
@@ -9,7 +13,7 @@ test('should transform assemblyOptions', () => {
     customBell.items,
     {},
     parentPrice,
-    parentQuantity,
+    parentQuantity
   )
 
   expect(resultBell.options).toHaveLength(5)
@@ -23,7 +27,7 @@ test('should transform assemblyOptions', () => {
     comboPizza.items,
     {},
     parentPrice,
-    parentQuantity,
+    parentQuantity
   )
 
   expect(resultPizza.options).toHaveLength(2)
@@ -46,7 +50,7 @@ test('input values', () => {
     starColor.items,
     starColor.inputValues,
     parentPrice,
-    parentQuantity,
+    parentQuantity
   )
 
   expect(resultStar.options).toHaveLength(1)
@@ -58,4 +62,19 @@ test('input values', () => {
     'Back text': 'Verso',
     'Glossy print': true,
   })
+})
+
+test('empty input values should result in empty options', () => {
+  const parentPrice = 450
+  const parentQuantity = 1
+
+  const resultStar = transformAssemblyOptions(
+    starColor.items,
+    {
+      Customization: {},
+    },
+    parentPrice,
+    parentQuantity
+  )
+  expect(resultStar.options.length).toBe(0)
 })

--- a/react/components/BuyButton/assemblyUtils.ts
+++ b/react/components/BuyButton/assemblyUtils.ts
@@ -1,19 +1,24 @@
 type GroupId = string
 type GroupTypes = 'SINGLE' | 'TOGGLE' | 'MULTIPLE'
 
-export const sumAssembliesPrice = (assemblyOptions: Record<GroupId, AssemblyOptionItem[]>) => {
+export const sumAssembliesPrice = (
+  assemblyOptions: Record<GroupId, AssemblyOptionItem[]>
+) => {
   const cleanAssemblies = assemblyOptions || {}
   const assembliesGroupItems = Object.values(cleanAssemblies)
-  return assembliesGroupItems.reduce<number>((sum: number, groupItems: AssemblyOptionItem[]) => {
-    const groupPrice = groupItems.reduce<number>((groupSum, item) => {
-      const childrenPrice: number = item.children
-        ? sumAssembliesPrice(item.children)
-        : 0
-      const itemCost = item.price * item.quantity
-      return groupSum + itemCost + childrenPrice * item.quantity
-    }, 0)
-    return groupPrice + sum
-  }, 0)
+  return assembliesGroupItems.reduce<number>(
+    (sum: number, groupItems: AssemblyOptionItem[]) => {
+      const groupPrice = groupItems.reduce<number>((groupSum, item) => {
+        const childrenPrice: number = item.children
+          ? sumAssembliesPrice(item.children)
+          : 0
+        const itemCost = item.price * item.quantity
+        return groupSum + itemCost + childrenPrice * item.quantity
+      }, 0)
+      return groupPrice + sum
+    },
+    0
+  )
 }
 
 interface AssemblyOptionItem {
@@ -27,7 +32,7 @@ interface AssemblyOptionItem {
   seller: string
 }
 
-type InputValue = Record<string, string|boolean>
+type InputValue = Record<string, string | boolean>
 
 export interface AssemblyOptions {
   items: Record<GroupId, AssemblyOptionItem[]>
@@ -87,7 +92,7 @@ export const transformAssemblyOptions = (
   assemblyOptionsItems: Record<GroupId, AssemblyOptionItem[]> = {},
   inputValues: Record<GroupId, InputValue> = {},
   parentPrice: number,
-  parentQuantity: number,
+  parentQuantity: number
 ): ParsedAssemblyOptions => {
   // contains options sent as arguments to graphql mutation
   const options: Option[] = []
@@ -115,12 +120,12 @@ export const transformAssemblyOptions = (
       const {
         options: childrenOptions,
         assemblyOptions: childrenAssemblyOptions,
-      } = childrenAddedData || { options: undefined, assemblyOptions: undefined }
+      } = childrenAddedData || {
+        options: undefined,
+        assemblyOptions: undefined,
+      }
 
-      const {
-        quantity,
-        initialQuantity,
-      } = item
+      const { quantity, initialQuantity } = item
 
       if (quantity >= initialQuantity && quantity > 0) {
         added.push({
@@ -170,10 +175,13 @@ export const transformAssemblyOptions = (
   const assemblyInputValuesKeys: GroupId[] = Object.keys(inputValues)
 
   for (const groupId of assemblyInputValuesKeys) {
-    options.push({
-      assemblyId: groupId,
-      inputValues: inputValues[groupId],
-    })
+    const inputValuesObject = inputValues[groupId] || {}
+    if (Object.keys(inputValuesObject).length > 0) {
+      options.push({
+        assemblyId: groupId,
+        inputValues: inputValues[groupId],
+      })
+    }
   }
 
   return {


### PR DESCRIPTION
#### What problem is this solving?

Adding an item with customization to the cart, would add customization even if none were selected.

This PR fixes this, is combined with one in the `product-customizer`.

If inputValues is {}, dont push anything to `options` array.

#### How should this be manually tested?

To test, watch the console to see the console log I left. add to cart and see that the options resulting was an empty array.

If a customization was added, check that the resulting options array has an object.

https://fidelis2--storecomponents.myvtex.com/star-color-top/p

With customization:
![image](https://user-images.githubusercontent.com/4925068/65966907-1f3df880-e437-11e9-83c1-c40a1638f595.png)


With no customization:
![image](https://user-images.githubusercontent.com/4925068/65966938-2f55d800-e437-11e9-984e-63e744f6993f.png)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
