### PR TITLE
Prevent DiscountBadge from rendering with negative discount values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `DiscountBadge` would show negative percentages when the actual selling price of a product is higher then it's original one.
 
 ## [3.71.2] - 2019-10-03
 ### Fixed

--- a/react/components/DiscountBadge/index.js
+++ b/react/components/DiscountBadge/index.js
@@ -16,7 +16,7 @@ const calculateDiscountTax = (listPrice, sellingPrice) => {
  */
 const DiscountBadge = ({ listPrice, sellingPrice, label = '', children }) => {
   const percent = calculateDiscountTax(listPrice, sellingPrice)
-  const shouldShowPercentage = percent && percent >= 0.1
+  const shouldShowPercentage = percent && percent >= 0.01
 
   return (
     <div className={`${styles.discountContainer} relative dib`}>

--- a/react/components/DiscountBadge/index.js
+++ b/react/components/DiscountBadge/index.js
@@ -16,13 +16,13 @@ const calculateDiscountTax = (listPrice, sellingPrice) => {
  */
 const DiscountBadge = ({ listPrice, sellingPrice, label = '', children }) => {
   const percent = calculateDiscountTax(listPrice, sellingPrice)
+  const shouldShowPercentage = percent && percent >= 0.1
+
   return (
     <div className={`${styles.discountContainer} relative dib`}>
-      {percent ? (
+      {shouldShowPercentage ? (
         <div
-          className={`${
-            styles.discountInsideContainer
-          } t-mini white absolute right-0 pv2 ph3 bg-emphasis z-1`}
+          className={`${styles.discountInsideContainer} t-mini white absolute right-0 pv2 ph3 bg-emphasis z-1`}
         >
           <IOMessage id={label}>
             {labelValue => (


### PR DESCRIPTION
#### What problem is this solving?

The `DiscountBadge` component did not check for negative discounts that could happen if the product was being sold with a price greater than the original one. This could result in strange behavior, like `-0%` discount badges showing up.

https://app.clubhouse.io/vtex/story/23001/discount-badge-should-never-show-0

#### How should this be manually tested?

This is kind of a pain to test, but you can to [Workspace](https://imageslider--storecomponents.myvtex.com/), open your [React Devtools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi), select any of the `DiscountBadge`s rendered by our Shelf and tweak the values of `sellingPrice` and `listPrice` props to test what happens at different discount percentages.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and an overall reduction of technical debt -->

