### PR TITLE
Fix infinite loop in SKUSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Infinity loop in product page because of calling `onSKUSelected`.
 
 ## [3.76.0] - 2019-10-23
 ### Added

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -7,7 +7,7 @@ import React, {
   FC,
 } from 'react'
 import { useRuntime } from 'vtex.render-runtime'
-import { filter, head, isEmpty, compose, keys, length } from 'ramda'
+import { filter, head, isEmpty, compose, keys, length, path } from 'ramda'
 import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
 
 import SKUSelector from './components/SKUSelector'
@@ -166,13 +166,15 @@ const SKUSelectorContainer: FC<Props> = ({
     const initialVariations = skuSelected
       ? selectedVariationFromItem(parseSku(skuSelected), variations)
       : buildEmptySelectedVariation(variations)
+
+      setSelectedVariations(initialVariations)
+    }, [variations])
+
+  useEffect(() => {
     if (skuSelected && onSKUSelected) {
       onSKUSelected(skuSelected.itemId)
     }
-
-    setSelectedVariations(initialVariations)
-    
-  }, [variations, skuSelected])
+  }, [path(['itemId'], skuSelected)])
 
   const imagesMap = useImagesMap(parsedItems, variations, thumbnailImage)
 


### PR DESCRIPTION
#### What problem is this solving?

Infinity loop in the product page

#### How should this be manually tested?

[Workspace CO](https://skutest--samsungco.myvtex.com/tv-smart-4k-qled-328/p)
[Workspace AR](https://skutest--samsungar.myvtex.com/clear-view-cover-note10-plus/p)
[Workspace PE](https://skutest--samsungpe.myvtex.com/ru7400-uhd/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
