### PR TITLE
Make the collapse div of GradientCollapse to be always block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `GradientCollapse` in safari not giving the full size to it's children.
 
 ## [3.78.0] - 2019-10-24
 ### Fixed

--- a/react/__tests__/components/__snapshots__/GradientCollapse.test.js.snap
+++ b/react/__tests__/components/__snapshots__/GradientCollapse.test.js.snap
@@ -4,7 +4,7 @@ exports[`<GradientCollapse /> component should match snapshot 1`] = `
 <DocumentFragment>
   <div
     class="relative"
-    style="transition: 600ms ease-in-out; height: auto; overflow: hidden;"
+    style="transition: 600ms ease-in-out; height: auto; overflow: hidden; display: block;"
   >
     <div
       class="h-auto"

--- a/react/__tests__/components/__snapshots__/ProductDescription.test.js.snap
+++ b/react/__tests__/components/__snapshots__/ProductDescription.test.js.snap
@@ -15,7 +15,7 @@ exports[`<ProductDescription /> should match the snapshot with description 1`] =
     >
       <div
         class="relative"
-        style="transition: 600ms ease-in-out; height: auto; overflow: hidden;"
+        style="transition: 600ms ease-in-out; height: auto; overflow: hidden; display: block;"
       >
         <div
           class="h-auto"

--- a/react/__tests__/components/__snapshots__/ProductSpecifications.test.js.snap
+++ b/react/__tests__/components/__snapshots__/ProductSpecifications.test.js.snap
@@ -14,7 +14,7 @@ exports[`<ProductSpecifications /> component should match snapshot with table vi
     </h2>
     <div
       class="relative"
-      style="transition: 600ms ease-in-out; height: auto; overflow: hidden;"
+      style="transition: 600ms ease-in-out; height: auto; overflow: hidden; display: block;"
     >
       <div
         class="h-auto"
@@ -103,7 +103,7 @@ exports[`<ProductSpecifications /> component should match snapshot with tabs vie
         >
           <div
             class="relative"
-            style="transition: 600ms ease-in-out; height: auto; overflow: hidden;"
+            style="transition: 600ms ease-in-out; height: auto; overflow: hidden; display: block;"
           >
             <div
               class="h-auto"

--- a/react/components/GradientCollapse/index.js
+++ b/react/components/GradientCollapse/index.js
@@ -89,6 +89,7 @@ function GradientCollapse(props) {
             ...transitionStyle(transitionTime),
             height,
             overflow: 'hidden',
+            display: 'block',
           }}
           onTransitionEnd={calcMaxHeight}
           className="relative"


### PR DESCRIPTION
#### What problem is this solving?

`GradientCollapse` not working as it should in safari. This happens due some problem with Safari when you create an element that has `flex-direction: column` and it's children has `height: auto`

#### How should this be manually tested?

Go to this [workspace](https://loja--garmin.myvtex.com/monitor-cardiaco-gps-garmin-forerunner-245/p) using safari to see the bug.
[This one](https://ademir--garmin.myvtex.com/monitor-cardiaco-gps-garmin-forerunner-245/p) has the fix

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

before:
![image](https://user-images.githubusercontent.com/8517023/67508179-ddcff000-f666-11e9-9f66-08b9180fab17.png)

After:
![image](https://user-images.githubusercontent.com/8517023/67508205-eb857580-f666-11e9-8e1e-c1dde71cd13a.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
