### PR TITLE
Add new `collapsable` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `collapsable` prop to `ProductSpecifications`.
 
 ## [3.79.3] - 2019-10-29
 

--- a/docs/ProductSpecifications.md
+++ b/docs/ProductSpecifications.md
@@ -49,6 +49,7 @@ Through the Storefront, you can change the `ProductSpecifications`'s behavior an
 | visibleSpecifications | `String[]` | Type names of specifications you want to appear. Only provide one of `hiddenSpecifications` or `visibleSpecifications` | `[]`          |
 | showSpecificationsTab | `Boolean`  | Choose if you want to show the component with tabs mode                                                                | `false`       |
 | shoudCollapseOnTabChange | `Boolean` | If it should collapse if you change the tab | `false` |
+| collapsable | `mobileOnly`&#124;`desktopOnly`&#124;`always`&#124;`never` | Control when should the content of the specifications be collapsable   | `always` |
 
 ### Styles API
 

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,8 @@
     "vtex.format-currency": "0.x",
     "vtex.search-graphql": "0.x",
     "vtex.css-handles": "0.x",
-    "vtex.store-image": "0.x"
+    "vtex.store-image": "0.x",
+    "vtex.device-detector": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/__mocks__/vtex.device-detector.js
+++ b/react/__mocks__/vtex.device-detector.js
@@ -1,0 +1,4 @@
+export const useDevice = () => ({
+  isMobile: false,
+  device: 'desktop',
+})

--- a/react/components/ProductSpecifications/index.js
+++ b/react/components/ProductSpecifications/index.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl'
 import HtmlParser from 'react-html-parser'
 import { useCssHandles } from 'vtex.css-handles'
 import { Tabs, Tab } from 'vtex.styleguide'
+import { useDevice } from 'vtex.device-detector'
 
 import GradientCollapse from '../GradientCollapse/index'
 
@@ -26,6 +27,7 @@ const CSS_HANDLES = [
 const ProductSpecifications = ({
   tabsMode,
   specifications,
+  collapsable = 'always',
   hiddenSpecifications,
   visibleSpecifications,
   shouldCollapseInTabChange,
@@ -33,6 +35,13 @@ const ProductSpecifications = ({
   const [currentTab, setCurrentTab] = useState(0)
   const [collapsed, setCollapsed] = useState(true)
   const handles = useCssHandles(CSS_HANDLES)
+  const { isMobile } = useDevice()
+
+  const shouldBeCollapsable = !!(
+    collapsable === 'always' ||
+    (collapsable === 'mobileOnly' && isMobile) ||
+    (collapsable === 'desktopOnly' && !isMobile)
+  )
 
   const handleTabChange = tabIndex => {
     setCurrentTab(tabIndex)
@@ -90,6 +99,43 @@ const ProductSpecifications = ({
     </FormattedMessage>
   )
 
+  const specificationsTable = (
+    <table
+      className={`${handles.specificationsTable} w-100 bg-base border-collapse`}
+    >
+      <thead>
+        <tr>
+          <th
+            className={`${handles.specificationsTablePropertyHeading} w-50 b--muted-4 bb bt c-muted-2 t-body tl pa5`}
+          >
+            <FormattedMessage id="store/product-description.property" />
+          </th>
+          <th
+            className={`${handles.specificationsTableSpecificationHeading} w-50 b--muted-4 bb bt c-muted-2 t-body tl pa5`}
+          >
+            <FormattedMessage id="store/product-description.specification" />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {specificationItems.map((specification, i) => (
+          <tr key={i}>
+            <td
+              className={`${handles.specificationItemProperty} w-50 b--muted-4 bb pa5`}
+            >
+              {HtmlParser(specification.property)}
+            </td>
+            <td
+              className={`${handles.specificationItemSpecifications} w-50 b--muted-4 bb pa5`}
+            >
+              {HtmlParser(specification.specifications)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+
   const tableView = (
     <Fragment>
       {specifications.length > 0 && (
@@ -97,46 +143,17 @@ const ProductSpecifications = ({
           className={`${handles.specificationsTableContainer} mt9 mt0-l pl8-l`}
         >
           {specificationTitle}
-          <GradientCollapse
-            collapseHeight={220}
-            collapsed={collapsed}
-            onCollapsedChange={(_, newValue) => setCollapsed(newValue)}
-          >
-            <table
-              className={`${handles.specificationsTable} w-100 bg-base border-collapse`}
+          {shouldBeCollapsable ? (
+            <GradientCollapse
+              collapseHeight={220}
+              collapsed={collapsed}
+              onCollapsedChange={(_, newValue) => setCollapsed(newValue)}
             >
-              <thead>
-                <tr>
-                  <th
-                    className={`${handles.specificationsTablePropertyHeading} w-50 b--muted-4 bb bt c-muted-2 t-body tl pa5`}
-                  >
-                    <FormattedMessage id="store/product-description.property" />
-                  </th>
-                  <th
-                    className={`${handles.specificationsTableSpecificationHeading} w-50 b--muted-4 bb bt c-muted-2 t-body tl pa5`}
-                  >
-                    <FormattedMessage id="store/product-description.specification" />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {specificationItems.map((specification, i) => (
-                  <tr key={i}>
-                    <td
-                      className={`${handles.specificationItemProperty} w-50 b--muted-4 bb pa5`}
-                    >
-                      {HtmlParser(specification.property)}
-                    </td>
-                    <td
-                      className={`${handles.specificationItemSpecifications} w-50 b--muted-4 bb pa5`}
-                    >
-                      {HtmlParser(specification.specifications)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </GradientCollapse>
+              {specificationsTable}
+            </GradientCollapse>
+          ) : (
+            specificationsTable
+          )}
         </div>
       )}
     </Fragment>
@@ -154,13 +171,17 @@ const ProductSpecifications = ({
             onClick={() => handleTabChange(i)}
           >
             <div className={`${handles.specificationsTab} pb8 c-muted-1 pv6`}>
-              <GradientCollapse
-                collapseHeight={220}
-                collapsed={collapsed}
-                onCollapsedChange={(_, newValue) => setCollapsed(newValue)}
-              >
-                {HtmlParser(specification.specifications)}
-              </GradientCollapse>
+              {shouldBeCollapsable ? (
+                <GradientCollapse
+                  collapseHeight={220}
+                  collapsed={collapsed}
+                  onCollapsedChange={(_, newValue) => setCollapsed(newValue)}
+                >
+                  {HtmlParser(specification.specifications)}
+                </GradientCollapse>
+              ) : (
+                HtmlParser(specification.specifications)
+              )}
             </div>
           </Tab>
         ))}
@@ -195,6 +216,7 @@ ProductSpecifications.propTypes = {
   visibleSpecifications: PropTypes.array,
   /** Specifications which will be hidden (optional) */
   hiddenSpecifications: PropTypes.array,
+  collapsable: PropTypes.oneOf('always', 'never', 'desktopOnly', 'mobileOnly'),
 }
 
 export default ProductSpecifications

--- a/react/components/ProductSpecifications/index.js
+++ b/react/components/ProductSpecifications/index.js
@@ -37,10 +37,10 @@ const ProductSpecifications = ({
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
 
-  const shouldBeCollapsable = !!(
+  const shouldBeCollapsable = Boolean(
     collapsable === 'always' ||
-    (collapsable === 'mobileOnly' && isMobile) ||
-    (collapsable === 'desktopOnly' && !isMobile)
+      (collapsable === 'mobileOnly' && isMobile) ||
+      (collapsable === 'desktopOnly' && !isMobile)
   )
 
   const handleTabChange = tabIndex => {

--- a/react/components/ProductSpecifications/index.js
+++ b/react/components/ProductSpecifications/index.js
@@ -216,7 +216,12 @@ ProductSpecifications.propTypes = {
   visibleSpecifications: PropTypes.array,
   /** Specifications which will be hidden (optional) */
   hiddenSpecifications: PropTypes.array,
-  collapsable: PropTypes.oneOf('always', 'never', 'desktopOnly', 'mobileOnly'),
+  collapsable: PropTypes.oneOf([
+    'always',
+    'never',
+    'desktopOnly',
+    'mobileOnly',
+  ]),
 }
 
 export default ProductSpecifications


### PR DESCRIPTION
#### What problem is this solving?

Add a new `collapsable` prop to `ProductSpecifications`, that enables the user to control when should the content of the specifications be collapsable (whether it should or should not use `GradientCollapsable`).

#### How should this be manually tested?

[Workspace](https://productspecifications--ecowaterqa.myvtex.com/whirlpool-central-water-filtration-system/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
