### PR TITLE
Feature/initial mode sku

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "extends": "vtex-react",
+  "env": {
+    "browser": true,
+    "es6": true,
+    "jest": true
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "eslintIntegration": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - `BuyButton` now only add a product to the cart if all variations have one options selected.
+- Show an error next to the variation name of the `SKUSelector` if you try to add to the cart before selecting all variations of the product.
 
 ## [3.81.1] - 2019-11-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `initialSelection` to `SKUSelector`.
+
+### Changed
+- `BuyButton` now only add a product to the cart if all variations have one options selected.
 
 ## [3.81.1] - 2019-11-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `initialSelection` and `showVariationsErrorMessage` to `SKUSelector`.
--  `showTooltipOnSkuNotSelected`to `BuyButton`.
+-  `showTooltipOnSkuNotSelected` to `BuyButton`.
 
 ### Changed
 - `BuyButton` now only add a product to the cart if all variations have one options selected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `initialSelection` to `SKUSelector`.
+- `initialSelection` and `showVariationsErrorMessage` to `SKUSelector`.
+-  `showTooltipOnSkuNotSelected`to `BuyButton`.
 
 ### Changed
 - `BuyButton` now only add a product to the cart if all variations have one options selected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  `showTooltipOnSkuNotSelected` to `BuyButton`.
 
 ### Changed
-- `BuyButton` now only add a product to the cart if all variations have one options selected.
+- `BuyButton` now only adds a product to the cart if all variations have one option selected.
 - Show an error next to the variation name of the `SKUSelector` if you try to add to the cart before selecting all variations of the product.
 
 ## [3.81.1] - 2019-11-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `initialSelection` and `showVariationsErrorMessage` to `SKUSelector`.
--  `showTooltipOnSkuNotSelected` to `BuyButton`.
+- `showTooltipOnSkuNotSelected` to `BuyButton`.
 
 ### Changed
 - `BuyButton` now only adds a product to the cart if all variations have one option selected.

--- a/docs/BuyButton.md
+++ b/docs/BuyButton.md
@@ -38,14 +38,15 @@ Through the Storefront, you can change the `BuyButton`'s behavior and interface.
 
 | Prop name            | Type      | Description                                                                      | Default value      |
 | -------------------- | --------- | -------------------------------------------------------------------------------- | ------------------ |
-| `isOneClickBuy`      | `Boolean` | Should redirect to the checkout page or not                                      | false              |
-| `shouldOpenMinicart` | `Boolean` | Should open the Minicart after clicking the button                               | false              |
+| `isOneClickBuy`      | `Boolean` | Should redirect to the checkout page or not                                      | `false`              |
+| `shouldOpenMinicart` | `Boolean` | Should open the Minicart after clicking the button                               | `false`              |
 | `large`              | `Boolean` | Sets button to large style, filling whole width (like a `block`)                 | -                  |
-| `available`          | `Boolean` | If component is available or not                                                 | true               |
+| `available`          | `Boolean` | If component is available or not                                                 | `true`               |
 | `showToast`          | `Boolean` | If toast with feedback should be shown after add item request is processed       | -                  |
-| `showItemsPrice`     | `Boolean` | If you want to show the total price of items to be added to cart                 | false              |
+| `showItemsPrice`     | `Boolean` | If you want to show the total price of items to be added to cart                 | `false`              |
 | `customToastURL`     | `String`  | Set the link associated with the Toast created when adding an item to your cart. | `/checkout/#/cart` |
 | `shouldAddToCart`    | `Boolean` | If it should add to cart when clicked                                             | true          |
+| `showTooltipOnSkuNotSelected` | `Boolean` | If it should a tooltip when you click the button but there's no SKU selected | `false` |
 
 ### Styles API
 

--- a/docs/BuyButton.md
+++ b/docs/BuyButton.md
@@ -46,7 +46,7 @@ Through the Storefront, you can change the `BuyButton`'s behavior and interface.
 | `showItemsPrice`     | `Boolean` | If you want to show the total price of items to be added to cart                 | `false`              |
 | `customToastURL`     | `String`  | Set the link associated with the Toast created when adding an item to your cart. | `/checkout/#/cart` |
 | `shouldAddToCart`    | `Boolean` | If it should add to cart when clicked                                             | true          |
-| `showTooltipOnSkuNotSelected` | `Boolean` | If it should a tooltip when you click the button but there's no SKU selected | `false` |
+| `showTooltipOnSkuNotSelected` | `Boolean` | If it should show a tooltip when you click the button but there's no SKU selected | `true` |
 
 ### Styles API
 

--- a/docs/SKUSelector.md
+++ b/docs/SKUSelector.md
@@ -72,6 +72,15 @@ These are properties that you can customize in your `blocks.json` file.
 | imageHeight | `number | object` | Height of the thumbnail, if you pass an object it expects two attributes, `desktop` and `mobile`, and the value of both is the height on each type of device | `'auto'` |
 | imageWidth | `number | object` | It works same way as `imageHeight` | `'auto'` |
 | showVariationsLabels | `boolean` | If should show the variations name | `true` |
+| initialSelection | `InitialSelectionEnum` | Control the initial selection chosen for the variations when page is loaded. | `complete` |
+| showVariationsErrorMessage | `boolean`| If should show an error message when you click in the `BuyButton` but didn't select an option of each variation | `false` |
+
+Values and description for `InitialSelectionEnum`:
+| Value | Name | Description |
+| ------------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `complete` | Complete | It will selected the variations values for the first SKU available in the product possible items |
+| `image` | Image | It will select the variation for variations with images (like Color). All other variations will be unselected |
+| `empty` | Empty | All variations will appear as unselected on first load |
 
 #### Content API
 

--- a/docs/SKUSelector.md
+++ b/docs/SKUSelector.md
@@ -73,7 +73,7 @@ These are properties that you can customize in your `blocks.json` file.
 | imageWidth | `number | object` | It works same way as `imageHeight` | `'auto'` |
 | showVariationsLabels | `boolean` | If should show the variations name | `true` |
 | initialSelection | `InitialSelectionEnum` | Control the initial selection chosen for the variations when page is loaded. | `complete` |
-| showVariationsErrorMessage | `boolean`| If should show an error message when you click in the `BuyButton` but didn't select an option of each variation | `false` |
+| showVariationsErrorMessage | `boolean`| If should show an error message when you click in the `BuyButton` but didn't select an option of each variation | `true` |
 
 Values and description for `InitialSelectionEnum`:
 | Value | Name | Description |

--- a/messages/context.json
+++ b/messages/context.json
@@ -156,6 +156,7 @@
   "admin/editor.logo.mobileHeight.title": "Title of mobileHeight property of Logo",
   "admin/editor.logo.mobileHeight.description": "Description of mobileHeight property of Logo",
   "store/skuSelector.seeMore": "Press button to see remaining items",
+  "store/sku-selector.variation.select-an-option": "You have to select an option",
   "admin/editor.skuSelector.title": "Title of SKU Selector component",
   "admin/editor.skuSelector.description": "Description of SKU Selector component",
   "admin/editor.skuSelector.seeMoreLabel.title": "Title of seeMoreLabel property",

--- a/messages/context.json
+++ b/messages/context.json
@@ -38,6 +38,7 @@
   "store/buybutton.buy-success-duplicate": "buybutton.buy-success-duplicate",
   "store/buybutton.add-failure": "buybutton.add-failure",
   "store/buybutton.buy-offline-success": "buybutton.buy-offline-success",
+  "store/buybutton.select-sku-variations": "Please select an option of each variation",
   "store/buybutton.see-cart": "Button label on the notification that pops up when the user adds an item to the cart, prompting the user to see said cart",
   "store/technicalspecifications.title": "technicalspecifications.title",
   "store/availability-subscriber.title": "availability-subscriber.title",

--- a/messages/en.json
+++ b/messages/en.json
@@ -38,6 +38,7 @@
   "store/buybutton.buy-success-duplicate": "Item already in your cart",
   "store/buybutton.add-failure": "Something went wrong and the item wasn't added to your cart!",
   "store/buybutton.buy-offline-success": "Item added to your offline cart",
+  "store/buybutton.select-sku-variations": "Please select an option of each variation",
   "store/buybutton.see-cart": "View cart",
   "store/technicalspecifications.title": "Technical Specifications",
   "store/availability-subscriber.title": "This product isn't available right now",

--- a/messages/en.json
+++ b/messages/en.json
@@ -156,6 +156,7 @@
   "admin/editor.logo.mobileHeight.title": "Mobile Height",
   "admin/editor.logo.mobileHeight.description": "Height to be used on mobile. If empty, will use the provided height value.",
   "store/skuSelector.seeMore": "See {quantity} more",
+  "store/sku-selector.variation.select-an-option": "Select an option",
   "admin/editor.skuSelector.title": "SKU Selector",
   "admin/editor.skuSelector.description": "Component that displays different given variations of an item for user to choose",
   "admin/editor.skuSelector.seeMoreLabel.title": "See more label",

--- a/messages/es.json
+++ b/messages/es.json
@@ -156,6 +156,7 @@
   "admin/editor.logo.mobileHeight.title": "Altura móvil",
   "admin/editor.logo.mobileHeight.description": "Altura que se utilizará en el dispositivo móvil. Si está vacío, utilizará el valor de altura proporcionado",
   "store/skuSelector.seeMore": "Ver {quantity} más",
+  "store/sku-selector.variation.select-an-option": "Selecciona una opción",
   "admin/editor.skuSelector.title": "Selector de SKU",
   "admin/editor.skuSelector.description": "Componente que muestra diferentes variaciones dadas de un elemento para que el usuario elija",
   "admin/editor.skuSelector.seeMoreLabel.title": "Rótulo del botón ver más",

--- a/messages/es.json
+++ b/messages/es.json
@@ -38,6 +38,7 @@
   "store/buybutton.buy-success-duplicate": "Ítem ya en tu carrito",
   "store/buybutton.add-failure": "¡Algo salió mal y el artículo no se agregó a tu carrito!",
   "store/buybutton.buy-offline-success": "Ítem agregado a su carrito offline",
+  "store/buybutton.select-sku-variations": "Por favor seleccione una opción de cada variación",
   "store/buybutton.see-cart": "Ver carrito",
   "store/technicalspecifications.title": "Especificaciones Técnicas",
   "store/availability-subscriber.title": "Este producto no está disponible actualmente",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -156,6 +156,7 @@
   "admin/editor.logo.mobileHeight.title": "Altura do celular",
   "admin/editor.logo.mobileHeight.description": "Altura a ser usada no celular. Se vazia, usará o valor de altura fornecido.",
   "store/skuSelector.seeMore": "Ver mais {quantity}",
+  "store/sku-selector.variation.select-an-option": "Selecione uma opção",
   "admin/editor.skuSelector.title": "Seletor de SKU",
   "admin/editor.skuSelector.description": "Componente que exibe diferentes variações dadas de um produto para o usuário escolher",
   "admin/editor.skuSelector.seeMoreLabel.title": "Rótulo do botão ver mais",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -38,6 +38,7 @@
   "store/buybutton.buy-success-duplicate": "Item já no seu carrinho",
   "store/buybutton.add-failure": "Algo deu errado e o item não pode ser adicionado ao seu carrinho!",
   "store/buybutton.buy-offline-success": "Item adicionado ao seu carrinho offline.",
+  "store/buybutton.select-sku-variations": "Por favor selecione uma opção de cada variação",
   "store/buybutton.see-cart": "Ver carrinho",
   "store/technicalspecifications.title": "Especificações Técnicas",
   "store/availability-subscriber.title": "Este produto não está disponível no momento",

--- a/react/__mocks__/vtex.product-context/useProduct.js
+++ b/react/__mocks__/vtex.product-context/useProduct.js
@@ -1,2 +1,12 @@
-const useProduct = jest.fn()
+const useProduct = jest.fn(() => {
+  return {
+    buyButton: {
+      clicked: false,
+    },
+    skuSelector: {
+      areAllVariationsSelected: true,
+    }
+  }
+})
+
 export default useProduct

--- a/react/__tests__/components/__snapshots__/BuyButton.test.js.snap
+++ b/react/__tests__/components/__snapshots__/BuyButton.test.js.snap
@@ -11,6 +11,7 @@ exports[`<BuyButton /> should match snapshot loading 1`] = `
 exports[`<BuyButton /> should match snapshot normal 1`] = `
 <DocumentFragment>
   <button
+    data-block="true"
     data-isloading="false"
   >
     Test
@@ -21,6 +22,7 @@ exports[`<BuyButton /> should match snapshot normal 1`] = `
 exports[`<BuyButton /> should match snapshot unavailable 1`] = `
 <DocumentFragment>
   <button
+    data-block="true"
     data-isloading="false"
     disabled=""
   >

--- a/react/__tests__/components/__snapshots__/SKUSelector.test.js.snap
+++ b/react/__tests__/components/__snapshots__/SKUSelector.test.js.snap
@@ -17,7 +17,7 @@ exports[`<SKUSelector /> should match the snapshot 1`] = `
           <span
             class="skuSelectorName c-muted-1 t-small overflow-hidden"
           >
-            Color
+            Color 
           </span>
         </div>
         <div

--- a/react/components/BuyButton/Wrapper.js
+++ b/react/components/BuyButton/Wrapper.js
@@ -75,6 +75,7 @@ const BuyButtonWrapper = ({
   disabled: propDisabled,
   shouldAddToCart,
   customToastURL,
+  showTooltipOnSkuNotSelected,
 }) => {
   const valuesFromContext = useProduct()
 
@@ -138,6 +139,7 @@ const BuyButtonWrapper = ({
       disabled={disabled}
       customToastURL={customToastURL}
       shouldAddToCart={shouldAddToCart}
+      showTooltipOnSkuNotSelected={showTooltipOnSkuNotSelected}
     >
       {children || (
         <BuyButtonMessage showItemsPrice={showItemsPrice} skuItems={skuItems} />

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -191,10 +191,7 @@ export const BuyButton = ({
 
   const handleClick = e => {
     dispatch({ type: 'SET_BUY_BUTTON_CLICKED', args: { clicked: true } })
-    if (!skuSelector.areAllVariationsSelected) {
-      // TODO show toast or something
-      return
-    } else if (shouldAddToCart) {
+    if (skuSelector.areAllVariationsSelected && shouldAddToCart) {
       handleAddToCart(e)
     }
   }

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -65,11 +65,11 @@ export const BuyButton = ({
   available = true,
   orderFormContext,
   isOneClickBuy = false,
-  children: childrenProp,
+  children,
   disabled: disabledProp,
   shouldAddToCart = true,
   shouldOpenMinicart = false,
-  showTooltipOnSkuNotSelected = false,
+  showTooltipOnSkuNotSelected = true,
   customToastURL = CONSTANTS.CHECKOUT_URL,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -201,16 +201,13 @@ export const BuyButton = ({
   }
 
   const disabled = disabledProp || !available || (orderFormContext && orderFormContext.loading)
-  let children = childrenProp
-  if (!available) {
-    children = (
-      <FormattedMessage id="store/buyButton-label-unavailable">
-          {message => (
-            <span className={handles.buyButtonText}>{message}</span>
-          )}
-      </FormattedMessage>
-    )
-  }
+  const unavailableLabel = (
+    <FormattedMessage id="store/buyButton-label-unavailable">
+        {message => (
+          <span className={handles.buyButtonText}>{message}</span>
+        )}
+    </FormattedMessage>
+  )
 
   const tooltipLabel = (
     <FormattedMessage id={CONSTANTS.TOOLTIP_ERROR_MESSAGE_ID}>
@@ -227,7 +224,7 @@ export const BuyButton = ({
       onClick={handleClick}
       isLoading={isAddingToCart}
     >
-      {children}
+      {available ? children : unavailableLabel}
     </Button>
   ) : (
     <Tooltip trigger="click" label={tooltipLabel}>
@@ -237,7 +234,7 @@ export const BuyButton = ({
         onClick={handleClick}
         isLoading={isAddingToCart}
         >
-        {children}
+        {available ? children : unavailableLabel}
       </Button>
     </Tooltip>
   )

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -6,6 +6,9 @@ import ContentLoader from 'react-content-loader'
 import { useRuntime } from 'vtex.render-runtime'
 import { usePWA } from 'vtex.store-resources/PWAContext'
 import { useCssHandles } from 'vtex.css-handles'
+import useProduct from 'vtex.product-context/useProduct'
+import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
+
 
 import { Button, ToastContext } from 'vtex.styleguide'
 
@@ -70,6 +73,8 @@ export const BuyButton = ({
   const handles = useCssHandles(CSS_HANDLES)
   const [isAddingToCart, setAddingToCart] = useState(false)
   const { showToast } = useContext(ToastContext)
+  const { skuSelector } = useProduct()
+  const dispatch = useProductDispatch()
   const { settings = {}, showInstallPrompt } = usePWA() || {}
   const { promptOnCustomEvent } = settings
   const translateMessage = useCallback(id => intl.formatMessage({ id: id }), [
@@ -182,6 +187,16 @@ export const BuyButton = ({
     }, 500)
   }
 
+  const handleClick = e => {
+    dispatch({ type: 'SET_BUY_BUTTON_CLICKED', args: { clicked: true } })
+    if (!skuSelector.areAllVariationsSelected) {
+      // TODO show toast or something
+      return
+    } else if (shouldAddToCart) {
+      handleAddToCart(e)
+    }
+  }
+
   return (
     <Fragment>
       {!skuItems ? (
@@ -195,7 +210,7 @@ export const BuyButton = ({
             (orderFormContext && orderFormContext.loading)
           }
           isLoading={isAddingToCart}
-          onClick={e => shouldAddToCart && handleAddToCart(e)}
+          onClick={handleClick}
         >
           {available ? (
             children

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -55,20 +55,21 @@ const skuItemToMinicartItem = item => {
  * Adds a list of sku items to the cart.
  */
 export const BuyButton = ({
-  isOneClickBuy = false,
-  shouldOpenMinicart = false,
-  available = true,
   intl,
+  large,
   addToCart,
-  setMinicartOpen,
   skuItems,
   onAddStart,
   onAddFinish,
+  setMinicartOpen,
+  available = true,
   orderFormContext,
+  isOneClickBuy = false,
   children: childrenProp,
-  large,
   disabled: disabledProp,
   shouldAddToCart = true,
+  shouldOpenMinicart = false,
+  showTooltipOnSkuNotSelected = false,
   customToastURL = CONSTANTS.CHECKOUT_URL,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -222,7 +223,7 @@ export const BuyButton = ({
     </FormattedMessage>
   )
 
-  return skuSelector.areAllVariationsSelected ? (
+  return !showTooltipOnSkuNotSelected || skuSelector.areAllVariationsSelected ? (
     <Button
       block={large}
       disabled={disabled}

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -4,7 +4,7 @@ import { pathOr, pick } from 'ramda'
 import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
 
 import SKUSelector from './index'
-import { ProductItem, Variations } from './types'
+import { ProductItem, Variations, InitialSelectionType } from './types'
 import { useResponsiveValues } from 'vtex.responsive-values'
 
 const useVariations = (skuItems: ProductItem[], shouldNotShow: boolean, visibleVariations?: string[]) => {
@@ -56,6 +56,7 @@ interface Props {
   showVariationsLabels?: boolean
   variationsSpacing?: number
   showVariationsErrorMessage?: boolean
+  initialSelection?: InitialSelectionType
 }
 
 const SKUSelectorWrapper: StorefrontFC<Props> = props => {
@@ -103,13 +104,14 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
       maxItems={props.maxItems}
       imageHeight={imageHeight}
       seeMoreLabel={props.seeMoreLabel}
-      variationsSpacing={props.variationsSpacing}
       onSKUSelected={props.onSKUSelected}
+      thumbnailImage={props.thumbnailImage}
+      variationsSpacing={props.variationsSpacing}
+      initialSelection={props.initialSelection}
       showVariationsLabels={props.showVariationsLabels}
       hideImpossibleCombinations={props.hideImpossibleCombinations}
       showVariationsErrorMessage={props.showVariationsErrorMessage}
       showValueNameForImageVariation={props.showValueNameForImageVariation}
-      thumbnailImage={props.thumbnailImage}
     />
   )
 }

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -55,6 +55,7 @@ interface Props {
   visibleVariations?: string[]
   showVariationsLabels?: boolean
   variationsSpacing?: number
+  showVariationsErrorMessage?: boolean
 }
 
 const SKUSelectorWrapper: StorefrontFC<Props> = props => {
@@ -106,6 +107,7 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
       onSKUSelected={props.onSKUSelected}
       showVariationsLabels={props.showVariationsLabels}
       hideImpossibleCombinations={props.hideImpossibleCombinations}
+      showVariationsErrorMessage={props.showVariationsErrorMessage}
       showValueNameForImageVariation={props.showValueNameForImageVariation}
       thumbnailImage={props.thumbnailImage}
     />

--- a/react/components/SKUSelector/components/ErrorMessage.tsx
+++ b/react/components/SKUSelector/components/ErrorMessage.tsx
@@ -1,25 +1,22 @@
 import React from 'react'
 import { useCssHandles } from 'vtex.css-handles'
-import { injectIntl, InjectedIntlProps, defineMessages } from 'react-intl'
-
-const messages = defineMessages({
-  selectOption: {
-    id: 'store/sku-selector.variation.select-an-option',
-    defaultMessage: ''
-  },
-})
+import { FormattedMessage } from 'react-intl'
 
 const CSS_HANDLES = ['errorMessage'] as const
 
-function ErrorMessage({ intl }: InjectedIntlProps) {
+function ErrorMessage() {
   const handles = useCssHandles(CSS_HANDLES)
   const className = `${handles.errorMessage} c-danger`
 
   return (
-    <span className={className}>
-      {intl.formatMessage(messages.selectOption)}
-    </span>
+    <FormattedMessage id="store/sku-selector.variation.select-an-option">
+      {message => (
+      <span className={className}>
+        {message}
+      </span>
+      )}
+    </FormattedMessage>
   )
 }
 
-export default injectIntl(ErrorMessage)
+export default ErrorMessage

--- a/react/components/SKUSelector/components/ErrorMessage.tsx
+++ b/react/components/SKUSelector/components/ErrorMessage.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+import { injectIntl, InjectedIntlProps, defineMessages } from 'react-intl'
+
+const messages = defineMessages({
+  selectOption: {
+    id: 'store/sku-selector.variation.select-an-option',
+    defaultMessage: ''
+  },
+})
+
+const CSS_HANDLES = ['errorMessage'] as const
+
+function ErrorMessage({ intl }: InjectedIntlProps) {
+  const handles = useCssHandles(CSS_HANDLES)
+  const className = `${handles.errorMessage} c-danger`
+
+  return (
+    <span className={className}>
+      {intl.formatMessage(messages.selectOption)}
+    </span>
+  )
+}
+
+export default injectIntl(ErrorMessage)

--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -34,8 +34,9 @@ interface Props {
   showBorders?: boolean
   imageHeight?: number
   imageWidth?: number
-  showVariationsLabels: boolean,
+  showVariationsLabels: boolean
   variationsSpacing?: number
+  showVariationsErrorMessage: boolean
 }
 
 const isSkuAvailable = compose<
@@ -232,6 +233,7 @@ const SKUSelector: FC<Props> = ({
   showVariationsLabels,
   hideImpossibleCombinations,
   showValueNameForImageVariation,
+  showVariationsErrorMessage,
 }) => {
   const [displayVariations, setDisplayVariations] = useState<
     DisplayVariation[] | null
@@ -299,6 +301,7 @@ const SKUSelector: FC<Props> = ({
             showLabel={showVariationsLabels}
             containerClasses={variationClasses}
             key={`${variationOption.name}-${index}`}
+            showErrorMessage={showVariationsErrorMessage}
             showValueNameForImageVariation={showValueNameForImageVariation}
           />
         )

--- a/react/components/SKUSelector/components/Variation.tsx
+++ b/react/components/SKUSelector/components/Variation.tsx
@@ -17,6 +17,8 @@ import { stripUrl, isColor, slug } from '../utils'
 import styles from '../styles.css'
 import { imageUrlForSize, VARIATION_IMG_SIZE } from '../../module/images'
 import { DisplayVariation } from '../types'
+import useProduct from 'vtex.product-context/useProduct'
+import ErrorMessage from './ErrorMessage'
 
 interface Props {
   variation: DisplayVariation
@@ -55,6 +57,7 @@ const Variation: FC<Props> = ({
   const { name, options } = variation
   const [showAll, setShowAll] = useState(false)
   const visibleItemsWhenCollapsed = maxItems - ITEMS_VISIBLE_THRESHOLD
+  const { buyButton } = useProduct()
 
   useEffect(() => {
     const selectedOptionPosition = findSelectedOption(selectedItem)(options)
@@ -90,7 +93,7 @@ const Variation: FC<Props> = ({
               styles.skuSelectorName
               } c-muted-1 t-small overflow-hidden`}
           >
-            {name}
+            {name} {buyButton.clicked && !selectedItem && (<ErrorMessage />)}
           </span>)}
           {displayImage && selectedItem && showValueNameForImageVariation && (
             <Fragment>

--- a/react/components/SKUSelector/components/Variation.tsx
+++ b/react/components/SKUSelector/components/Variation.tsx
@@ -73,18 +73,17 @@ const Variation: FC<Props> = ({
   const shouldCollapse = !showAll && options.length > maxItems
 
   const overflowQuantity = options.length - visibleItemsWhenCollapsed
-
   const displayOptions = options.slice(
     0,
     shouldCollapse ? visibleItemsWhenCollapsed : options.length
-  )
-  const showAllAction = useCallback(() => setShowAll(true), [setShowAll])
-  const containerClasses = classnames(
-    'flex flex-column',
-    containerClassesProp,
-    styles.skuSelectorSubcontainer,
-    `${styles.skuSelectorSubcontainer}--${slug(name)}`, 
-  )
+    )
+    const showAllAction = useCallback(() => setShowAll(true), [setShowAll])
+    const containerClasses = classnames(
+      'flex flex-column',
+      containerClassesProp,
+      styles.skuSelectorSubcontainer,
+      `${styles.skuSelectorSubcontainer}--${slug(name)}`, 
+      )
 
   return (
     <div className={containerClasses}>

--- a/react/components/SKUSelector/components/Variation.tsx
+++ b/react/components/SKUSelector/components/Variation.tsx
@@ -32,6 +32,7 @@ interface Props {
   showBorders?: boolean
   showLabel: boolean
   containerClasses?: string
+  showErrorMessage: boolean
 }
 
 const ITEMS_VISIBLE_THRESHOLD = 2
@@ -45,12 +46,13 @@ const Variation: FC<Props> = ({
   maxItems,
   showLabel,
   variation,
+  imageWidth,
+  imageHeight,
+  showBorders,
   maxSkuPrice,
   seeMoreLabel,
   selectedItem,
-  imageHeight,
-  imageWidth,
-  showBorders,
+  showErrorMessage,
   showValueNameForImageVariation,
   containerClasses: containerClassesProp,
 }) => {
@@ -93,7 +95,7 @@ const Variation: FC<Props> = ({
               styles.skuSelectorName
               } c-muted-1 t-small overflow-hidden`}
           >
-            {name} {buyButton.clicked && !selectedItem && (<ErrorMessage />)}
+            {name} {showErrorMessage && buyButton.clicked && !selectedItem && (<ErrorMessage />)}
           </span>)}
           {displayImage && selectedItem && showValueNameForImageVariation && (
             <Fragment>

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -145,7 +145,7 @@ const SKUSelectorContainer: FC<Props> = ({
   variationsSpacing,
   showVariationsLabels = true,
   hideImpossibleCombinations = true,
-  showVariationsErrorMessage = false,
+  showVariationsErrorMessage = true,
   showValueNameForImageVariation = false,
   initialSelection = InitialSelectionType.complete,
 }) => {
@@ -169,11 +169,11 @@ const SKUSelectorContainer: FC<Props> = ({
   }
 
   const getNewSelectedVariations = useCallback(() => {
-    const hasSkuInquery = Boolean(query && query.skuId)
+    const hasSKuInQuery = Boolean(query && query.skuId)
     const parsedSku = parseSku(skuSelected)
     const emptyVariations = buildEmptySelectedVariation(variations)
   
-    if (hasSkuInquery || initialSelection === InitialSelectionType.complete) {
+    if (hasSKuInQuery || initialSelection === InitialSelectionType.complete) {
        return selectedVariationFromItem(parsedSku, variations)
     } else if (initialSelection === InitialSelectionType.image) {
       const colorVariationName = parsedSku.variations.find(isColor)

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -124,6 +124,7 @@ interface Props {
   thumbnailImage?: string
   showVariationsLabels?: boolean
   variationsSpacing?: number
+  showVariationsErrorMessage?: boolean
 }
 
 /**
@@ -136,13 +137,14 @@ const SKUSelectorContainer: FC<Props> = ({
   maxItems = 10,
   variations,
   skuSelected,
-  hideImpossibleCombinations = true,
-  showValueNameForImageVariation = false,
-  thumbnailImage,
-  imageHeight,
   imageWidth,
+  imageHeight,
+  thumbnailImage,
   variationsSpacing,
   showVariationsLabels = true,
+  hideImpossibleCombinations = true,
+  showVariationsErrorMessage = false,
+  showValueNameForImageVariation = false,
 }) => {
   const variationsCount = keyCount(variations)
   const [
@@ -259,6 +261,7 @@ const SKUSelectorContainer: FC<Props> = ({
       variationsSpacing={variationsSpacing}
       showVariationsLabels={showVariationsLabels}
       hideImpossibleCombinations={hideImpossibleCombinations}
+      showVariationsErrorMessage={showVariationsErrorMessage}
       showValueNameForImageVariation={showValueNameForImageVariation}
     />
   )

--- a/react/components/SKUSelector/types/index.ts
+++ b/react/components/SKUSelector/types/index.ts
@@ -15,6 +15,12 @@ export interface ProductItem {
   }[]
 }
 
+export enum InitialSelectionType {
+  complete = 'complete',
+  image = 'image',
+  empty = 'empty'
+}
+
 export interface SelectorProductItem extends Omit<ProductItem, 'variations'> {
   variations: string[]
   variationValues: Record<string, string>

--- a/react/typings/vtex.css-handles.d.ts
+++ b/react/typings/vtex.css-handles.d.ts
@@ -1,0 +1,3 @@
+declare module 'vtex.css-handles' {
+  const useCssHandles: any
+}

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -37,6 +37,9 @@ declare module 'vtex.product-context/useProduct' {
       isVisible: boolean
       areAllVariationsSelected: boolean
     }
+    buyButton: {
+      clicked: boolean
+    }
     assemblyOptions: {
       items: Record<GroupId, AssemblyOptionItem[]>
       inputValues: Record<GroupId, InputValues>

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -1,6 +1,7 @@
 declare module 'vtex.render-runtime' {
   interface Runtime {
-    setQuery: (vars: { skuId: string }, options?: { replace?: boolean }) => void
+    setQuery: (vars: { skuId: string }, options?: { replace?: boolean } ) => void
+    query?: { skuId?: string }
   }
   export const useRuntime: () => Runtime
 }

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -5,4 +5,5 @@ declare module 'vtex.styleguide' {
   export const Button: any
   export const Modal: any
   export const withToast: any
+  export const Tooltip: any
 }


### PR DESCRIPTION
#### What problem is this solving?

Add prop `initialSelection` to SKUSelector, so you can go to the page of a product and no SKU is selected

#### How should this be manually tested?

[storecomponents workspace](https://skuinitial--storecomponents.myvtex.com/classic-shoes/p) `initialSelection = 'complete'` (default value)
[garmin workspace](https://skuinitial--garmin.myvtex.com/monitor-cardiaco-gps-garmin-forerunner-45/p) `initialSelection = 'empty'`
[als workspace](https://skuinitial--alssports.myvtex.com/adidas-shorts-must-have-french-terry/p) `initialSelection = 'image'`

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [X] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
