### PR TITLE
Add items to cart validating with id and seller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Support to block class.
 
+### Fixed
+- Verify that the item has been added to the cart by filtering `skuId` and `seller` in the BuyButton.
+
 ## [3.85.0] - 2019-11-12
 ### Added
 - Option to edit `visibleSpecifications` and `hiddenSpecifications` in Site Editor.

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -148,7 +148,7 @@ export const BuyButton = ({
         const { items } = mutationRes.data.addItem
 
         success = skuItems.filter(
-          skuItem => !!items.find(({ id }) => id === skuItem.skuId)
+          skuItem => !!items.find(({ id, seller }) => id === skuItem.skuId && seller === skuItem.seller)
         )
         await orderFormContext.refetch().catch(() => null)
       }
@@ -156,13 +156,12 @@ export const BuyButton = ({
       const addedItem =
         (linkStateItems &&
           skuItems.filter(
-            skuItem => !!linkStateItems.find(({ id }) => id === skuItem.skuId)
+            skuItem => !!linkStateItems.find(({ id, seller }) => id === skuItem.skuId && seller === skuItem.seller)
           )) ||
         success
 
-      const foundItem =
-        orderFormItems &&
-        orderFormItems.filter(item => item.id === addedItem[0].skuId).length > 0
+      const foundItem = addedItem.length && orderFormItems && orderFormItems
+        .filter(item => item.id === addedItem[0].skuId && item.seller === addedItem[0].seller).length > 0
 
       success = addedItem
 


### PR DESCRIPTION
#### What problem is this solving?
Currently we working a functionality that allows the user to see the "additional offers" of the same product, in other words means to see all the offers of the different sellers associated with a product, with this possibility the user can add the same product to the cart but sold by a different "seller". We try to perform this functionality using the BuyButton of the store-component, but when you try to add the product with another seller the buy button notice that the product is already added to the cart.

We note that the BuyButton uses the “addToCart” mutation (minicart\react\localState\index.js) to add to the cart, here you will find the new items that must be added in the local state should not have been added recently, such validation is performed using the "id" of the item, which is insufficient and does not allow adding that item with different vendors. 

The main change proposed was made in the [Minicart](https://github.com/vtex-apps/minicart/pull/183) project, but we note that in the BuyButton component they validate that the new item was added to the cart using a validation with "skuId", so we add the id of the "seller" in validation.

#### Screenshots or example usage
![screencapture-chrome-extension-fdpohaocaechififmbbbbbknoalclacl-editor-html-2019-11-01-14_08_56](https://user-images.githubusercontent.com/46934781/68049588-4d6e5c80-fcb1-11e9-97d0-14be342fc9c8.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️| Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->