### PR TITLE
Pass collapsable prop from wrapper to actual component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `collapsable` prop not being passed down from the Wrapper to the actual component on `ProductSpecifications`.
 
 ## [3.80.2] - 2019-11-01
 ### Fixed

--- a/react/components/ProductSpecifications/Wrapper.js
+++ b/react/components/ProductSpecifications/Wrapper.js
@@ -23,6 +23,7 @@ const ProductSpecificationsWrapper = ({
   specifications: propsSpecifications,
   tabsMode, // This is a legacy prop passed by product-details
   showSpecificationsTab = false,
+  collapsable = 'always',
 }) => {
   const productContext = useProduct()
 
@@ -35,6 +36,7 @@ const ProductSpecificationsWrapper = ({
       visibleSpecifications={visibleSpecifications}
       tabsMode={tabsMode != null ? tabsMode : showSpecificationsTab}
       specifications={specifications}
+      collapsable={collapsable}
     />
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

`collapsable` prop was not being passed down from the Wrapper to the actual component on `ProductSpecifications`.

#### How should this be manually tested?

(Here the prop value is set to "never")
[Workspace](https://denise2--storecomponents.myvtex.com/classic-shoes/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
