### PR TITLE
Fix typo in `collapsible` prop name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `collapsable` prop to `collapsible` on `ProductSpecifications`.
 
 ## [3.81.0] - 2019-11-06
 ### Added

--- a/docs/ProductSpecifications.md
+++ b/docs/ProductSpecifications.md
@@ -49,7 +49,7 @@ Through the Storefront, you can change the `ProductSpecifications`'s behavior an
 | visibleSpecifications | `String[]` | Type names of specifications you want to appear. Only provide one of `hiddenSpecifications` or `visibleSpecifications` | `[]`          |
 | showSpecificationsTab | `Boolean`  | Choose if you want to show the component with tabs mode                                                                | `false`       |
 | shoudCollapseOnTabChange | `Boolean` | If it should collapse if you change the tab | `false` |
-| collapsable | `mobileOnly`&#124;`desktopOnly`&#124;`always`&#124;`never` | Control when should the content of the specifications be collapsable   | `always` |
+| collapsible | `mobileOnly`&#124;`desktopOnly`&#124;`always`&#124;`never` | Control when should the content of the specifications be collapsible   | `always` |
 
 ### Styles API
 

--- a/react/components/ProductSpecifications/Wrapper.js
+++ b/react/components/ProductSpecifications/Wrapper.js
@@ -23,7 +23,7 @@ const ProductSpecificationsWrapper = ({
   specifications: propsSpecifications,
   tabsMode, // This is a legacy prop passed by product-details
   showSpecificationsTab = false,
-  collapsable = 'always',
+  collapsible = 'always',
 }) => {
   const productContext = useProduct()
 
@@ -36,7 +36,7 @@ const ProductSpecificationsWrapper = ({
       visibleSpecifications={visibleSpecifications}
       tabsMode={tabsMode != null ? tabsMode : showSpecificationsTab}
       specifications={specifications}
-      collapsable={collapsable}
+      collapsible={collapsible}
     />
   )
 }

--- a/react/components/ProductSpecifications/index.js
+++ b/react/components/ProductSpecifications/index.js
@@ -27,7 +27,7 @@ const CSS_HANDLES = [
 const ProductSpecifications = ({
   tabsMode,
   specifications,
-  collapsable = 'always',
+  collapsible = 'always',
   hiddenSpecifications,
   visibleSpecifications,
   shouldCollapseInTabChange,
@@ -37,10 +37,10 @@ const ProductSpecifications = ({
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
 
-  const shouldBeCollapsable = Boolean(
-    collapsable === 'always' ||
-      (collapsable === 'mobileOnly' && isMobile) ||
-      (collapsable === 'desktopOnly' && !isMobile)
+  const shouldBeCollapsible = Boolean(
+    collapsible === 'always' ||
+      (collapsible === 'mobileOnly' && isMobile) ||
+      (collapsible === 'desktopOnly' && !isMobile)
   )
 
   const handleTabChange = tabIndex => {
@@ -143,7 +143,7 @@ const ProductSpecifications = ({
           className={`${handles.specificationsTableContainer} mt9 mt0-l pl8-l`}
         >
           {specificationTitle}
-          {shouldBeCollapsable ? (
+          {shouldBeCollapsible ? (
             <GradientCollapse
               collapseHeight={220}
               collapsed={collapsed}
@@ -171,7 +171,7 @@ const ProductSpecifications = ({
             onClick={() => handleTabChange(i)}
           >
             <div className={`${handles.specificationsTab} pb8 c-muted-1 pv6`}>
-              {shouldBeCollapsable ? (
+              {shouldBeCollapsible ? (
                 <GradientCollapse
                   collapseHeight={220}
                   collapsed={collapsed}
@@ -216,7 +216,7 @@ ProductSpecifications.propTypes = {
   visibleSpecifications: PropTypes.array,
   /** Specifications which will be hidden (optional) */
   hiddenSpecifications: PropTypes.array,
-  collapsable: PropTypes.oneOf([
+  collapsible: PropTypes.oneOf([
     'always',
     'never',
     'desktopOnly',


### PR DESCRIPTION
#### What problem is this solving?

This prop was created with a typo: should be `collapsible` and not `collapsable`.

#### How should this be manually tested?

[Workspace](https://denise2--storecomponents.myvtex.com/classic-shoes/p)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
