### PR TITLE
Fix ProductImages thumbs always keeping active the first item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `ProductImages`' thumbs always keep active the first item.
 
 ## [3.84.0] - 2019-11-08
 ### Changed

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -51,6 +51,7 @@ const ThumbnailSwiper = ({
   thumbUrls,
   position,
   gallerySwiper,
+  activeIndex,
 }) => {
   const hasThumbs = slides.length > 1
 
@@ -64,25 +65,29 @@ const ThumbnailSwiper = ({
       isThumbsVertical && position === THUMBS_POSITION_HORIZONTAL.RIGHT,
   })
 
-  const itemContainerClasses = classNames('swiper-slide mb5 pointer', {
-    'w-20': !isThumbsVertical,
-    'w-100': isThumbsVertical,
-  })
-
+  
   return (
     <div className={thumbClasses} data-testid="thumbnail-swiper">
       <Swiper {...swiperParams} rebuildOnUpdate>
-        {slides.map((slide, i) => (
-          <Thumbnail
-            key={`${i}-${slide.alt}`}
-            itemContainerClasses={itemContainerClasses}
-            index={i}
-            height={isThumbsVertical ? 'auto' : '115px'}
-            gallerySwiper={gallerySwiper}
-            alt={slide.alt}
-            thumbUrl={slide.thumbUrl || thumbUrls[i]}
-          />
-        ))}
+        {slides.map((slide, i) => {
+          const itemContainerClasses = classNames('swiper-slide mb5 pointer', {
+            'w-20': !isThumbsVertical,
+            'w-100': isThumbsVertical,
+            'swiper-slide-active': activeIndex === i,
+          })
+
+          return (
+            <Thumbnail
+              key={`${i}-${slide.alt}`}
+              itemContainerClasses={itemContainerClasses}
+              index={i}
+              height={isThumbsVertical ? 'auto' : '115px'}
+              gallerySwiper={gallerySwiper}
+              alt={slide.alt}
+              thumbUrl={slide.thumbUrl || thumbUrls[i]}
+            />
+          )
+        })}
       </Swiper>
     </div>
   )

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -102,7 +102,7 @@ class Carousel extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { loaded, activeIndex, gallerySwiper } = this.state
+    const { loaded, activeIndex, gallerySwiper, thumbSwiper } = this.state
     const isVideo = this.isVideo
 
     if (!equals(prevProps.slides, this.props.slides)) {
@@ -110,6 +110,12 @@ class Carousel extends Component {
       this.setState(initialState)
       return
     }
+
+    if (gallerySwiper && gallerySwiper !== prevProps.gallerySwiper && gallerySwiper.controller
+      && thumbSwiper && thumbSwiper !== prevProps.thumbSwiper && thumbSwiper.controller) {
+        gallerySwiper.controller.control = thumbSwiper
+        thumbSwiper.controller.control = gallerySwiper
+      }
 
     const paginationElement = path(['pagination', 'el'], gallerySwiper)
     if (paginationElement) paginationElement.hidden = isVideo[activeIndex]
@@ -303,7 +309,7 @@ class Carousel extends Component {
   }
 
   render() {
-    const { thumbsLoaded, gallerySwiper } = this.state
+    const { thumbsLoaded, gallerySwiper, activeIndex } = this.state
 
     const {
       slides = [],
@@ -343,6 +349,7 @@ class Carousel extends Component {
       <ThumbnailSwiper
         isThumbsVertical={isThumbsVertical}
         slides={slides}
+        activeIndex={activeIndex}
         swiperParams={this.thumbnailsParams}
         thumbUrls={this.state.thumbUrl}
         position={position}


### PR DESCRIPTION
#### What problem is this solving?

As title says

#### How should this be manually tested?

[Workspace](https://imagebug--samsungar.myvtex.com/galaxy-s9--con-personal/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
