### PR TITLE
Add support to blockClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support to block class.
 
 ## [3.85.0] - 2019-11-12
 ### Added

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -61,8 +61,9 @@ You should follow the Styles API instruction in the main [README](/README.md#sty
 Below, we describe the namespace that are defined in the `ProductImages`.
 
 | Class name                | Description                                                                             | Component Source                                                                            |
-| ------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `.content`                | The wrapper of `Carousel` scope                                                         | [index](/react/components/ProductImages/index.js)                                           |
+| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `.content (deprecated)`  | Use `productImagesContainer` instead | [index](/react/components/ProductImages/index.js) |
+| `.productImagesContainer` | The wrapper of `Carousel` scope | [index](/react/components/ProductImages/index.js) |
 | `.video`                  | The wrapper of `Video` scope                                                            | [Video](/react/components/ProductImages/components/Video/index.js)                          |
 | `.image`                  | The wrapper container to `ProductImage` component                                      | [ProductImage](/react/components/ProductImages/components/ProductImage.tsx)          |
 | `carouselCursorDefault`   | Specification that define the default customization for the cursor in `Swipe` Component | [Carousel](/react/components/ProductImages/components/Carousel/index.js)                    |

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -2,12 +2,14 @@ import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
 
 import Carousel from './components/Carousel'
-import styles from './styles.css'
 import {
   THUMBS_ORIENTATION,
   THUMBS_POSITION_HORIZONTAL,
   DEFAULT_EXCLUDE_IMAGE_WITH,
 } from './utils/enums'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = ['content', 'productImagesContainer']
 
 const ProductImages = ({
   position,
@@ -28,6 +30,7 @@ const ProductImages = ({
   }
 
   const excludeImageRegexes = hiddenImages && hiddenImages.map(text => new RegExp(text, 'i'))
+  const handles = useCssHandles(CSS_HANDLES)
 
   const images = allImages.filter(image =>
     !image.imageLabel || !excludeImageRegexes.some(regex => regex.test(image.imageLabel))
@@ -52,7 +55,7 @@ const ProductImages = ({
   }, [images, videos])
 
   return (
-    <div className={`${styles.content} w-100`}>
+    <div className={`${handles.productImagesContainer} ${handles.content} w-100`}>
       <Carousel
         slides={slides}
         position={position}

--- a/react/components/ProductImages/styles.css
+++ b/react/components/ProductImages/styles.css
@@ -2,9 +2,6 @@
 *   Product Image CSS Module
 */
 
-.content {
-}
-
 .productVideo { }
 
 .productImage { }


### PR DESCRIPTION
#### What problem is this solving?

As title says

#### How should this be manually tested?

[Workspace](https://imagesprops--storecomponents.myvtex.com/classic-shoes/p) with a block class prop
[SamsungAR](https://imagesprops--samsungar.myvtex.com/galaxy-s9--con-personal/p)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [X] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

* I linked this change to all these stores because I removed the old handle of the container of `ProductImages`, so I tested in all these stores to see if something broke, apparently, everything is ok.
* This is related to https://github.com/vtex-apps/store-discussion/issues/133
