### PR TITLE
Add title prop to ProductDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `title` to `ProductDescription`.
 
 ## [3.88.0] - 2019-11-18
 ### Added

--- a/messages/context.json
+++ b/messages/context.json
@@ -167,5 +167,7 @@
   "admin/editor.skuSelector.title": "Title of SKU Selector component",
   "admin/editor.skuSelector.description": "Description of SKU Selector component",
   "admin/editor.skuSelector.seeMoreLabel.title": "Title of seeMoreLabel property",
-  "admin/editor.skuSelector.seeMoreLabel.description": "Description of seeMoreLabel property"
+  "admin/editor.skuSelector.seeMoreLabel.description": "Description of seeMoreLabel property",
+  "admin/editor.product-description.title": "Product description",
+  "admin/editor.product-description.title-prop.title": "Title"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -167,5 +167,7 @@
   "admin/editor.skuSelector.title": "SKU Selector",
   "admin/editor.skuSelector.description": "Component that displays different given variations of an item for user to choose",
   "admin/editor.skuSelector.seeMoreLabel.title": "See more label",
-  "admin/editor.skuSelector.seeMoreLabel.description": "Label of see more button. The string must have a {quantity} placeholder to show the appropriate remaining items available. Example: \"See {quantity} more\""
+  "admin/editor.skuSelector.seeMoreLabel.description": "Label of see more button. The string must have a {quantity} placeholder to show the appropriate remaining items available. Example: \"See {quantity} more\"",
+  "admin/editor.product-description.title": "Product description",
+  "admin/editor.product-description.title-prop.title": "Title"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -167,5 +167,7 @@
   "admin/editor.skuSelector.title": "Selector de SKU",
   "admin/editor.skuSelector.description": "Componente que muestra diferentes variaciones dadas de un elemento para que el usuario elija",
   "admin/editor.skuSelector.seeMoreLabel.title": "Rótulo del botón ver más",
-  "admin/editor.skuSelector.seeMoreLabel.description": "Etiqueta del botón ver más. La cadena debe tener un marcador de posición {quantity} para mostrar los elementos restantes apropiados disponibles. Ejemplo: \"Ver {quantity} más\""
+  "admin/editor.skuSelector.seeMoreLabel.description": "Etiqueta del botón ver más. La cadena debe tener un marcador de posición {quantity} para mostrar los elementos restantes apropiados disponibles. Ejemplo: \"Ver {quantity} más\"",
+  "admin/editor.product-description.title": "Descripción del producto",
+  "admin/editor.product-description.title-prop.title": "Título"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -167,5 +167,7 @@
   "admin/editor.skuSelector.title": "Seletor de SKU",
   "admin/editor.skuSelector.description": "Componente que exibe diferentes variações dadas de um produto para o usuário escolher",
   "admin/editor.skuSelector.seeMoreLabel.title": "Rótulo do botão ver mais",
-  "admin/editor.skuSelector.seeMoreLabel.description": "Rótulo do botão ver mais. A mensagem deve ter um espaço reservado {quantity} para mostrar os itens restantes apropriados disponíveis. Exemplo: \"Ver mais {quantity}\""
+  "admin/editor.skuSelector.seeMoreLabel.description": "Rótulo do botão ver mais. A mensagem deve ter um espaço reservado {quantity} para mostrar os itens restantes apropriados disponíveis. Exemplo: \"Ver mais {quantity}\"",
+  "admin/editor.product-description.title": "Descrição de produto",
+  "admin/editor.product-description.title-prop.title": "Título"
 }

--- a/react/components/ProductDescription/Wrapper.js
+++ b/react/components/ProductDescription/Wrapper.js
@@ -13,10 +13,15 @@ const ProductDescriptionWrapper = props => {
 
   return (
     <ProductDescription
+      title={props.title}
       description={description}
       collapseContent={props.collapseContent}
     />
   )
+}
+
+ProductDescriptionWrapper.schema = {
+  title: 'admin/editor.product-description.title',
 }
 
 ProductDescriptionWrapper.defaultProps = {

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -1,8 +1,9 @@
 import React, { memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, injectIntl } from 'react-intl'
 import HtmlParser from 'react-html-parser'
 import { useCssHandles } from 'vtex.css-handles'
+import { formatIOMessage } from 'vtex.native-types'
 
 import GradientCollapse from '../GradientCollapse/index'
 
@@ -16,7 +17,7 @@ const CSS_HANDLES = [
  * Product Description Component.
  * Render the description of a product
  */
-const ProductDescription = ({ description, collapseContent }) => {
+const ProductDescription = ({ description, collapseContent, title, intl }) => {
   if (!description) {
     return null
   }
@@ -34,7 +35,7 @@ const ProductDescription = ({ description, collapseContent }) => {
           <h2
             className={`${handles.productDescriptionTitle} t-heading-5 mb5 mt0`}
           >
-            {txt}
+            {title ? formatIOMessage({ id: title, intl }) : txt}
           </h2>
         )}
       </FormattedMessage>
@@ -53,9 +54,10 @@ const ProductDescription = ({ description, collapseContent }) => {
 }
 
 ProductDescription.propTypes = {
+  title: PropTypes.string,
   /** Product description string */
   description: PropTypes.string,
   collapseContent: PropTypes.bool,
 }
 
-export default memo(ProductDescription)
+export default injectIntl(memo(ProductDescription))

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -52,6 +52,16 @@
         }
       }
     },
+    "ProductDescription": {
+      "title": "admin/editor.product-description.title",
+      "type": "object",
+      "properties": {
+        "title": {
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "title": "admin/editor.product-description.title-prop.title"
+        }
+      }
+    },
     "ProductPrice": {
       "properties": {
         "labelSellingPrice": {

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -24,7 +24,10 @@
     }
   },
   "product-description": {
-    "component": "ProductDescription"
+    "component": "ProductDescription",
+    "content": {
+      "$ref": "#/definitions/ProductDescription"
+    }
   },
   "product-separator": {
     "component": "ProductSeparator"


### PR DESCRIPTION
#### What problem is this solving?

We need a way to display something customizable in the title of the product description.

#### How should this be manually tested?

* Go to the [workspace](https://productdescriptionprop--gympassus.myvtex.com/concept2-rowerg%E2%84%A2-model-e-79/p)
* Change the title of Product description


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8517023/69079851-a6602380-0a19-11ea-8fbe-29b41fb32d2c.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
