### PR TITLE
add minSearchTermLength prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `minSearchTermLength` prop to `SearchBar`.
+
 ## [3.87.0] - 2019-11-13
 ### Added
 - `showNavigationArrows` and `showPaginationDots` props on `product-images`.

--- a/docs/SearchBar.md
+++ b/docs/SearchBar.md
@@ -30,6 +30,8 @@ Then, add `search-bar` block into your app theme, as we do in our [Store Header]
 | `maxWidth`            | `Number` \| `String` | Max width of the search bar                                                                                                                       | -             |
 | `customSearchPageUrl` | `string`             | Template for a custom url. It can have a substring `${term}` used as placeholder to interpolate the searched term. (e.g. `/search?query=${term}`) | -             |
 | ~`iconClasses`~       | `String`             | **DEPRECATED** ~Custom classes for the search icon~ Use the CSS handle `searchBarIcon`.                                                           | -             |
+|`minSearchTermLength`       | `Number`             | If defined, it will block searches where the term length is lesser than `minSearchTermLength`.                                                           | -             |
+
 
 ### CSS Handles
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,6 +1,7 @@
 {
   "store/search.placeholder": "search.placeholder",
   "store/search.searchFor": "search.searchFor",
+  "store/search.searchTermTooShort": "search.searchTermTooShort",
   "admin/editor.productName.title": "admin/editor.productName.title",
   "admin/editor.productName.description": "admin/editor.productName.description",
   "admin/editor.productName.showBrandName.title": "admin/editor.productName.showBrandName.title",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,7 @@
 {
   "store/search.placeholder": "Search",
   "store/search.searchFor": "Search for {term}",
+  "store/search.searchTermTooShort": "Search term is too short",
   "admin/editor.productName.title": "Product name",
   "admin/editor.productName.description": "Product name Component",
   "admin/editor.productName.showBrandName.title": "Shows the brand name",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,6 +1,7 @@
 {
   "store/search.placeholder": "Buscar",
   "store/search.searchFor": "Buscar {term}",
+  "store/search.searchTermTooShort": "El término de búsqueda es demasiado corto",
   "admin/editor.productName.title": "Nombre del producto",
   "admin/editor.productName.description": "Componente del nombre del producto",
   "admin/editor.productName.showBrandName.title": "Mostrar la marca",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,7 @@
 {
   "store/search.placeholder": "Buscar",
   "store/search.searchFor": "Buscar por {term}",
+  "store/search.searchTermTooShort": "O termo de busca é muito curto",
   "admin/editor.productName.title": "Nome do produto",
   "admin/editor.productName.description": "Componente do nome do produto",
   "admin/editor.productName.showBrandName.title": "Mostrar a marca",

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -22,6 +22,7 @@ const AutocompleteInput = ({
   iconBlockClass,
   iconClasses,
   autoFocus,
+  inputErrorMessage,
   ...restProps
 }) => {
   const inputRef = useRef(null)
@@ -75,6 +76,8 @@ const AutocompleteInput = ({
           prefix={hasIconLeft && prefix}
           suffix={suffix}
           {...restProps}
+          error={!!inputErrorMessage}
+          errorMessage={inputErrorMessage}
         />
       </div>
     </div>
@@ -107,6 +110,8 @@ AutocompleteInput.propTypes = {
   iconBlockClass: PropTypes.string,
   /** Identify if the search input should autofocus or not */
   autoFocus: PropTypes.bool,
+  /** Error message showed in search input */
+  inputErrorMessage: PropTypes.string,
 }
 
 export default AutocompleteInput

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -60,6 +60,7 @@ class SearchBarContainer extends Component {
       placeholder = intl.formatMessage({
         id: 'store/search.placeholder',
       }),
+      minSearchTermLength,
     } = this.props
 
     const { inputValue } = this.state
@@ -79,6 +80,8 @@ class SearchBarContainer extends Component {
         maxWidth={maxWidth}
         attemptPageTypeSearch={attemptPageTypeSearch}
         customSearchPageUrl={customSearchPageUrl}
+        minSearchTermLength={minSearchTermLength}
+        intl={intl}
       />
     )
   }
@@ -108,6 +111,8 @@ SearchBarContainer.propTypes = {
   /** A template for a custom url. It can have a substring ${term} used as placeholder to interpolate the searched term. (e.g. `/search?query=${term}`) */
   customSearchPageUrl: PropTypes.string,
   placeholder: PropTypes.string,
+  /** Minimum search term length allowed */
+  minSearchTermLength: PropTypes.number,
 }
 
 export default injectIntl(SearchBarContainer)


### PR DESCRIPTION
#### What problem is this solving?

`SearchBar` has no input validation. Thus, it is possible to request a search result with an empty query or with a limited number of characters. In many cases, this behavior is undesirable.

This PR adds the `minSearchTermLength` to validate the minimum number of characters in the search input.

#### How should this be manually tested?

Add the prop `minSearchTermLength`to the `search-bar` block.

```
"search-bar#input-validation": {
    "props": {
      "minSearchTermLength": 2
    }
  }
```
[Workspace](https://inputvalidation--biggy.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![input-validation](https://user-images.githubusercontent.com/40380674/69171715-3ca84e00-0adb-11ea-92c4-6bf176de3a2f.gif)

#### Type of changes

✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

