### PR TITLE
Add data-testid to BuyButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `data-testid` to `BuyButton`.
 
 ## [3.91.1] - 2019-11-26
 ### Fixed

--- a/react/components/BuyButton/Wrapper.js
+++ b/react/components/BuyButton/Wrapper.js
@@ -24,7 +24,14 @@ const BuyButtonMessage = ({ showItemsPrice, skuItems }) => {
   if (!showItemsPrice) {
     return (
       <FormattedMessage id="store/buy-button.add-to-cart">
-        {message => <span className={handles.buyButtonText}>{message}</span>}
+        {message => (
+          <span
+            data-testid="store-components__buy-button-message"
+            className={handles.buyButtonText}
+          >
+            {message}
+          </span>
+        )}
       </FormattedMessage>
     )
     return
@@ -41,12 +48,17 @@ const BuyButtonMessage = ({ showItemsPrice, skuItems }) => {
 
   return (
     <div
-      className={`${
-        handles.buttonDataContainer
-      } flex w-100 justify-between items-center`}
+      className={`${handles.buttonDataContainer} flex w-100 justify-between items-center`}
     >
       <FormattedMessage id="store/buy-button.add-to-cart">
-        {message => <span className={handles.buyButtonText}>{message}</span>}
+        {message => (
+          <span
+            data-testid="store-components__buy-button-message"
+            className={handles.buyButtonText}
+          >
+            {message}
+          </span>
+        )}
       </FormattedMessage>
       <ProductPrice
         showLabels={false}


### PR DESCRIPTION
#### What problem is this solving?

Should make testing a bit easier by adding `data-testid="store-components__buy-button-message"` to the text rendered inside of `BuyButton`.

#### How should this be manually tested?

[Workspace](https://buybuttontestid--storecomponents.myvtex.com/everyday-necessaire/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
