### PR TITLE
Make BuyButton redirect to the appropriate cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `BuyButton` redirects to the appropriate cart depending on the version of `vtex.checkout` installed in the account.
 
 ## [3.91.1] - 2019-11-26
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,8 @@
     "vtex.search-graphql": "0.x",
     "vtex.css-handles": "0.x",
     "vtex.store-image": "0.x",
-    "vtex.device-detector": "0.x"
+    "vtex.device-detector": "0.x",
+    "vtex.apps-graphql": "2.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -9,7 +9,6 @@ import { useCssHandles } from 'vtex.css-handles'
 import useProduct from 'vtex.product-context/useProduct'
 import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
 
-
 import { Button, ToastContext, Tooltip } from 'vtex.styleguide'
 
 const CONSTANTS = {
@@ -19,7 +18,6 @@ const CONSTANTS = {
   DUPLICATE_CART_ITEM_ID: 'store/buybutton.buy-success-duplicate',
   ERROR_MESSAGE_ID: 'store/buybutton.add-failure',
   SEE_CART_ID: 'store/buybutton.see-cart',
-  CHECKOUT_URL: '/checkout/#/cart',
   TOAST_TIMEOUT: 3000,
 }
 
@@ -70,7 +68,8 @@ export const BuyButton = ({
   shouldAddToCart = true,
   shouldOpenMinicart = false,
   showTooltipOnSkuNotSelected = true,
-  customToastURL = CONSTANTS.CHECKOUT_URL,
+  checkoutUrl,
+  customToastURL = checkoutUrl,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const [isAddingToCart, setAddingToCart] = useState(false)
@@ -114,7 +113,7 @@ export const BuyButton = ({
   }
 
   const { rootPath = '' } = useRuntime()
-  const checkoutUrl = rootPath + CONSTANTS.CHECKOUT_URL
+  const fullCheckoutUrl = rootPath + checkoutUrl
 
   const handleAddToCart = async event => {
     event.stopPropagation()
@@ -148,7 +147,11 @@ export const BuyButton = ({
         const { items } = mutationRes.data.addItem
 
         success = skuItems.filter(
-          skuItem => !!items.find(({ id, seller }) => id === skuItem.skuId && seller === skuItem.seller)
+          skuItem =>
+            !!items.find(
+              ({ id, seller }) =>
+                id === skuItem.skuId && seller === skuItem.seller
+            )
         )
         await orderFormContext.refetch().catch(() => null)
       }
@@ -156,12 +159,22 @@ export const BuyButton = ({
       const addedItem =
         (linkStateItems &&
           skuItems.filter(
-            skuItem => !!linkStateItems.find(({ id, seller }) => id === skuItem.skuId && seller === skuItem.seller)
+            skuItem =>
+              !!linkStateItems.find(
+                ({ id, seller }) =>
+                  id === skuItem.skuId && seller === skuItem.seller
+              )
           )) ||
         success
 
-      const foundItem = addedItem.length && orderFormItems && orderFormItems
-        .filter(item => item.id === addedItem[0].skuId && item.seller === addedItem[0].seller).length > 0
+      const foundItem =
+        addedItem.length &&
+        orderFormItems &&
+        orderFormItems.filter(
+          item =>
+            item.id === addedItem[0].skuId &&
+            item.seller === addedItem[0].seller
+        ).length > 0
 
       success = addedItem
 
@@ -186,7 +199,7 @@ export const BuyButton = ({
       setAddingToCart(false)
       showToastMessage()
       if (isOneClickBuy) {
-        location.assign(checkoutUrl)
+        location.assign(fullCheckoutUrl)
       }
       onAddFinish && onAddFinish()
     }, 500)
@@ -206,24 +219,22 @@ export const BuyButton = ({
     return <ContentLoader />
   }
 
-  const disabled = disabledProp || !available || (orderFormContext && orderFormContext.loading)
+  const disabled =
+    disabledProp || !available || (orderFormContext && orderFormContext.loading)
   const unavailableLabel = (
     <FormattedMessage id="store/buyButton-label-unavailable">
-        {message => (
-          <span className={handles.buyButtonText}>{message}</span>
-        )}
+      {message => <span className={handles.buyButtonText}>{message}</span>}
     </FormattedMessage>
   )
 
   const tooltipLabel = (
     <FormattedMessage id={CONSTANTS.TOOLTIP_ERROR_MESSAGE_ID}>
-      {message => (
-        <span className={handles.errorMessage}>{message}</span>
-      )}
+      {message => <span className={handles.errorMessage}>{message}</span>}
     </FormattedMessage>
   )
 
-  return !showTooltipOnSkuNotSelected || skuSelector.areAllVariationsSelected ? (
+  return !showTooltipOnSkuNotSelected ||
+    skuSelector.areAllVariationsSelected ? (
     <Button
       block={large}
       disabled={disabled}
@@ -239,7 +250,7 @@ export const BuyButton = ({
         disabled={disabled}
         onClick={handleClick}
         isLoading={isAddingToCart}
-        >
+      >
         {available ? children : unavailableLabel}
       </Button>
     </Tooltip>
@@ -311,6 +322,8 @@ BuyButton.propTypes = {
   disabled: PropTypes.bool,
   /** A custom URL for the `VIEW CART` button inside the toast */
   customToastURL: PropTypes.string,
+  /** The URL to the cart **/
+  checkoutUrl: PropTypes.string,
 }
 
 export default BuyButton

--- a/react/components/BuyButton/queries/installedApp.gql
+++ b/react/components/BuyButton/queries/installedApp.gql
@@ -1,0 +1,5 @@
+query installedApp($slug: String!) {
+  installedApp(slug: $slug) {
+    version
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

We're developing a new Checkout within IO, and along with it we built a new Cart. It is located in a different path (`/cart` instead of `/checkout/#/cart`), so we need to change this component to redirect to the new cart **when `vtex.checkout@1.x` is installed in the account**. To do so this PR makes a query to `apps-graphql` to find out which major of `vtex.checkout` is installed in the account and defines the checkout URL accordingly.

#### How should this be manually tested?

[Workspace with major 0](https://buybutton0--checkoutio.myvtex.com/teste-so-delivery-copy-256--copy-257--copy-261--copy-262--copy-263--copy-264-/p)
[Workspace with major 1](https://buybutton1--checkoutio.myvtex.com/teste-so-delivery-copy-256--copy-257--copy-261--copy-262--copy-263--copy-264-/p)

After clicking "Add to cart", the first workspace should take you to `/checkout/#/cart`, while the second takes you to `/cart`. Also, the "View cart" button in the toast that is shown after clicking the button should point to the same URL.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/27290/resolver-direcionamento-para-o-novo-carrinho-no-minicart-e-no-botão-de-adicionar-ao-carrinho-página-de-produto).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

This **should not be merged** until we make sure no account in production has `vtex.checkout@1.x` installed.