### PR TITLE
Chore/sku ssr

### DIFF
--- a/messages/context.json
+++ b/messages/context.json
@@ -39,6 +39,7 @@
   "store/buybutton.add-failure": "buybutton.add-failure",
   "store/buybutton.buy-offline-success": "buybutton.buy-offline-success",
   "store/buybutton.select-sku-variations": "Please select an option of each variation",
+  "store/buybutton.cart-not-ready": "Message showed when user presses buy button but order form is not loaded yet",
   "store/buybutton.see-cart": "Button label on the notification that pops up when the user adds an item to the cart, prompting the user to see said cart",
   "store/technicalspecifications.title": "technicalspecifications.title",
   "store/availability-subscriber.title": "availability-subscriber.title",

--- a/messages/en.json
+++ b/messages/en.json
@@ -39,6 +39,7 @@
   "store/buybutton.add-failure": "Something went wrong and the item wasn't added to your cart!",
   "store/buybutton.buy-offline-success": "Item added to your offline cart",
   "store/buybutton.select-sku-variations": "Please select an option of each variation",
+  "store/buybutton.cart-not-ready": "Cart not loaded yet. Please try again in a moment.",
   "store/buybutton.see-cart": "View cart",
   "store/technicalspecifications.title": "Technical Specifications",
   "store/availability-subscriber.title": "This product isn't available right now",

--- a/messages/es.json
+++ b/messages/es.json
@@ -39,6 +39,7 @@
   "store/buybutton.add-failure": "¡Algo salió mal y el artículo no se agregó a tu carrito!",
   "store/buybutton.buy-offline-success": "Ítem agregado a su carrito offline",
   "store/buybutton.select-sku-variations": "Por favor seleccione una opción de cada variación",
+  "store/buybutton.cart-not-ready": "El carrito aún no está cargado. Vuelva a intentarlo en un momento",
   "store/buybutton.see-cart": "Ver carrito",
   "store/technicalspecifications.title": "Especificaciones Técnicas",
   "store/availability-subscriber.title": "Este producto no está disponible actualmente",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -39,6 +39,7 @@
   "store/buybutton.add-failure": "Algo deu errado e o item não pode ser adicionado ao seu carrinho!",
   "store/buybutton.buy-offline-success": "Item adicionado ao seu carrinho offline.",
   "store/buybutton.select-sku-variations": "Por favor selecione uma opção de cada variação",
+  "store/buybutton.cart-not-ready": "O carrinho ainda não está carregado. Por favor, tente novamente num instante.",
   "store/buybutton.see-cart": "Ver carrinho",
   "store/technicalspecifications.title": "Especificações Técnicas",
   "store/availability-subscriber.title": "Este produto não está disponível no momento",

--- a/react/__mocks__/vtex.store-resources/OrderFormContext.js
+++ b/react/__mocks__/vtex.store-resources/OrderFormContext.js
@@ -6,7 +6,8 @@ const mockOrderForm = {
   },
   items: [],
   addItem: ({ items = [] }) => new Promise(resolve => resolve({ data: { addItem: { ...mockOrderForm, items }}})),
-  refetch: () => new Promise(resolve => resolve({ data: { orderForm: mockOrderForm }}))
+  refetch: () => new Promise(resolve => resolve({ data: { orderForm: mockOrderForm }})),
+  loading: false,
 }
 
 export function orderFormConsumer(Comp) {
@@ -15,4 +16,8 @@ export function orderFormConsumer(Comp) {
       return <Comp {...this.props} orderFormContext={mockOrderForm} />
     }
   }
+}
+
+export function useOrderForm() {
+  return mockOrderForm
 }

--- a/react/__tests__/hooks/useEffectkSkipMount.test.ts
+++ b/react/__tests__/hooks/useEffectkSkipMount.test.ts
@@ -1,0 +1,23 @@
+import useEffectSkipMount from '../../components/SKUSelector/components/hooks/useEffectSkipMount'
+import { renderHook } from '@vtex/test-tools/react'
+
+it('ensure that function wont be called on first render', () => {
+  const fakeFn = jest.fn()
+  const deps = ['a']
+  const { rerender } = renderHook(() => useEffectSkipMount(fakeFn, deps))
+  expect(fakeFn).toBeCalledTimes(0)
+  rerender()
+  expect(fakeFn).toBeCalledTimes(0)
+})
+
+it('ensure that after prop changes, provided function is called', () => {
+  const fakeFn = jest.fn()
+  const { rerender } = renderHook(({ deps }) => useEffectSkipMount(fakeFn, deps), {
+    initialProps: {
+      deps: ['a']
+    }
+  })
+  expect(fakeFn).toBeCalledTimes(0)
+  rerender({ deps: ['b'] })
+  expect(fakeFn).toBeCalledTimes(1)
+})

--- a/react/components/BuyButton/Wrapper.js
+++ b/react/components/BuyButton/Wrapper.js
@@ -3,7 +3,7 @@ import useProduct from 'vtex.product-context/useProduct'
 import { path, isEmpty, compose } from 'ramda'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { withToast } from 'vtex.styleguide'
-import { orderFormConsumer } from 'vtex.store-resources/OrderFormContext'
+import { useOrderForm } from 'vtex.store-resources/OrderFormContext'
 import ProductPrice from '../ProductPrice'
 import { graphql } from 'react-apollo'
 import { useCssHandles } from 'vtex.css-handles'
@@ -65,7 +65,6 @@ const BuyButtonWrapper = ({
   intl,
   addToCart,
   showToast,
-  orderFormContext,
   onAddStart,
   onAddFinish,
   children,
@@ -82,6 +81,7 @@ const BuyButtonWrapper = ({
   showTooltipOnSkuNotSelected,
   checkoutVersion,
 }) => {
+  const orderFormContext = useOrderForm()
   const valuesFromContext = useProduct()
 
   const isEmptyContext = !valuesFromContext || isEmpty(valuesFromContext)
@@ -192,8 +192,7 @@ const EnhancedBuyButton = compose(
   withOpenMinicart,
   withCheckoutVersion,
   withToast,
-  injectIntl,
-  orderFormConsumer
+  injectIntl
 )(BuyButtonWrapper)
 
 // This function is public available to be used only by vtex.product-summary.

--- a/react/components/GradientCollapse/index.js
+++ b/react/components/GradientCollapse/index.js
@@ -124,7 +124,7 @@ function GradientCollapse(props) {
 GradientCollapse.propTypes = {
   /** Maximum height collapsed */
   collapseHeight: PropTypes.number.isRequired,
-  collapsed: PropTypes.boolean,
+  collapsed: PropTypes.bool,
   children: PropTypes.node,
   onCollapsedChange: PropTypes.func,
 }

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -77,13 +77,12 @@ const ThumbnailSwiper = ({
     'db-ns': hasThumbs,
     mt3: !isThumbsVertical,
     'w-20 bottom-0 top-0 absolute': isThumbsVertical,
-    'left-0 pr5':
+    'left-0':
       isThumbsVertical && position === THUMBS_POSITION_HORIZONTAL.LEFT,
-    'right-0 pl5':
+    'right-0':
       isThumbsVertical && position === THUMBS_POSITION_HORIZONTAL.RIGHT,
   })
 
-  
   return (
     <div className={thumbClasses} data-testid="thumbnail-swiper">
       <Swiper {...swiperParams} rebuildOnUpdate>

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -14,11 +14,22 @@ import ProductImage from '../ProductImage'
 import styles from '../../styles.css'
 import './global.css'
 
+const FakeSwiper = ({ children, containerClass }) => {
+  return (
+    <div className={containerClass}>
+      <div className="swiper-wrapper">
+        {React.Children.toArray(children)[0]}
+      </div>
+    </div>
+  )
+}
+
 /** Swiper and its modules are imported using require to avoid breaking SSR */
 const Swiper = window.navigator
   ? require('react-id-swiper/lib/ReactIdSwiper.full').default
-  : null
-const SwiperModules = window.navigator ? require('swiper/dist/js/swiper') : null
+  : FakeSwiper
+
+const SwiperModules = window.navigator ? require('swiper/dist/js/swiper') : {}
 
 import ThumbnailSwiper from './ThumbnailSwiper'
 import {
@@ -125,9 +136,9 @@ class Carousel extends Component {
 
     if (gallerySwiper && gallerySwiper !== prevProps.gallerySwiper && gallerySwiper.controller
       && thumbSwiper && thumbSwiper !== prevProps.thumbSwiper && thumbSwiper.controller) {
-        gallerySwiper.controller.control = thumbSwiper
-        thumbSwiper.controller.control = gallerySwiper
-      }
+      gallerySwiper.controller.control = thumbSwiper
+      thumbSwiper.controller.control = gallerySwiper
+    }
 
     const paginationElement = path(['pagination', 'el'], gallerySwiper)
     if (paginationElement) paginationElement.hidden = isVideo[activeIndex]
@@ -345,10 +356,6 @@ class Carousel extends Component {
       zoomProps: { zoomType },
     } = this.props
 
-    if (!thumbsLoaded || Swiper == null) {
-      return null
-    }
-
     const isThumbsVertical =
       thumbnailsOrientation === THUMBS_ORIENTATION.VERTICAL
     const hasThumbs = slides && slides.length > 1
@@ -362,18 +369,18 @@ class Carousel extends Component {
       'w-100 border-box',
       galleryCursor[zoomType],
       {
-        'ml-20-ns w-80-ns':
+        'ml-20-ns w-80-ns pl5 justify-end':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.LEFT &&
           hasThumbs,
-        'mr-20-ns w-80-ns':
+        'mr-20-ns w-80-ns pr5':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
           hasThumbs,
       }
     )
 
-    const thumbnailSwiper = slides && (
+    const thumbnailSwiper = thumbsLoaded && slides && (
       <ThumbnailSwiper
         isThumbsVertical={isThumbsVertical}
         slides={slides}
@@ -387,8 +394,17 @@ class Carousel extends Component {
       />
     )
 
+    const containerClasses = classNames(cssHandles.carouselContainer, 'relative overflow-hidden w-100', {
+      'flex justify-end': isThumbsVertical &&
+        position === THUMBS_POSITION_HORIZONTAL.LEFT &&
+        hasThumbs,
+      'flex justify-start': isThumbsVertical &&
+        position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
+        hasThumbs,
+    })
+
     return (
-      <div className={`${cssHandles.carouselContainer} relative overflow-hidden w-100`} aria-hidden="true">
+      <div className={containerClasses} aria-hidden="true">
         {isThumbsVertical && thumbnailSwiper}
         <div className={imageClasses}>
           <ReactResizeDetector handleHeight onResize={this.updateSwiperSize}>

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -25,7 +25,7 @@ const FakeSwiper = ({ children, containerClass, direction = THUMBS_ORIENTATION.H
   }
   const child = childrenArray[0]
   const childClass = path(['props', 'className'], child)
-  const newChildClass = childClass ? `${childrenClass} swiper-slide-active` : childClass
+  const newChildClass = childClass ? `${childClass} swiper-slide-active` : childClass
   return (
     <div className={`${containerClass} swiper-container-initialized ${swiperContainerDirection}`}>
       <div className="swiper-wrapper">

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -14,11 +14,24 @@ import ProductImage from '../ProductImage'
 import styles from '../../styles.css'
 import './global.css'
 
-const FakeSwiper = ({ children, containerClass }) => {
+/**
+ * ReactIdSwiper cannot be SSRendered, so this is a fake swiper that copies some of its classes and HTML layout and render only the first image of the children array.
+ */
+const FakeSwiper = ({ children, containerClass, direction = THUMBS_ORIENTATION.HORIZONTAL }) => {
+  const swiperContainerDirection = direction === THUMBS_ORIENTATION.HORIZONTAL ? 'swiper-container-horizontal' : direction === THUMBS_ORIENTATION.VERTICAL ? 'swiper-container-vertical' : ''
+  const childrenArray = React.Children.toArray(children)
+  if (childrenArray.length === 0) {
+    return null
+  }
+  const child = childrenArray[0]
+  const childClass = path(['props', 'className'], child)
+  const newChildClass = childClass ? `${childrenClass} swiper-slide-active` : childClass
   return (
-    <div className={containerClass}>
+    <div className={`${containerClass} swiper-container-initialized ${swiperContainerDirection}`}>
       <div className="swiper-wrapper">
-        {React.Children.toArray(children)[0]}
+        {React.cloneElement(child, {
+          className: newChildClass,
+        })}
       </div>
     </div>
   )

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -369,7 +369,7 @@ class Carousel extends Component {
       'w-100 border-box',
       galleryCursor[zoomType],
       {
-        'ml-20-ns w-80-ns pl5 justify-end':
+        'ml-20-ns w-80-ns pl5':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.LEFT &&
           hasThumbs,

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -395,10 +395,10 @@ class Carousel extends Component {
     )
 
     const containerClasses = classNames(cssHandles.carouselContainer, 'relative overflow-hidden w-100', {
-      'flex justify-end': isThumbsVertical &&
+      'flex-ns justify-end-ns': isThumbsVertical &&
         position === THUMBS_POSITION_HORIZONTAL.LEFT &&
         hasThumbs,
-      'flex justify-start': isThumbsVertical &&
+      'flex-ns justify-start-ns': isThumbsVertical &&
         position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
         hasThumbs,
     })

--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, memo, useState, useEffect, FC, useMemo } from 'react'
+import React, { useCallback, memo, useState, FC, useMemo } from 'react'
 
 import Variation from './Variation'
 
@@ -21,6 +21,7 @@ import {
   Variations,
   DisplayMode,
 } from '../types'
+import useEffectSkipMount from './hooks/useEffectSkipMount'
 
 interface Props {
   seeMoreLabel: string
@@ -272,7 +273,7 @@ const SKUSelector: FC<Props> = ({
   ])
   const [displayVariations, setDisplayVariations] = useState<DisplayVariation[]>(() => getAvailableVariations(availableVariationsPayload))
 
-  useEffect(() => {
+  useEffectSkipMount(() => {
     let isCurrent = true
     const promise = getAvailableVariationsPromise(availableVariationsPayload)
     promise.then(availableVariations => {

--- a/react/components/SKUSelector/components/Variation.tsx
+++ b/react/components/SKUSelector/components/Variation.tsx
@@ -3,7 +3,6 @@ import React, {
   memo,
   useState,
   Fragment,
-  useEffect,
   useCallback,
 } from 'react'
 import { Button } from 'vtex.styleguide'
@@ -60,20 +59,18 @@ const Variation: FC<Props> = ({
   containerClasses: containerClassesProp,
 }) => {
   const { name, options } = variation
-  const [showAll, setShowAll] = useState(false)
+  
+  const [showAll, setShowAll] = useState(() => {
+    const selectedOptionPosition = findSelectedOption(selectedItem)(options)
+    return selectedOptionPosition >= visibleItemsWhenCollapsed
+  })
+  
   const visibleItemsWhenCollapsed = maxItems - ITEMS_VISIBLE_THRESHOLD
   const {
     buyButton = {
       clicked: false,
     }
   } = useProduct()
-
-  useEffect(() => {
-    const selectedOptionPosition = findSelectedOption(selectedItem)(options)
-    if (selectedOptionPosition >= visibleItemsWhenCollapsed) {
-      setShowAll(true)
-    }
-  }, [])
 
   const displayImage = isColor(name)
 

--- a/react/components/SKUSelector/components/Variation.tsx
+++ b/react/components/SKUSelector/components/Variation.tsx
@@ -60,12 +60,13 @@ const Variation: FC<Props> = ({
 }) => {
   const { name, options } = variation
   
+  const visibleItemsWhenCollapsed = maxItems - ITEMS_VISIBLE_THRESHOLD
+
   const [showAll, setShowAll] = useState(() => {
     const selectedOptionPosition = findSelectedOption(selectedItem)(options)
     return selectedOptionPosition >= visibleItemsWhenCollapsed
   })
   
-  const visibleItemsWhenCollapsed = maxItems - ITEMS_VISIBLE_THRESHOLD
   const {
     buyButton = {
       clicked: false,

--- a/react/components/SKUSelector/components/hooks/useEffectSkipMount.ts
+++ b/react/components/SKUSelector/components/hooks/useEffectSkipMount.ts
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, EffectCallback } from 'react'
 
-const useEffectSkipMount = (func: Function, deps: any[]) => {
+const useEffectSkipMount = (func: EffectCallback, deps: any[]) => {
   const isFirstRender = useRef(true)
   useEffect(() => {
     if (isFirstRender.current) {

--- a/react/components/SKUSelector/components/hooks/useEffectSkipMount.ts
+++ b/react/components/SKUSelector/components/hooks/useEffectSkipMount.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from 'react'
+
+const useEffectSkipMount = (func: Function, deps: any[]) => {
+  const isFirstRender = useRef(true)
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    return func()
+  }, deps)
+}
+
+export default useEffectSkipMount

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -26,6 +26,7 @@ import {
   InitialSelectionType,
   DisplayMode
 } from './types'
+import useEffectSkipMount from './components/hooks/useEffectSkipMount'
 
 const keyCount = compose(
   length,
@@ -204,7 +205,7 @@ const SKUSelectorContainer: FC<Props> = ({
   ] = useState<SelectedVariations>(() => getNewSelectedVariations(query, skuSelected, variations, initialSelection))
   useAllSelectedEvent(selectedVariations, variationsCount)
 
-  useEffect(() => {
+  useEffectSkipMount(() => {
     setSelectedVariations(getNewSelectedVariations(query, skuSelected, variations, initialSelection))
   }, [variations])
 


### PR DESCRIPTION
#### What problem is this solving?

Image and SKUSelector are not being rendered ssr, when they can be

Faz a primeira imagem do product-images ser renderizada SSR (hoje só retorna null)
Faz SKUSelector renderizar SSR (hj só retorna null)
Faz o botão de compra renderizar available quando possível, hoje ele renderiza unavailable e só troca para available quando orderFormCOntext carrega completo (pq ele depende dos produtos no carrinho para o otimista). Enquanto ele ta carregando, se o usuário clicar  vai mostrar o tooltip igual quando nao tem todas variações selecionadas.

https://wfbeta--garmin.myvtex.com/monitor-cardiaco-gps-garmin-forerunner-245/p

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
