### PR TITLE
prevent add to cart when order form context is loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent add to cart while orderForm is loading.
 
 ## [3.95.4] - 2019-12-17
 

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -230,6 +230,9 @@ export const BuyButton = ({
   }
 
   const handleClick = e => {
+    if (orderFormContext && orderFormContext.loading) {
+      return
+    }
     if (dispatch) {
       dispatch({ type: 'SET_BUY_BUTTON_CLICKED', args: { clicked: true } })
     }


### PR DESCRIPTION
#### What problem is this solving?

Before, the button would be unavailable so the click was blocked. I changed this and added the tooltip. I thought the tooltip would block the button press action, but it doesn't, so we need to early return.

#### How should this be manually tested?

https://fidelis--alssports.myvtex.com/patagn-pullover-better-sweater/p

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
