### PR TITLE
handle buy button press while order form is loading by calling add to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Handle buy button click while order form is loading by handling it gracefully and don't show tooltip.
+- Handle buy button click while order form is loading by handling it gracefully and not showing the tooltip.
 
 ## [3.95.7] - 2019-12-19
+### Changed
+- Update `react-id-swiper` dependency to 3.3.2, fixes issues in ProductImages.
 
 ## [3.95.6] - 2019-12-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handle buy button click while order form is loading by handling it gracefully and don't show tooltip.
 
 ## [3.95.7] - 2019-12-19
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -39,7 +39,6 @@
   "store/buybutton.add-failure": "buybutton.add-failure",
   "store/buybutton.buy-offline-success": "buybutton.buy-offline-success",
   "store/buybutton.select-sku-variations": "Please select an option of each variation",
-  "store/buybutton.cart-not-ready": "Message showed when user presses buy button but order form is not loaded yet",
   "store/buybutton.see-cart": "Button label on the notification that pops up when the user adds an item to the cart, prompting the user to see said cart",
   "store/technicalspecifications.title": "technicalspecifications.title",
   "store/availability-subscriber.title": "availability-subscriber.title",

--- a/messages/en.json
+++ b/messages/en.json
@@ -39,7 +39,6 @@
   "store/buybutton.add-failure": "Something went wrong and the item wasn't added to your cart!",
   "store/buybutton.buy-offline-success": "Item added to your offline cart",
   "store/buybutton.select-sku-variations": "Please select an option of each variation",
-  "store/buybutton.cart-not-ready": "Cart not loaded yet. Please try again in a moment.",
   "store/buybutton.see-cart": "View cart",
   "store/technicalspecifications.title": "Technical Specifications",
   "store/availability-subscriber.title": "This product isn't available right now",

--- a/messages/es.json
+++ b/messages/es.json
@@ -39,7 +39,6 @@
   "store/buybutton.add-failure": "¡Algo salió mal y el artículo no se agregó a tu carrito!",
   "store/buybutton.buy-offline-success": "Ítem agregado a su carrito offline",
   "store/buybutton.select-sku-variations": "Por favor seleccione una opción de cada variación",
-  "store/buybutton.cart-not-ready": "El carrito aún no está cargado. Vuelva a intentarlo en un momento",
   "store/buybutton.see-cart": "Ver carrito",
   "store/technicalspecifications.title": "Especificaciones Técnicas",
   "store/availability-subscriber.title": "Este producto no está disponible actualmente",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -39,7 +39,6 @@
   "store/buybutton.add-failure": "Algo deu errado e o item não pode ser adicionado ao seu carrinho!",
   "store/buybutton.buy-offline-success": "Item adicionado ao seu carrinho offline.",
   "store/buybutton.select-sku-variations": "Por favor selecione uma opção de cada variação",
-  "store/buybutton.cart-not-ready": "O carrinho ainda não está carregado. Por favor, tente novamente num instante.",
   "store/buybutton.see-cart": "Ver carrinho",
   "store/technicalspecifications.title": "Especificações Técnicas",
   "store/availability-subscriber.title": "Este produto não está disponível no momento",


### PR DESCRIPTION
… cart after it is loaded

#### What problem is this solving?

When order form is loading and BB is pressed, just call the prepare function and create a hook to call the add to cart part after order form is loaded.

#### How should this be manually tested?

https://oft--alssports.myvtex.com/patagn-jacket-retro-pile/p?skuId=581482

In this mock wks: https://oftmock--alssports.myvtex.com/patagn-vest-nano-puff/p?skuId=22739

I am artificially making an orderForm context that keeps loading, so you have 10 seconds to click on the add to cart and trigger the PR change hehe

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
