### PR TITLE
Fix space between variation name and :

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Space between variation name and `:`.
 
 ## [3.95.8] - 2019-12-19
 ### Fixed

--- a/react/components/SKUSelector/components/ErrorMessage.tsx
+++ b/react/components/SKUSelector/components/ErrorMessage.tsx
@@ -11,9 +11,11 @@ function ErrorMessage() {
   return (
     <FormattedMessage id="store/sku-selector.variation.select-an-option">
       {message => (
-        <span className={className}>
-          {message}
-        </span>
+        <>{' '}{/* this space is necessary */}
+          <span className={className}>
+            {message}
+          </span>
+        </>
       )}
     </FormattedMessage>
   )

--- a/react/components/SKUSelector/components/Variation.tsx
+++ b/react/components/SKUSelector/components/Variation.tsx
@@ -99,7 +99,7 @@ const Variation: FC<Props> = ({
               styles.skuSelectorName
               } c-muted-1 t-small overflow-hidden`}
           >
-            {name} {showErrorMessage && buyButton.clicked && !selectedItem && (<ErrorMessage />)}
+            {name}{showErrorMessage && buyButton.clicked && !selectedItem && (<ErrorMessage />)}
           </span>)}
           {displayImage && selectedItem && showValueNameForImageVariation && (
             <Fragment>


### PR DESCRIPTION
#### What problem is this solving?

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/71215034-6c42a580-2295-11ea-9465-567d95896709.png) | ![image](https://user-images.githubusercontent.com/284515/71214977-4ddcaa00-2295-11ea-9935-656fb21398ca.png)

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/star-color-top/p?skuId=2000564

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
