### PR TITLE
Fix/swiper update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix problem of swiper breaking when updating in a infinite loop.
 
 ## [3.97.0] - 2019-12-26
 ### Added

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -25,10 +25,10 @@ const CSS_HANDLES = [
 const Thumbnail = ({
   alt,
   index,
+  onThumbClick,
   height,
   thumbUrl,
   handles,
-  gallerySwiper,
   maxHeight = 150,
   aspectRatio = 'auto',
   itemContainerClasses,
@@ -37,7 +37,7 @@ const Thumbnail = ({
     <div
       className={itemContainerClasses}
       style={{ height, maxHeight: maxHeight || 'unset' }}
-      onClick={() => gallerySwiper && gallerySwiper.slideTo(index)}
+      onClick={() => onThumbClick(index)}
     >
       <figure
         className={handles.figure}
@@ -65,7 +65,7 @@ const ThumbnailSwiper = ({
   swiperParams,
   thumbUrls,
   position,
-  gallerySwiper,
+  onThumbClick,
   activeIndex,
   thumbnailAspectRatio,
   thumbnailMaxHeight,
@@ -104,7 +104,7 @@ const ThumbnailSwiper = ({
               index={i}
               handles={handles}
               height={isThumbsVertical ? 'auto' : '115px'}
-              gallerySwiper={gallerySwiper}
+              onThumbClick={onThumbClick}
               alt={slide.alt}
               thumbUrl={slide.thumbUrl || thumbUrls[i]}
               aspectRatio={thumbnailAspectRatio}

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -70,11 +70,9 @@ const initialState = {
 }
 
 class Carousel extends Component {
-  state = {
-    ...initialState,
-    thumbSwiper: null,
-    gallerySwiper: null,
-  }
+  thumbSwiper = null
+  gallerySwiper = null
+  state = initialState
 
   async setInitialVariablesState() {
     const slides = this.props.slides || []
@@ -95,13 +93,12 @@ class Carousel extends Component {
   }
 
   updateSwiperSize = debounce(() => {
-    const { thumbSwiper, gallerySwiper } = this.state
-    if (thumbSwiper) {
-      thumbSwiper.update()
+    if (this.thumbSwiper) {
+      this.thumbSwiper.update()
     }
 
-    if (gallerySwiper) {
-      gallerySwiper.update()
+    if (this.gallerySwiper) {
+      this.gallerySwiper.update()
     }
   }, 500)
 
@@ -140,23 +137,23 @@ class Carousel extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { loaded, activeIndex, gallerySwiper, thumbSwiper } = this.state
+    const { loaded, activeIndex } = this.state
     const isVideo = this.isVideo
 
     if (!equals(prevProps.slides, this.props.slides)) {
       this.setInitialVariablesState()
       this.setState(initialState)
       if (this.props.slides && this.props.slides.length > 1) {
-        gallerySwiper && gallerySwiper.slideTo(0)
-        thumbSwiper && thumbSwiper.slideTo(0)
+        this.gallerySwiper && this.gallerySwiper.slideTo(0)
+        this.thumbSwiper && this.thumbSwiper.slideTo(0)
       }
       return
     }
 
-    const paginationElement = path(['pagination', 'el'], gallerySwiper)
+    const paginationElement = path(['pagination', 'el'], this.gallerySwiper)
     if (paginationElement) paginationElement.hidden = isVideo[activeIndex]
 
-    const gallerySwiperZoom = path(['zoom'], gallerySwiper)
+    const gallerySwiperZoom = path(['zoom'], this.gallerySwiper)
 
     if (gallerySwiperZoom) {
       loaded[activeIndex]
@@ -166,7 +163,7 @@ class Carousel extends Component {
   }
 
   onSlideChange = () => {
-    const activeIndex = path(['activeIndex'], this.state.gallerySwiper)
+    const activeIndex = path(['activeIndex'], this.gallerySwiper)
     this.setState({ activeIndex, sliderChanged: true })
   }
 
@@ -214,7 +211,6 @@ class Carousel extends Component {
   }
 
   get galleryParams() {
-    const { thumbSwiper } = this.state
     const {
       cssHandles,
       slides = [],
@@ -244,7 +240,7 @@ class Carousel extends Component {
         },
       }),
       thumbs: {
-        swiper: thumbSwiper,
+        swiper: this.thumbSwiper,
       },
       threshold: 10,
       resistanceRatio: slides.length > 1 ? 0.85 : 0,
@@ -272,8 +268,8 @@ class Carousel extends Component {
         slideChange: this.onSlideChange,
       },
       getSwiper: swiper => {
-        if (this.state.gallerySwiper !== swiper) {
-          this.setState({ gallerySwiper: swiper })
+        if (this.gallerySwiper !== swiper) {
+          this.gallerySwiper = swiper
         }
       }
     }
@@ -357,15 +353,15 @@ class Carousel extends Component {
        * one thumbnail */
       slidesPerGroup: displayThumbnailsArrows ? 4 : 1,
       getSwiper: swiper => {
-        if (this.state.thumbSwiper !== swiper) {
-          this.setState({ thumbSwiper: swiper })
+        if (this.thumbSwiper !== swiper) {
+          this.thumbSwiper = swiper
         }
       }
     }
   }
 
   render() {
-    const { thumbsLoaded, gallerySwiper, activeIndex } = this.state
+    const { thumbsLoaded, activeIndex } = this.state
 
     const {
       position,
@@ -409,7 +405,7 @@ class Carousel extends Component {
         swiperParams={this.thumbnailsParams}
         thumbUrls={this.state.thumbUrl}
         position={position}
-        gallerySwiper={gallerySwiper}
+        onThumbClick={index => this.gallerySwiper && this.gallerySwiper.slideTo(index)}
         thumbnailAspectRatio={thumbnailAspectRatio}
         thumbnailMaxHeight={thumbnailMaxHeight}
       />

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -271,7 +271,11 @@ class Carousel extends Component {
       on: {
         slideChange: this.onSlideChange,
       },
-      getSwiper: swiper => this.setState({ gallerySwiper: swiper }),
+      getSwiper: swiper => {
+        if (this.state.gallerySwiper !== swiper) {
+          this.setState({ gallerySwiper: swiper })
+        }
+      }
     }
   }
 
@@ -352,7 +356,11 @@ class Carousel extends Component {
        * so that clicking on next/prev will scroll more than
        * one thumbnail */
       slidesPerGroup: displayThumbnailsArrows ? 4 : 1,
-      getSwiper: swiper => this.setState({ thumbSwiper: swiper }),
+      getSwiper: swiper => {
+        if (this.state.thumbSwiper !== swiper) {
+          this.setState({ thumbSwiper: swiper })
+        }
+      }
     }
   }
 


### PR DESCRIPTION
#### What problem is this solving?

The getSwiper method setting the swiper on state was causing some infinite loops problem.
This pr removes the `gallerySwiper` and `thumbsSwiper` from ProductImages state. It uses class ref instead. Its better for performance and probably the correct way of doing it.

https://fidimg--alssports.myvtex.com/
https://fidimg--boticario.myvtex.com/
https://fidimg--tbb.myvtex.com/
https://fidimg--melimeloparis.myvtex.com/
https://fidimg--storecomponents.myvtex.com/
https://fidimg--exitocol.myvtex.com/
https://fidimg--naturitasit.myvtex.com/
https://fidimg--paguemenos.myvtex.com/
https://fidimg--garmin.myvtex.com/
https://fidimg--motorolauk.myvtex.com/

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
