### PR TITLE
Added an unavaliable class to skuSelectorItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `unavailable` class added at `skuSelectorItem`. Appears only when product is unavailable. 
+
 ## [3.98.0] - 2020-01-02
 ### Added
 - `showValueForVariation` to `SKUSelector`.

--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -52,6 +52,7 @@ const SelectorItem: FC<Props> = ({
   const containerClasses = classNames(
     styles.skuSelectorItem,
     `${styles.skuSelectorItem}--${slug(variationValue)}`,
+    !isAvailable && styles.unavailable,
     'relative di pointer flex items-center outline-0',
     {
       [styles.skuSelectorItemImage]: isImage,

--- a/react/components/SKUSelector/styles.css
+++ b/react/components/SKUSelector/styles.css
@@ -16,6 +16,9 @@
 .skuSelectorTextContainer {
 }
 
+.unavailable {
+}
+
 .skuSelectorSelectContainer {}
 
 .skuSelectorItem {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a new class at the `skuSelectorItem` when the product is unavailable.

#### What problem is this solving?

The new class allows us to style or hide only the unavailable items on `skuSelector`.

#### How should this be manually tested?
You can test at:
https://unavailableclass--miniprix.myvtex.com/pantofi-din-piele-naturala-cu-sireturi-si-model-perforat-1947901002/p?skuId=192263

#### Screenshots or example usage
https://i.imgur.com/aG9helV.png

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
