### PR TITLE
Fix/sku selector images bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue with image sizing in the SKU Selector.
 
 ## [3.100.0] - 2020-01-13
 ### Added

--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -110,10 +110,9 @@ const SelectorItem: FC<Props> = ({
         >
           {isImage && imageUrl ? (
             <img
-              className={`${styles.skuSelectorItemImageValue} h-100`}
+              className={styles.skuSelectorItemImageValue}
               src={imageUrl}
               alt={imageLabel as string | undefined}
-              style={{ objectFit: 'contain' }}
             />
           ) : (
             variationValue

--- a/react/components/SKUSelector/components/Variation.tsx
+++ b/react/components/SKUSelector/components/Variation.tsx
@@ -155,7 +155,7 @@ const Variation: FC<Props> = ({
           )}
         </div>
         <div
-          className={`${styles.skuSelectorOptionsList} w-100 inline-flex flex-wrap ml2 flex justify-center`}
+          className={`${styles.skuSelectorOptionsList} w-100 inline-flex flex-wrap ml2 items-center`}
         >
           {mode === DisplayMode.select && !displayImage ? (
             <SelectModeVariation


### PR DESCRIPTION
#### What problem is this solving?

There was a bug where the size of the images rendered in the SKU Selector would be different from the expected one.

Reported here: https://vtex.slack.com/archives/C9P4RMW6Q/p1578941818347900

#### How should this be manually tested?

[Workspace](https://skuselectorfix--alssports.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
