### PR TITLE
Fixed sku variation order on pdp

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "vtex",
+  "root": true,
+  "env": {
+    "node": true,
+    "es6": true,
+    "jest": true
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The order of the SKU variations in the product details page. The order should be the one in the catalog now.
 
 ## [3.100.1] - 2020-01-14
 ### Fixed

--- a/react/.eslintrc.json
+++ b/react/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "vtex-react",
+  "env": {
+    "browser": true,
+    "es6": true,
+    "jest": true
+  }
+}

--- a/react/typings/product.d.ts
+++ b/react/typings/product.d.ts
@@ -8,6 +8,7 @@ export interface Product {
   titleTag: string
   metaTagDescription: string
   items: SKU[]
+  skuSpecifications: SkuSpecification[]
 }
 
 export interface Category {
@@ -38,4 +39,17 @@ interface Seller {
 
 interface CommertialOffer {
   AvailableQuantity: number
+}
+
+interface SkuSpecification {
+  field: SkuSpecificationField
+  values: SkuSpecificationValues[]
+}
+
+interface SkuSpecificationField {
+  name: string
+}
+
+interface SkuSpecificationValues {
+  name: string
 }

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -24,6 +24,20 @@ interface ProductItem {
 interface Product {
   itemMetadata: ItemMetadata
   items: ProductItem[]
+  skuSpecifications: SkuSpecification[]
+}
+
+interface SkuSpecification {
+  field: SkuSpecificationField
+  values: SkuSpecificationValues[]
+}
+
+interface SkuSpecificationField {
+  name: string
+}
+
+interface SkuSpecificationValues {
+  name: string
 }
 
 declare module 'vtex.product-context/useProduct' {


### PR DESCRIPTION
#### What problem is this solving?

This PR Fixes the ordination of the SKU variations on the PDP to be orderes as it is in the catalog. **NOTE: THIS IS ONLY WORKING FOR THE SKU VARIATION TYPES RIGHT NOW, IT IS NOT POSSIBLE TO ORDER THE VARIATIONS WITHIN A VARIATION TYPE BECAUSE OF A BUG ON THE CATALOG. EXAMPLE: YOU CAN MAKE `SIZE` COME BEFORE `COLOR` BUT YOU CAN'T MAKE `RED` COME BEFORE `BLUE`**

#### How should this be manually tested?

**TO BE TESTED**
[Workspace](https://iaronaraujo--storecomponents.myvtex.com/classic-shoes/p?skuId=35)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Without this change:

![image](https://user-images.githubusercontent.com/8443580/72459521-b5f5b180-37a9-11ea-858c-0017c70a8956.png)

With this change:

![image](https://user-images.githubusercontent.com/8443580/72459490-a1191e00-37a9-11ea-9a68-18e6b917414a.png)

