### PR TITLE
Add min items prop to sku selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `visibility` prop to `sku-selector` to show it only when it has more than one sku
+
 ## [3.100.1] - 2020-01-14
 ### Fixed
 - Issue with image sizing in the SKU Selector.
@@ -102,7 +105,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.92.8] - 2019-12-09
 ### Changed
-- Updated documentation for the following `store-components` blocks: Image, Info Card, Buy Button, Logo, Product Brand, Product Image, Product Name, Product Price and Shipping Simulator. 
+- Updated documentation for the following `store-components` blocks: Image, Info Card, Buy Button, Logo, Product Brand, Product Image, Product Name, Product Price and Shipping Simulator.
 
 ## [3.92.7] - 2019-12-06
 ### Fixed

--- a/docs/SKUSelector.md
+++ b/docs/SKUSelector.md
@@ -85,7 +85,7 @@ The SKU Selector is a Product Details Page block and it is responsible for displ
 | Value           | Description                                                               |
 | --------------- | ------------------------------------------------------------------------- |
 | `always`        | It will show the SKU selector even if the product has only one SKU        |
-| `more-than-one` | It will show the SKU selector only when the product has more than one SKU |
+| `more-than-one` | It will show the SKU selector only when the product has more than one SKU option |
 
 ## Customization
 

--- a/docs/SKUSelector.md
+++ b/docs/SKUSelector.md
@@ -52,8 +52,9 @@ The SKU Selector is a Product Details Page block and it is responsible for displ
 | `showVariationsErrorMessage`     | `boolean`                                            | If an error message should be displayed when the `BuyButton` is clicked on but didn't select an option for each available variation                                                                                                                         | `true`                              |
 | `displayMode`                    | `Enum`                                               | How the variations will be displayed. It doesn't apply to image variations. Notice that this prop is _responsive_, so you can specify a value for each breakpoint.                                                                                          | `default`                           |
 | `sliderDisplayThreshold`         | `Number`                                             | Controls the maximum number of SKUs that should be displayed using `'default'` displayMode before using displayMode `'slider'`. Notice this prop only takes effect you `displayMode` is set to `slider`.                                                    | `3`                                 |
-| `sliderArrowSize`            | `Enum`                                               | Controls the size (height and width) in pixels of the navigation arrows rendered when `displayMode` is set to `"slider"`.                                                                                                                                   | `12`                                |
+| `sliderArrowSize`                | `Enum`                                               | Controls the size (height and width) in pixels of the navigation arrows rendered when `displayMode` is set to `"slider"`.                                                                                                                                   | `12`                                |
 | `sliderItemsPerPage`             | `{ desktop: Number, tablet: Number, phone: Number }` | Controls how many slides should be shown on each type of device when `displayMode` is set to `slider`.                                                                                                                                                      | `{desktop: 3, tablet: 2, phone: 1}` |
+| `visibility`                     | `Enum`                                               | Controls when the SKU selector shows depending on the mumber of items available                                                                                                                                                                             | `always`                            |
 
 - Possible values for `ShowValueForVariation`:
 
@@ -78,6 +79,13 @@ The SKU Selector is a Product Details Page block and it is responsible for displ
 | `complete` | Complete | It will select the variations values of the first SKU available                                |
 | `image`    | Image    | It will select the first image variation (like Color). All other variations will be unselected |
 | `empty`    | Empty    | All variations will appear as unselected when the page is loaded                               |
+
+- Possible values for `visibility`:
+
+| Value           | Description                                                               |
+| --------------- | ------------------------------------------------------------------------- |
+| `always`        | It will show the SKU selector even if the product has only one SKU        |
+| `more-than-one` | It will show the SKU selector only when the product has more than one SKU |
 
 ## Customization
 

--- a/docs/SKUSelector.md
+++ b/docs/SKUSelector.md
@@ -84,7 +84,7 @@ The SKU Selector is a Product Details Page block and it is responsible for displ
 
 | Value           | Description                                                               |
 | --------------- | ------------------------------------------------------------------------- |
-| `always`        | It will show the SKU selector even if the product has only one SKU        |
+| `always`        | It will show the SKU selector even if the product has only one SKU option        |
 | `more-than-one` | It will show the SKU selector only when the product has more than one SKU option |
 
 ## Customization

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -62,7 +62,7 @@ interface Props {
   skuSelected: ProductItem
   onSKUSelected?: (skuId: string) => void
   maxItems?: number
-  minItems?: number
+  visibility?: string
   seeMoreLabel: string
   hideImpossibleCombinations?: boolean
   showValueNameForImageVariation?: boolean
@@ -98,13 +98,13 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
       ? props.skuSelected
       : valuesFromContext.selectedItem
 
-  const minItems = props.minItems != null ? props.minItems : 1
+  const visibility = props.visibility != null ? props.visibility : 'always'
 
   const shouldNotShow =
     skuItems.length === 0 ||
     !skuSelected?.variations ||
     skuSelected.variations.length === 0 ||
-    skuItems.length < minItems
+    (visibility === 'more-than-one' && skuItems.length === 1)
 
   const variations = useVariations(
     skuItems,

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -62,6 +62,7 @@ interface Props {
   skuSelected: ProductItem
   onSKUSelected?: (skuId: string) => void
   maxItems?: number
+  minItems?: number
   seeMoreLabel: string
   hideImpossibleCombinations?: boolean
   showValueNameForImageVariation?: boolean
@@ -97,10 +98,13 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
       ? props.skuSelected
       : valuesFromContext.selectedItem
 
+  const minItems = props.minItems != null ? props.minItems : 1
+
   const shouldNotShow =
     skuItems.length === 0 ||
     !skuSelected?.variations ||
-    skuSelected.variations.length === 0
+    skuSelected.variations.length === 0 ||
+    skuItems.length < minItems
 
   const variations = useVariations(
     skuItems,


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
To be able to show sku selector only when a minimum quantity of skus is presented

#### How should this be manually tested?

https://gris--storecomponents.myvtex.com/traveler-backpack/p has only one sku and thus the selector is not displayed (minItems is set to 2 in the theme)

https://gris--storecomponents.myvtex.com/classic-shoes/p has more than 1 sku and thus the selector is being displayed

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

