### PR TITLE
Fix product specifications values exibition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix specification values exibition. It was showing just the first value of the array.
+
 ## [3.102.1] - 2020-01-23
 ### Changed
 - Ordered `SearchBar` props on readme.

--- a/react/components/ProductSpecifications/index.js
+++ b/react/components/ProductSpecifications/index.js
@@ -54,7 +54,7 @@ const ProductSpecifications = ({
     const mappedSpecifications = specifications.map(specification => {
       return {
         property: specification.name,
-        specifications: specification.values[0],
+        specifications: specification.values.join(", "),
       }
     })
 


### PR DESCRIPTION
#### What problem is this solving?

Carrefour and ACCT reported a bug in which the values of the product specifications were not being displayed correctly in the product details page. It was showing just the first value of the array. This PR aims to fix that problem, by showing all the values of the array.

#### How should this be manually tested?

- In `vtexcommercestable`, the values are correct: [Evidence in vtexcommercestable](https://carrefourbr.vtexcommercestable.com.br/teste-02/p)
![image](https://user-images.githubusercontent.com/19555647/73476129-74036880-4370-11ea-84ee-a39d45dfad77.png)

- In the workspace `master`, it doesn't show all the values: [Evidence in master](https://carrefourbr.myvtex.com/teste-02/p)
![image](https://user-images.githubusercontent.com/19555647/73476425-f1c77400-4370-11ea-9d9d-bec28f9f328d.png)

- [Linked workspace with the fix](https://phdro--carrefourbr.myvtex.com/teste-02/p)
![image](https://user-images.githubusercontent.com/19555647/73476540-305d2e80-4371-11ea-94a8-ebdf7ccf3ecd.png)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
Tests in `carrefourbr`

**Before**
![before](https://user-images.githubusercontent.com/19555647/73474740-b7a8a300-436d-11ea-84b9-b8aa79eff74a.png)
**After**
![after](https://user-images.githubusercontent.com/19555647/73474764-c1320b00-436d-11ea-97b7-714cf5839007.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
