### PR TITLE
Add translations of the title of the image component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Translations for the prop `title` of the `image` block.
 
 ## [3.102.2] - 2020-01-30
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -124,6 +124,8 @@
   "admin/editor.image.title": "Image",
   "admin/editor.image.description": "Show any image",
   "admin/editor.image.src.title": "Image",
+  "admin/editor.image.title.title": "Image title",
+  "admin/editor.image.title.description": "Title to be shown on hover",
   "admin/editor.image.alt.title": "Alternative text",
   "admin/editor.product-images.title": "ProductImages component title on storefront",
   "admin/editor.product-images.description": "Description of ProductImages component",

--- a/messages/en.json
+++ b/messages/en.json
@@ -124,6 +124,8 @@
   "admin/editor.image.title": "Image",
   "admin/editor.image.description": "Show any image",
   "admin/editor.image.src.title": "Image",
+  "admin/editor.image.title.title": "Image title",
+  "admin/editor.image.title.description": "Title to be shown on hover",
   "admin/editor.image.alt.title": "Alternative text",
   "admin/editor.product-images.title": "Product Images",
   "admin/editor.product-images.description": "Product images component allow you to customize the product images",

--- a/messages/es.json
+++ b/messages/es.json
@@ -124,6 +124,8 @@
   "admin/editor.image.title": "Imagen",
   "admin/editor.image.description": "Mostrar cualquier imagen",
   "admin/editor.image.src.title": "Imagen",
+  "admin/editor.image.title.title": "Título de la imagen",
+  "admin/editor.image.title.description": "Título que se mostrará al pasar el mouse sobre la imagen",
   "admin/editor.image.alt.title": "Texto alternativo",
   "admin/editor.product-images.title": "Product Images",
   "admin/editor.product-images.description": "El componente de imágenes del producto le permite personalizar las imágenes del producto",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -124,6 +124,8 @@
   "admin/editor.image.title": "Imagem",
   "admin/editor.image.description": "Exiba qualquer imagem",
   "admin/editor.image.src.title": "Imagem",
+  "admin/editor.image.title.title": "Título da imagem",
+  "admin/editor.image.title.description": "Título a ser mostrado quando você passa o mouse pela imagem",
   "admin/editor.image.alt.title": "Texto alternativo",
   "admin/editor.product-images.title": "Imagems do produto",
   "admin/editor.product-images.description": "Componente que permite personalizar propriedades das imagens do produto",


### PR DESCRIPTION
#### What problem is this solving?

Related to https://github.com/vtex-apps/store-image/pull/9

#### How should this be manually tested?

[Workspace](https://imagetitle--storecomponents.myvtex.com/admin/cms/site-editor/about-us) hover the image

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
