### PR TITLE
Dispatch SELECT_IMAGE_VARIATION when selection a image variation sku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Dispatch `SELECT_IMAGE_VARIATION` action when manually selecting a image variant SKU
 
 ## [3.102.2] - 2020-01-30
 

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -165,7 +165,9 @@ const getNewSelectedVariations = (
 
   if (hasSkuInQuery || initialSelection === InitialSelectionType.complete) {
     return selectedVariationFromItem(parsedSku, variations)
-  } else if (initialSelection === InitialSelectionType.image) {
+  }
+
+  if (initialSelection === InitialSelectionType.image) {
     const colorVariationName = parsedSku.variations.find(isColor)
     return {
       ...emptyVariations,
@@ -246,6 +248,8 @@ const SKUSelectorContainer: FC<Props> = ({
 
   const imagesMap = useImagesMap(parsedItems, variations, thumbnailImage)
 
+  const dispatch = useProductDispatch()
+
   const onSelectItem = useCallback(
     ({
       name: variationName,
@@ -291,6 +295,17 @@ const SKUSelectorContainer: FC<Props> = ({
           finalSelected
         )
         skuIdToRedirect = newItem!.itemId
+      }
+
+      // if (un)selecting a color variation, dispatch to the product context
+      // so we can show/hide the mainImageLabel if defined
+      if(isColor(variationName)) {
+        dispatch({
+          type: 'SELECT_IMAGE_VARIATION',
+          args: {
+            selectedImageVariationSKU: isRemoving ? null : skuIdToRedirect
+          }
+        })
       }
 
       if (isRemoving) {


### PR DESCRIPTION
#### What problem is this solving?

Currently, we can't know if a sku was selected internally/automatically or manually (user click). This PR makes the selection method dispatch an action that modifies the product context, defining a manually selected sku (or null, if unselecting).

Related to: https://github.com/vtex-apps/product-summary/pull/236 and https://github.com/vtex-apps/product-context/pull/19

https://app.clubhouse.io/vtex/story/30770/mainimagelabel-should-not-affect-sku-selector-image-behavior

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?


1) https://kiwi--worldwidegolf.myvtex.com/
2) In `home`, check if the golf ball product is displaying a box
3) Click in a color variant
4) Image should change to that color
5) Click again, to remove the color
6) Should display the box again


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
