### PR TITLE
Fix/sku query id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Only define a selected SKU if all visible variations are set.
+- Handle initial empty SKU selection.
 
 ## [3.102.6] - 2020-02-11
 ### Added
@@ -22,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.102.3] - 2020-02-10
 ### Fixed
 - French color typo
-  
+
 ## [3.102.2] - 2020-01-30
 
 ### Fixed

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -135,7 +135,8 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
     pick(['imageHeight', 'imageWidth'], props)
   )
 
-  const shouldSelectInitialSKU = props.initialSelection !== 'empty'
+  const shouldSelectInitialSKU =
+    props.initialSelection !== InitialSelectionType.empty
 
   const skuItems =
     props.skuItems != null

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -106,7 +106,7 @@ const useVariations = (
 
 interface Props {
   skuItems: ProductItem[]
-  skuSelected: ProductItem
+  skuSelected: ProductItem | null
   onSKUSelected?: (skuId: string) => void
   maxItems?: number
   visibility?: string
@@ -134,22 +134,25 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
   const { imageHeight, imageWidth } = useResponsiveValues(
     pick(['imageHeight', 'imageWidth'], props)
   )
+
+  const shouldSelectInitialSKU = props.initialSelection !== 'empty'
+
   const skuItems =
     props.skuItems != null
       ? props.skuItems
       : valuesFromContext?.product?.items ?? []
 
-  const skuSelected =
-    props.skuSelected != null
-      ? props.skuSelected
-      : valuesFromContext.selectedItem
+  let skuSelected = props.skuSelected ?? null
+  if (shouldSelectInitialSKU && skuSelected == null) {
+    skuSelected = valuesFromContext.selectedItem
+  }
 
   const visibility = props.visibility != null ? props.visibility : 'always'
 
   const shouldNotShow =
     skuItems.length === 0 ||
-    !skuSelected?.variations ||
-    skuSelected.variations.length === 0 ||
+    skuSelected?.variations.length === 0 ||
+    (shouldSelectInitialSKU && skuSelected == null) ||
     (visibility === 'more-than-one' && skuItems.length === 1)
 
   const skuSpecifications = valuesFromContext?.product?.skuSpecifications ?? []
@@ -169,7 +172,7 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
     }
   }, [shouldNotShow, dispatch])
 
-  if (shouldNotShow || !skuSelected) {
+  if (shouldNotShow) {
     return null
   }
 

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -151,9 +151,9 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
   const visibility = props.visibility != null ? props.visibility : 'always'
 
   const shouldNotShow =
+    (shouldSelectInitialSKU && skuSelected == null) ||
     skuItems.length === 0 ||
     skuSelected?.variations.length === 0 ||
-    (shouldSelectInitialSKU && skuSelected == null) ||
     (visibility === 'more-than-one' && skuItems.length === 1)
 
   const skuSpecifications = valuesFromContext?.product?.skuSpecifications ?? []

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -1,7 +1,7 @@
 declare module 'vtex.render-runtime' {
   interface Runtime {
-    setQuery: (vars: { skuId: string }, options?: { replace?: boolean } ) => void
-    query?: { skuId?: string }
+    setQuery: (vars: { skuId: string }, options?: { replace?: boolean }) => void
+    query?: Record<string, string>
   }
   export const useRuntime: () => Runtime
 }


### PR DESCRIPTION
#### What problem is this solving?

- Only define a selected SKU if all visible variations have a selection.
- When `initialSelection` is `empty`, don't set initial SKU and wait for the user to manually select one.

#### How should this be manually tested?

1. Go to: https://kiwi--worldwidegolf.myvtex.com/
2. In the shelf, check the url of a product with a lot of variations. It should have no `skuId` in its redirect URL.
3. Select a color SKU. It still should have no `skuId` in its URL.
4. Select all other variations. The URL now should contain the `skuId=...` parameter.

Other accounts/workspaces: 

- https://kiwi--redoxx.myvtex.com/ (unselect a variation from a sku selector and note the summaries URLs don't contain the `skuId` query value compared with https://kiwi--redoxx.myvtex.com/)
- https://kiwi--garmin.myvtex.com/ (unselect a variation from a sku selector and note the summaries URLs don't contain the `skuId` query value compared with https://garmin.myvtex.com/)
- https://kiwi--umbro.myvtex.com/ (unselect a variation from a sku selector and note the summaries URLs don't contain the `skuId` query value compared with https://umbro.myvtex.com/)

Related to: https://github.com/vtex-apps/product-summary/pull/237
Clubhouse Story: https://app.clubhouse.io/vtex/story/31692/improve-sku-selector-on-shelf-initialstate-empty

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
