### PR TITLE
Fix interaction between hiddenSpecifications and visibleSpecifciations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stop considering empty arrays to `visibleSpecifications` and `hiddenSpecifications` in `ProductSpecfications`.
 
 ## [3.102.7] - 2020-02-12
 ### Fixed

--- a/react/components/ProductSpecifications/Wrapper.js
+++ b/react/components/ProductSpecifications/Wrapper.js
@@ -26,9 +26,7 @@ const ProductSpecificationsWrapper = ({
   collapsible = 'always',
 }) => {
   const productContext = useProduct()
-
-  const specifications =
-    propsSpecifications || getSpecifications(productContext)
+  const specifications = propsSpecifications || getSpecifications(productContext)
 
   return (
     <ProductSpecifications

--- a/react/components/ProductSpecifications/index.js
+++ b/react/components/ProductSpecifications/index.js
@@ -58,7 +58,8 @@ const ProductSpecifications = ({
       }
     })
 
-    if (visibleSpecifications && hiddenSpecifications) {
+    if (visibleSpecifications && visibleSpecifications.length > 0
+      && hiddenSpecifications && hiddenSpecifications.length > 0) {
       console.warn(
         'A product-specification block is using both visibleSpecifications and hiddenSpecifications props at the same time. Please choose only one of them.'
       )
@@ -66,7 +67,7 @@ const ProductSpecifications = ({
       return mappedSpecifications
     }
 
-    if (visibleSpecifications) {
+    if (visibleSpecifications && visibleSpecifications.length > 0) {
       return mappedSpecifications.filter(specification =>
         visibleSpecifications.find(
           filter =>
@@ -74,7 +75,7 @@ const ProductSpecifications = ({
         )
       )
     }
-    if (hiddenSpecifications) {
+    if (hiddenSpecifications && hiddenSpecifications.length > 0) {
       return mappedSpecifications.filter(
         specification =>
           !hiddenSpecifications.find(


### PR DESCRIPTION
#### What problem is this solving?



#### How should this be manually tested?

[The lifestyle spec is not showing because is in the hiddenSpecifications](https://hidden--redoxx.myvtex.com/safari-beanos-bag-pr5-91031/p)
[Lifestyle spec showing](https://redoxx.myvtex.com/safari-beanos-bag-pr5-91031/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
