### PR TITLE
Feat/display mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `displayMode` prop to define the behavior of buttons on the `SearchBar` component.
+
+### Changed
+- Deprecate `submitOnIconClick` prop from `SearchBar` in favor of `displayMode`.
 
 ## [3.103.0] - 2020-02-14
 ### Added

--- a/docs/SearchBar.md
+++ b/docs/SearchBar.md
@@ -59,11 +59,13 @@ Then, add `search-bar` block into your app theme, as we do in our [Store Header]
 
 Below, we describe the namespace that are defined in the `SearchBar`.
 
-| Class name            | Description                                                           | Component Source                                                                 |
-| --------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `searchBarContainer`  | The main container of `SearchBar`                                     | [SearchBar](/react/components/SearchBar/components/SearchBar.js)                 |
-| `compactMode`         | Properties to be applied to the input when `compactMode` prop is true | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `paddingInput`        | The padding of the `SearchBar` input                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `searchBarIcon`       | Targets the search bar icon                                           | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `searchBarSearchIcon` | Targets the search bar _search_ icon                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `searchBarClearIcon`  | Targets the search bar _clear_ icon                                   | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| Class name                       | Description                                                           | Component Source                                                                 |
+| -------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `searchBarContainer`             | The main container of `SearchBar`                                     | [SearchBar](/react/components/SearchBar/components/SearchBar.js)                 |
+| `compactMode`                    | Properties to be applied to the input when `compactMode` prop is true | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `paddingInput`                   | The padding of the `SearchBar` input                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarIcon`                  | Targets the search bar icon                                           | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarIcon--prefix`          | Targets the search bar _prefix_ icon icon                             | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarIcon--search`          | Targets the search bar _search_ icon                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarIcon--external-search` | Targets the search bar external _search_ icon                         | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarIcon--clear`           | Targets the search bar _clear_ icon                                   | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |

--- a/docs/SearchBar.md
+++ b/docs/SearchBar.md
@@ -20,31 +20,40 @@ Then, add `search-bar` block into your app theme, as we do in our [Store Header]
 
 ### Props
 
-| Prop name                 | Type                                          | Description                                                                                                                                       | Default value |
-| ------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `attemptPageTypeSearch`   | `Boolean` | If `true` when clicked on result link of brand, department or category will link to the corresponding brand, department or category page. When `false` will always go to a full text search page.  | `false`        |
-| `autocompleteAlignment`   | [`HorizontalAlignment`](#horizontalalignment) | Autocomplete Horizontal alignment.                                                                                                                | `left`        |
-| `autocompleteFullWidth`  | `Boolean`                                     | If true, the autocomplete will fill the whole window horizontally.                                                                                | `false`       |
-| `autoFocus`               | `Boolean`                                     | Identify if the search input should autofocus or not                                                                                              | -             |
-| `blurOnSubmit`            | `Boolean`                                     | Identify if input should blur on submit.                                                                                                          | `false`       |
-| `compactMode`             | `Boolean`                                     | Identify when to use the compact version of the component                                                                                         | -             |
-| `customSearchPageUrl`     | `string`                                      | Template for a custom url. It can have a substring `${term}` used as placeholder to interpolate the searched term. (e.g. `/search?query=${term}`) | -             |
-| `emptyPlaceholder`        | `String!`                                     | Shows a placeholder when the ResultList hasn't results to displayed                                                                               | -             |
-| `hasIconLeft`             | `Boolean`                                     | Identify if the search icon is on left or right position                                                                                          | -             |
-| ~`iconClasses`~           | `String`                                      | **DEPRECATED** ~Custom classes for the search icon~ Use the CSS handle `searchBarIcon`.                                                           | -             |
-| `maxWidth`                | `Number` \| `String`                          | Max width of the search bar                                                                                                                       | -             |
-| `minSearchTermLength`     | `Number`                                      | If defined, it will block searches where the term length is lesser than `minSearchTermLength`.                                                    | -             |
-| `openAutocompleteOnFocus` | `Boolean`                                     | Identify if autocomplete should be open on input focus or not.                                                                                    | `false`       |
- `placeholder`             | `String!`                                     | Placeholder to be used on the input                                                                                                               | -             |
-| `submitOnIconClick`       | `Boolean`                                     | Identify if search icon should submit on click.                                                                                                   | `false`       |
+| Prop name                 | Type                                          | Description                                                                                                                                                                                       | Default value  |
+| ------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `attemptPageTypeSearch`   | `Boolean`                                     | If `true` when clicked on result link of brand, department or category will link to the corresponding brand, department or category page. When `false` will always go to a full text search page. | `false`        |
+| `autocompleteAlignment`   | [`HorizontalAlignment`](#horizontalalignment) | Autocomplete Horizontal alignment.                                                                                                                                                                | `left`         |
+| `autocompleteFullWidth`   | `Boolean`                                     | If true, the autocomplete will fill the whole window horizontally.                                                                                                                                | `false`        |
+| `autoFocus`               | `Boolean`                                     | Identify if the search input should autofocus or not                                                                                                                                              | -              |
+| `blurOnSubmit`            | `Boolean`                                     | Identify if input should blur on submit.                                                                                                                                                          | `false`        |
+| `compactMode`             | `Boolean`                                     | Identify when to use the compact version of the component                                                                                                                                         | -              |
+| `customSearchPageUrl`     | `string`                                      | Template for a custom url. It can have a substring `${term}` used as placeholder to interpolate the searched term. (e.g. `/search?query=${term}`)                                                 | -              |
+| `emptyPlaceholder`        | `String!`                                     | Shows a placeholder when the ResultList hasn't results to displayed                                                                                                                               | -              |
+| `hasIconLeft`             | `Boolean`                                     | Identify if the search icon is on left or right position                                                                                                                                          | -              |
+| ~`iconClasses`~           | `String`                                      | **DEPRECATED** ~Custom classes for the search icon~ Use the CSS handle `searchBarIcon`.                                                                                                           | -              |
+| `maxWidth`                | `Number` \| `String`                          | Max width of the search bar                                                                                                                                                                       | -              |
+| `minSearchTermLength`     | `Number`                                      | If defined, it will block searches where the term length is lesser than `minSearchTermLength`.                                                                                                    | -              |
+| `openAutocompleteOnFocus` | `Boolean`                                     | Identify if autocomplete should be open on input focus or not.                                                                                                                                    | `false`        |
+| `placeholder`             | `String!`                                     | Placeholder to be used on the input                                                                                                                                                               | -              |
+| ~`submitOnIconClick`~     | `Boolean`                                     | **DEPRECATED** - ~Identify if search icon should submit on click.~ Use the `displayMode` prop instead.                                                                                            | `false`        |
+| `displayMode`             | [`DisplayMode`](#displaymode)                 | Define the component display mode,such as which buttons should be visible                                                                                                                         | `clear-button` |
+
+### `DisplayMode`
+
+| Enum name                  | Enum value                   | Empty state                                                                                                                             | Filled state                                                                                                                             |
+| -------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `clear-button`             | `'clear-button'`             | ![clear-button-empty](https://user-images.githubusercontent.com/12702016/74764904-5cc5e580-5261-11ea-9df8-484cf457c266.png)             | ![clear-button-filled](https://user-images.githubusercontent.com/12702016/74764917-60f20300-5261-11ea-8911-11c8fd9582d9.png)             |
+| `search-button`            | `'search-button'`            | ![search-and-clear-buttons-empty](https://user-images.githubusercontent.com/12702016/74764924-62bbc680-5261-11ea-9f1d-2118274da996.png) | ![search-and-clear-buttons-filled](https://user-images.githubusercontent.com/12702016/74764928-64858a00-5261-11ea-9ed2-42da887e6641.png) |
+| `search-and-clear-buttons` | `'search-and-clear-buttons'` | ![search-button-empty](https://user-images.githubusercontent.com/12702016/74764929-65b6b700-5261-11ea-815c-ecc9f0c44e0f.png)            | ![search-button-filled](https://user-images.githubusercontent.com/12702016/74764934-66e7e400-5261-11ea-8a86-59da9a1c0faa.png)            |
 
 ### `HorizontalAlignment`
 
 | Enum name | Enum value |
 | --------- | ---------- |
-| left      | 'left'     |
-| center    | 'center'   |
-| right     | 'right'    |
+| `left`    | `'left'`   |
+| `center`  | `'center'` |
+| `right`   | `'right'`  |
 
 ### CSS Handles
 

--- a/docs/SearchBar.md
+++ b/docs/SearchBar.md
@@ -62,6 +62,7 @@ Below, we describe the namespace that are defined in the `SearchBar`.
 | Class name                       | Description                                                           | Component Source                                                                 |
 | -------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | `compactMode`                    | Properties to be applied to the input when `compactMode` prop is true | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `externalSearchButtonWrapper`    | Targets the external search bar icon wrapper                          | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
 | `paddingInput`                   | The padding of the `SearchBar` input                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
 | `searchBarContainer`             | The main container of `SearchBar`                                     | [SearchBar](/react/components/SearchBar/components/SearchBar.js)                 |
 | `searchBarIcon--clear`           | Targets the search bar _clear_ icon                                   | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
@@ -69,3 +70,4 @@ Below, we describe the namespace that are defined in the `SearchBar`.
 | `searchBarIcon--prefix`          | Targets the search bar _prefix_ icon icon                             | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
 | `searchBarIcon--search`          | Targets the search bar _search_ icon                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
 | `searchBarIcon`                  | Targets the search bar icon                                           | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `suffixWrapper`                  | Targets the wrapper for all the input sufixes wrapper                 | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |

--- a/docs/SearchBar.md
+++ b/docs/SearchBar.md
@@ -59,9 +59,11 @@ Then, add `search-bar` block into your app theme, as we do in our [Store Header]
 
 Below, we describe the namespace that are defined in the `SearchBar`.
 
-| Class name           | Description                                                           | Component Source                                                                 |
-| -------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `searchBarContainer` | The main container of `SearchBar`                                     | [SearchBar](/react/components/SearchBar/components/SearchBar.js)                 |
-| `compactMode`        | Properties to be applied to the input when `compactMode` prop is true | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `paddingInput`       | The padding of the `SearchBar` input                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `searchBarIcon`      | The class that targets the search bar icon                            | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| Class name            | Description                                                           | Component Source                                                                 |
+| --------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `searchBarContainer`  | The main container of `SearchBar`                                     | [SearchBar](/react/components/SearchBar/components/SearchBar.js)                 |
+| `compactMode`         | Properties to be applied to the input when `compactMode` prop is true | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `paddingInput`        | The padding of the `SearchBar` input                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarIcon`       | Targets the search bar icon                                           | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarSearchIcon` | Targets the search bar _search_ icon                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarClearIcon`  | Targets the search bar _clear_ icon                                   | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |

--- a/docs/SearchBar.md
+++ b/docs/SearchBar.md
@@ -29,30 +29,30 @@ Then, add `search-bar` block into your app theme, as we do in our [Store Header]
 | `blurOnSubmit`            | `Boolean`                                     | Identify if input should blur on submit.                                                                                                                                                          | `false`        |
 | `compactMode`             | `Boolean`                                     | Identify when to use the compact version of the component                                                                                                                                         | -              |
 | `customSearchPageUrl`     | `string`                                      | Template for a custom url. It can have a substring `${term}` used as placeholder to interpolate the searched term. (e.g. `/search?query=${term}`)                                                 | -              |
+| `displayMode`             | [`DisplayMode`](#displaymode)                 | Define the component display mode,such as which buttons should be visible                                                                                                                         | `clear-button` |
 | `emptyPlaceholder`        | `String!`                                     | Shows a placeholder when the ResultList hasn't results to displayed                                                                                                                               | -              |
 | `hasIconLeft`             | `Boolean`                                     | Identify if the search icon is on left or right position                                                                                                                                          | -              |
-| ~`iconClasses`~           | `String`                                      | **DEPRECATED** ~Custom classes for the search icon~ Use the CSS handle `searchBarIcon`.                                                                                                           | -              |
 | `maxWidth`                | `Number` \| `String`                          | Max width of the search bar                                                                                                                                                                       | -              |
 | `minSearchTermLength`     | `Number`                                      | If defined, it will block searches where the term length is lesser than `minSearchTermLength`.                                                                                                    | -              |
 | `openAutocompleteOnFocus` | `Boolean`                                     | Identify if autocomplete should be open on input focus or not.                                                                                                                                    | `false`        |
 | `placeholder`             | `String!`                                     | Placeholder to be used on the input                                                                                                                                                               | -              |
-| ~`submitOnIconClick`~     | `Boolean`                                     | **DEPRECATED** - ~Identify if search icon should submit on click.~ Use the `displayMode` prop instead.                                                                                            | `false`        |
-| `displayMode`             | [`DisplayMode`](#displaymode)                 | Define the component display mode,such as which buttons should be visible                                                                                                                         | `clear-button` |
+| ~`iconClasses`~           | `String`                                      | ![DEPRECATED](https://img.shields.io/badge/-deprecated-red) ~Custom classes for the search icon~ Use the CSS handle `searchBarIcon`.                                                              | -              |
+| ~`submitOnIconClick`~     | `Boolean`                                     | ![DEPRECATED](https://img.shields.io/badge/-deprecated-red) - ~Identify if search icon should submit on click.~ Use the `displayMode` prop instead.                                               | `false`        |
 
 ### `DisplayMode`
 
 | Enum name                  | Enum value                   | Empty state                                                                                                                             | Filled state                                                                                                                             |
 | -------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `clear-button`             | `'clear-button'`             | ![clear-button-empty](https://user-images.githubusercontent.com/12702016/74764904-5cc5e580-5261-11ea-9df8-484cf457c266.png)             | ![clear-button-filled](https://user-images.githubusercontent.com/12702016/74764917-60f20300-5261-11ea-8911-11c8fd9582d9.png)             |
-| `search-button`            | `'search-button'`            | ![search-and-clear-buttons-empty](https://user-images.githubusercontent.com/12702016/74764924-62bbc680-5261-11ea-9f1d-2118274da996.png) | ![search-and-clear-buttons-filled](https://user-images.githubusercontent.com/12702016/74764928-64858a00-5261-11ea-9ed2-42da887e6641.png) |
 | `search-and-clear-buttons` | `'search-and-clear-buttons'` | ![search-button-empty](https://user-images.githubusercontent.com/12702016/74764929-65b6b700-5261-11ea-815c-ecc9f0c44e0f.png)            | ![search-button-filled](https://user-images.githubusercontent.com/12702016/74764934-66e7e400-5261-11ea-8a86-59da9a1c0faa.png)            |
+| `search-button`            | `'search-button'`            | ![search-and-clear-buttons-empty](https://user-images.githubusercontent.com/12702016/74764924-62bbc680-5261-11ea-9f1d-2118274da996.png) | ![search-and-clear-buttons-filled](https://user-images.githubusercontent.com/12702016/74764928-64858a00-5261-11ea-9ed2-42da887e6641.png) |
 
 ### `HorizontalAlignment`
 
 | Enum name | Enum value |
 | --------- | ---------- |
-| `left`    | `'left'`   |
 | `center`  | `'center'` |
+| `left`    | `'left'`   |
 | `right`   | `'right'`  |
 
 ### CSS Handles
@@ -61,11 +61,11 @@ Below, we describe the namespace that are defined in the `SearchBar`.
 
 | Class name                       | Description                                                           | Component Source                                                                 |
 | -------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `searchBarContainer`             | The main container of `SearchBar`                                     | [SearchBar](/react/components/SearchBar/components/SearchBar.js)                 |
 | `compactMode`                    | Properties to be applied to the input when `compactMode` prop is true | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
 | `paddingInput`                   | The padding of the `SearchBar` input                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `searchBarIcon`                  | Targets the search bar icon                                           | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarContainer`             | The main container of `SearchBar`                                     | [SearchBar](/react/components/SearchBar/components/SearchBar.js)                 |
+| `searchBarIcon--clear`           | Targets the search bar _clear_ icon                                   | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarIcon--external-search` | Targets the search bar external _search_ icon                         | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
 | `searchBarIcon--prefix`          | Targets the search bar _prefix_ icon icon                             | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
 | `searchBarIcon--search`          | Targets the search bar _search_ icon                                  | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `searchBarIcon--external-search` | Targets the search bar external _search_ icon                         | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
-| `searchBarIcon--clear`           | Targets the search bar _clear_ icon                                   | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |
+| `searchBarIcon`                  | Targets the search bar icon                                           | [AutocompleteInput](/react/components/SearchBar/components/AutocompleteInput.js) |

--- a/react/__mocks__/vtex.css-handles.js
+++ b/react/__mocks__/vtex.css-handles.js
@@ -10,7 +10,7 @@ export const useCssHandles = cssHandles => {
 }
 
 export function applyModifiers(baseClass, modifier) {
-  return `${baseClass}--${modifier}`
+  return [baseClass, `${baseClass}--${modifier}`].join(' ')
 }
 
 export const withCssHandles = (handles = [], options) => Component => {
@@ -19,7 +19,7 @@ export const withCssHandles = (handles = [], options) => Component => {
 
     return <Component cssHandles={cssHandles} {...props} />
   }
-  
+
   const displayName = Component.displayName || Component.name || 'Component'
   EnhancedComponent.displayName = `withCssHandles(${displayName})`
 

--- a/react/__tests__/components/SearchBar.test.js
+++ b/react/__tests__/components/SearchBar.test.js
@@ -38,14 +38,14 @@ describe('<SearchBar />', () => {
   })
 
   it('should have CSS handle searchBarIcon', () => {
-    const { container, debug } = renderComponent()
+    const { container } = renderComponent()
     const element = container.querySelector('.searchBarIcon')
 
     expect(element).toBeTruthy()
   })
 
   it('should display internal search icon button', () => {
-    const { container, debug } = renderComponent({
+    const { container } = renderComponent({
       displayMode: 'search-button',
     })
 
@@ -53,16 +53,16 @@ describe('<SearchBar />', () => {
   })
 
   it('should display internal clear icon button when a value is typed', () => {
-    const { container, debug } = renderComponent({
+    const { container } = renderComponent({
       displayMode: 'search-button',
-      value: 'foo'
+      value: 'foo',
     })
 
     expect(container.querySelector('.searchBarIcon--search')).toBeTruthy()
   })
 
   it('should display external search icon button', () => {
-    const { container, debug } = renderComponent({
+    const { container } = renderComponent({
       displayMode: 'search-and-clear-buttons',
     })
 
@@ -72,13 +72,11 @@ describe('<SearchBar />', () => {
   })
 
   it('should display interal clear icon button when a value is typed', () => {
-    const { container, debug } = renderComponent({
+    const { container } = renderComponent({
       displayMode: 'search-and-clear-buttons',
-      value: 'foo'
+      value: 'foo',
     })
 
-    expect(
-      container.querySelector('.searchBarIcon--clear')
-    ).toBeTruthy()
+    expect(container.querySelector('.searchBarIcon--clear')).toBeTruthy()
   })
 })

--- a/react/__tests__/components/SearchBar.test.js
+++ b/react/__tests__/components/SearchBar.test.js
@@ -21,7 +21,10 @@ describe('<SearchBar />', () => {
   }
 
   const renderComponent = (customProps = {}) => {
-    return render(<SearchBar />, { graphql: { mocks: [mockedResult] }, MockedProvider })
+    return render(<SearchBar {...customProps} />, {
+      graphql: { mocks: [mockedResult] },
+      MockedProvider,
+    })
   }
 
   it('should be able to mount and not break', () => {
@@ -35,10 +38,47 @@ describe('<SearchBar />', () => {
   })
 
   it('should have CSS handle searchBarIcon', () => {
-    const { container } = renderComponent()
-
+    const { container, debug } = renderComponent()
     const element = container.querySelector('.searchBarIcon')
 
     expect(element).toBeTruthy()
+  })
+
+  it('should display internal search icon button', () => {
+    const { container, debug } = renderComponent({
+      displayMode: 'search-button',
+    })
+
+    expect(container.querySelector('.searchBarIcon--search')).toBeTruthy()
+  })
+
+  it('should display internal clear icon button when a value is typed', () => {
+    const { container, debug } = renderComponent({
+      displayMode: 'search-button',
+      value: 'foo'
+    })
+
+    expect(container.querySelector('.searchBarIcon--search')).toBeTruthy()
+  })
+
+  it('should display external search icon button', () => {
+    const { container, debug } = renderComponent({
+      displayMode: 'search-and-clear-buttons',
+    })
+
+    expect(
+      container.querySelector('.searchBarIcon--external-search')
+    ).toBeTruthy()
+  })
+
+  it('should display interal clear icon button when a value is typed', () => {
+    const { container, debug } = renderComponent({
+      displayMode: 'search-and-clear-buttons',
+      value: 'foo'
+    })
+
+    expect(
+      container.querySelector('.searchBarIcon--clear')
+    ).toBeTruthy()
   })
 })

--- a/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
+++ b/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
@@ -32,7 +32,7 @@ exports[`<SearchBar /> should match snapshot 1`] = `
                 value=""
               />
               <div
-                class="flex h-100"
+                class="suffixWrapper flex h-100"
               >
                 <button
                   class=" searchBarIcon searchBarIcon--search flex items-center pointer bn bg-transparent outline-0 pv0 pl0 pr3"

--- a/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
+++ b/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
@@ -16,10 +16,10 @@ exports[`<SearchBar /> should match snapshot 1`] = `
         role="combobox"
       >
         <div
-          class="autoCompleteOuterContainer flex"
+          class="autoCompleteOuterContainer"
         >
           <div
-            class="w-100"
+            class="w-100 flex"
           >
             <label>
               <input
@@ -31,13 +31,17 @@ exports[`<SearchBar /> should match snapshot 1`] = `
                 placeholder="Search"
                 value=""
               />
-              <button
-                class=" searchBarIcon flex items-center pointer bn bg-transparent outline-0"
+              <div
+                class="flex h-100"
               >
-                <div
-                  class="extension-point-icon-search"
-                />
-              </button>
+                <button
+                  class=" searchBarIcon searchBarIcon--search flex items-center pointer bn bg-transparent outline-0 pv0 pl0 pr3"
+                >
+                  <div
+                    class="extension-point-icon-search"
+                  />
+                </button>
+              </div>
             </label>
           </div>
         </div>

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -14,12 +14,14 @@ const DISPLAY_MODES = [
 
 /** Midleware component to adapt the styleguide/Input to be used by the Downshift*/
 const CSS_HANDLES = [
+  'autoCompleteOuterContainer',
+  'compactMode',
+  'externalSearchButtonWrapper',
+  'paddingInput',
+  'searchBarClearIcon',
   'searchBarIcon',
   'searchBarSearchIcon',
-  'searchBarClearIcon',
-  'compactMode',
-  'autoCompleteOuterContainer',
-  'paddingInput',
+  'suffixWrapper',
 ]
 
 const CloseIcon = () => {
@@ -125,7 +127,9 @@ const AutocompleteInput = ({
   )
 
   const externalSearchButton = showExternalSearchButton && (
-    <div className={`bw1 bl b--muted-4 flex items-center `}>
+    <div
+      className={`${handles.externalSearchButtonWrapper} bw1 bl b--muted-4 flex items-center `}
+    >
       <button
         className={`${iconClasses || ''} ${applyModifiers(
           handles.searchBarIcon,
@@ -139,7 +143,7 @@ const AutocompleteInput = ({
   )
 
   const suffix = (
-    <div className="flex h-100">
+    <div className={`${handles.suffixWrapper} flex h-100`}>
       {clearButton}
       {internalSearchButton}
       {externalSearchButton}

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { Input } from 'vtex.styleguide'
 import { ExtensionPoint, useChildBlock } from 'vtex.render-runtime'
-import { useCssHandles } from 'vtex.css-handles'
+import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { IconSearch, IconClose } from 'vtex.store-icons'
 
 const DISPLAY_MODES = [
@@ -91,12 +91,18 @@ const AutocompleteInput = ({
 
   const hasValue = value != null && value.length > 0
 
-  const clearButton = ((mode === 'clear-button' && hasValue) ||
-    mode === 'search-and-clear-buttons') && (
+  const showClearButton =
+    (mode === 'clear-button' && hasValue) || mode === 'search-and-clear-buttons'
+  const showInternalSearchButton =
+    (mode === 'clear-button' && !hasValue) || mode === 'search-button'
+  const showExternalSearchButton = mode === 'search-and-clear-buttons'
+
+  const clearButton = showClearButton && (
     <button
-      className={`${iconClasses || ''} ${
-        handles.searchBarClearIcon
-      }  flex items-center pointer bn bg-transparent outline-0 pv0 pl0 pr3`}
+      className={`${iconClasses || ''} ${applyModifiers(
+        handles.searchBarIcon,
+        'clear'
+      )} flex items-center pointer bn bg-transparent outline-0 pv0 pl0 pr3`}
       style={{
         visibility: hasValue ? 'visible' : 'hidden',
       }}
@@ -106,24 +112,25 @@ const AutocompleteInput = ({
     </button>
   )
 
-  const internalSearchButton = ((mode === 'clear-button' && !hasValue) ||
-    mode === 'search-button') && (
+  const internalSearchButton = showInternalSearchButton && (
     <button
-      className={`${iconClasses || ''} ${
-        handles.searchBarSearchIcon
-      }  flex items-center pointer bn bg-transparent outline-0 pv0 pl0 pr3`}
+      className={`${iconClasses || ''} ${applyModifiers(
+        handles.searchBarIcon,
+        'search'
+      )} flex items-center pointer bn bg-transparent outline-0 pv0 pl0 pr3`}
       onClick={() => hasValue && onGoToSearchPage()}
     >
       <SearchIcon />
     </button>
   )
 
-  const externalSearchButton = mode === 'search-and-clear-buttons' && (
-    <div className="bw1 bl b--muted-4 flex items-center">
+  const externalSearchButton = showExternalSearchButton && (
+    <div className={`bw1 bl b--muted-4 flex items-center `}>
       <button
-        className={`${iconClasses || ''} ${
-          handles.searchBarSearchIcon
-        } flex items-center h-100 pointer pv0 nr5 ph5 bn c-link`}
+        className={`${iconClasses || ''} ${applyModifiers(
+          handles.searchBarIcon,
+          'external-search'
+        )}  flex items-center h-100 pointer pv0 nr5 ph5 bn c-link`}
         onClick={onGoToSearchPage}
       >
         <SearchIcon />
@@ -140,7 +147,12 @@ const AutocompleteInput = ({
   )
 
   const prefix = (
-    <span className={`${iconClasses} ${handles.searchBarIcon}`}>
+    <span
+      className={`${iconClasses} ${applyModifiers(
+        handles.searchBarIcon,
+        'prefix'
+      )} `}
+    >
       <SearchIcon />
     </span>
   )

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -47,6 +47,7 @@ const SearchBar = ({
   openAutocompleteOnFocus,
   blurOnSubmit,
   submitOnIconClick,
+  displayMode,
   minSearchTermLength,
   autocompleteFullWidth,
   intl,
@@ -196,6 +197,7 @@ const SearchBar = ({
                 iconClasses={iconClasses}
                 onGoToSearchPage={onGoToSearchPage}
                 submitOnIconClick={submitOnIconClick}
+                displayMode={displayMode}
                 openAutocompleteOnFocus={openAutocompleteOnFocus}
                 openMenu={openMenu}
                 inputErrorMessage={inputErrorMessage}

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -65,7 +65,7 @@ class SearchBarContainer extends Component {
       openAutocompleteOnFocus = false,
       blurOnSubmit = false,
       submitOnIconClick,
-      displayMode = 'clear',
+      displayMode = 'clear-button',
       minSearchTermLength,
       autocompleteFullWidth = false,
     } = this.props

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -64,7 +64,8 @@ class SearchBarContainer extends Component {
       autocompleteAlignment = 'right',
       openAutocompleteOnFocus = false,
       blurOnSubmit = false,
-      submitOnIconClick = false,
+      submitOnIconClick,
+      displayMode = 'clear',
       minSearchTermLength,
       autocompleteFullWidth = false,
     } = this.props
@@ -90,6 +91,7 @@ class SearchBarContainer extends Component {
         openAutocompleteOnFocus={openAutocompleteOnFocus}
         blurOnSubmit={blurOnSubmit}
         submitOnIconClick={submitOnIconClick}
+        displayMode={displayMode}
         minSearchTermLength={minSearchTermLength}
         autocompleteFullWidth={autocompleteFullWidth}
         intl={intl}
@@ -134,6 +136,7 @@ SearchBarContainer.propTypes = {
   blurOnSubmit: PropTypes.bool,
   /** Identify if icon should submit on click */
   submitOnIconClick: PropTypes.bool,
+  displayMode: PropTypes.string,
   /** Minimum search term length allowed */
   minSearchTermLength: PropTypes.number,
   /** If true, the autocomplete will fill the whole window horizontally */


### PR DESCRIPTION
#### What problem is this solving?

SearchBar must have an option to control the display mode of the search and clear icons.

https://app.clubhouse.io/vtex/story/31177/search-bar-must-have-option-to-keep-the-search-icon

#### How should this be manually tested?

All three display modes are here:
https://kiwisearch--storecomponents.myvtex.com/

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/12702016/74767127-035fb580-5265-11ea-8f56-5e11e719e7ea.png)



#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
