### PR TITLE
Fix moving icon in SearchBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `SearchBar` moving when icon change from `search` to `clear`.
 
 ## [3.104.1] - 2020-02-19
 ### Fixed

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -28,10 +28,10 @@ const CloseIcon = () => {
   const hasIconBlock = Boolean(useChildBlock({ id: 'icon-close' }))
 
   if (hasIconBlock) {
-    return <ExtensionPoint id="icon-close" size={22} type="line" />
+    return <ExtensionPoint id="icon-close" size={16} type="line" />
   }
 
-  return <IconClose type="line" size={22} />
+  return <IconClose type="line" size={16} />
 }
 
 const SearchIcon = () => {


### PR DESCRIPTION
#### What problem is this solving?

The search bar input was getting bigger when switching the right icon from the `search` to the `clear` icon.

#### How should this be manually tested?

https://kiwiaccount--storecomponents.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
