### PR TITLE
Add color name for Italian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Color name for Italian.
 
 ## [3.105.1] - 2020-03-09
 ### Fixed

--- a/react/components/SKUSelector/utils/index.ts
+++ b/react/components/SKUSelector/utils/index.ts
@@ -54,6 +54,7 @@ export const isColor = (variation: string) => {
     'cor',
     'color',
     'colour',
+    'colore',
     'farbe',
     'couleur',
     'kleuren',

--- a/react/package.json
+++ b/react/package.json
@@ -50,7 +50,7 @@
     "eslint": "^6.5.1",
     "eslint-config-vtex-react": "^5.0.1",
     "prettier": "^1.18.2",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   },
   "vtexTestTools": {
     "defaultLocale": "en"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5598,10 +5598,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.7.3:
   version "3.7.4"


### PR DESCRIPTION
#### What problem is this solving?

Add Italian translation for color variation.

#### How should this be manually tested?

[Workspace](https://breno--miriadeit.myvtex.com/prodotto-1/p?__bindingAddress=www.miriade.com/it)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/76642567-37f82180-6532-11ea-9475-5277ef05c127.png) | ![image](https://user-images.githubusercontent.com/284515/76642545-2ca4f600-6532-11ea-843b-dc918c5c076d.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
