### PR TITLE
Add new css handles to gradient collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `showMoreButton`, `content` and `container` CSS Handles to `GradientCollapse`.
 
 ## [3.106.0] - 2020-03-16
 ### Added

--- a/docs/GradientCollapse.md
+++ b/docs/GradientCollapse.md
@@ -7,42 +7,50 @@
 :loudspeaker: **Disclaimer:** Don't fork this project, use, contribute, or open issue with your feature request.
 
 ## Table of Contents
+
 - [Usage](#usage)
   - [Configuration](#configuration)
   - [Styles API](#styles-api)
     - [CSS Namespaces](#css-namespaces)
 
 ## Usage
+
 You should follow the usage instruction in the main [README](https://github.com/vtex-apps/store-components/blob/master/README.md#usage).
 
-To import it into your code: 
+To import it into your code:
+
 ```js
 import { GradientCollapse } from 'vtex.store-components'
 ```
 
-You can use it in your code like a React component with the jsx tag: `<GradientCollapse />`. 
+You can use it in your code like a React component with the jsx tag: `<GradientCollapse />`.
+
 ```jsx
-<GradientCollapse> 
+<GradientCollapse>
   I'm a text and I will collapse if I'm bigger than my collapseHeight!
 </GradientCollapse>
 ```
 
 ### Configuration
 
-| Prop name | Type | Description | Default Value |
-| --------- | ---- | ----------- | ----------- |
-| `collapseHeight` | `Number!` | MaxHeight of the container | - |
-| `children` | `Node` | The component to be collapsed | - |
+| Prop name        | Type      | Description                   | Default Value |
+| ---------------- | --------- | ----------------------------- | ------------- |
+| `collapseHeight` | `Number!` | MaxHeight of the container    | -             |
+| `children`       | `Node`    | The component to be collapsed | -             |
 
 ### Styles API
 
 You should follow the Styles API instruction in the main [README](/README.md#styles-api).
 
-#### CSS Namespaces
-Below, we describe the namespace that are defined in the `GradientCollapse`.
+## Customization
 
-| Class name | Description | Component Source |
-| ---------- | ----------- | ---------------- |
-| `fadeBottom` | The bottom of the collapse | [index](/react/components/GradientCollapse/index.js) |
-| `pointerEventsNone` | The GradientCollapse container | [index](/react/components/GradientCollapse/index.js) |
-| `pointerEventsAuto` | The _Show Less_/_Show More_ button area | [index](/react/components/GradientCollapse/index.js) |
+In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
+
+| CSS Handles         |
+| ------------------- |
+| `container`         |
+| `content`           |
+| `fadeBottom`        |
+| `pointerEventsAuto` |
+| `pointerEventsNone` |
+| `showMoreButton`    |

--- a/docs/GradientCollapse.md
+++ b/docs/GradientCollapse.md
@@ -4,20 +4,17 @@
 
 `GradientCollapse` is a VTEX component that hides part of the children when it is bigger than the `collapseHeight` giving the user the _show more_ or _show less_ options. This Component can be imported and used by any VTEX app.
 
-:loudspeaker: **Disclaimer:** Don't fork this project, use, contribute, or open issue with your feature request.
+## Configuration
 
-## Table of Contents
+1. Import the `vtex.store-component` app to your theme's dependencies in the `manifest.json`;
 
-- [Usage](#usage)
-  - [Configuration](#configuration)
-  - [Styles API](#styles-api)
-    - [CSS Namespaces](#css-namespaces)
+```json
+  "dependencies": {
+    "vtex.store-components": "3.x"
+  }
+```
 
-## Usage
-
-You should follow the usage instruction in the main [README](https://github.com/vtex-apps/store-components/blob/master/README.md#usage).
-
-To import it into your code:
+2. Import it into your code:
 
 ```js
 import { GradientCollapse } from 'vtex.store-components'
@@ -31,16 +28,10 @@ You can use it in your code like a React component with the jsx tag: `<GradientC
 </GradientCollapse>
 ```
 
-### Configuration
-
 | Prop name        | Type      | Description                   | Default Value |
 | ---------------- | --------- | ----------------------------- | ------------- |
-| `collapseHeight` | `Number!` | MaxHeight of the container    | -             |
-| `children`       | `Node`    | The component to be collapsed | -             |
-
-### Styles API
-
-You should follow the Styles API instruction in the main [README](/README.md#styles-api).
+| `collapseHeight` | `Number!` | MaxHeight of the container    | `undefined`   |
+| `children`       | `Node`    | The component to be collapsed | `null`        |
 
 ## Customization
 

--- a/react/__tests__/components/__snapshots__/GradientCollapse.test.js.snap
+++ b/react/__tests__/components/__snapshots__/GradientCollapse.test.js.snap
@@ -3,11 +3,11 @@
 exports[`<GradientCollapse /> component should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="relative"
+    class="container relative"
     style="transition: 600ms ease-in-out; height: auto; overflow: hidden; display: block;"
   >
     <div
-      class="h-auto"
+      class="content h-auto"
     >
       Test
     </div>
@@ -22,7 +22,7 @@ exports[`<GradientCollapse /> component should match snapshot 1`] = `
         class="pointerEventsAuto bg-base tc w-100"
       >
         <button
-          class="c-action-primary t-action pointer ma5 bn outline-0"
+          class="showMoreButton c-action-primary t-action pointer ma5 bn outline-0"
         >
           <span>
             Show more

--- a/react/components/GradientCollapse/index.js
+++ b/react/components/GradientCollapse/index.js
@@ -4,7 +4,11 @@ import { Transition } from 'react-transition-group'
 import debounce from 'debounce'
 import { FormattedMessage } from 'react-intl'
 import classNames from 'classnames'
+import { useCssHandles } from 'vtex.css-handles'
+
 import styles from './styles.css'
+
+const CSS_HANDLES = ['container', 'content', 'showMoreButton']
 
 const transitionStyle = transitionTime => ({
   transition: `${transitionTime}ms ease-in-out`,
@@ -29,6 +33,7 @@ function GradientCollapse(props) {
     onCollapsedChange,
     collapsed: collapsedProp,
   } = props
+  const handles = useCssHandles(CSS_HANDLES)
   const [collapsed, setCollapsed] = useState(collapsedProp)
   const [prevCollapsedProp, setPrevCollapsedProp] = useState(collapsedProp)
   const [maxHeight, setMaxHeight] = useState('auto')
@@ -92,9 +97,9 @@ function GradientCollapse(props) {
             display: 'block',
           }}
           onTransitionEnd={calcMaxHeight}
-          className="relative"
+          className={`${handles.container} relative`}
         >
-          <div ref={wrapper} className="h-auto">
+          <div ref={wrapper} className={`${handles.content} h-auto`}>
             {children}
           </div>
           <div className={pointerEventsNoneClasses}>
@@ -105,13 +110,13 @@ function GradientCollapse(props) {
             <div className={pointerEventsAutoClasses(state)}>
               <button
                 onClick={e => handleCollapsedChange(e, !collapsed)}
-                className="c-action-primary t-action pointer ma5 bn outline-0"
+                className={`${handles.showMoreButton} c-action-primary t-action pointer ma5 bn outline-0`}
               >
                 {state === 'entered' || (collapsed && state !== 'exited') ? (
                   <FormattedMessage id="store/product-description.collapse.showLess" />
                 ) : (
-                    <FormattedMessage id="store/product-description.collapse.showMore" />
-                  )}
+                  <FormattedMessage id="store/product-description.collapse.showMore" />
+                )}
               </button>
             </div>
           </div>


### PR DESCRIPTION
#### What problem is this solving?

This PR adds missing css handles to the `GradientCollapse` component.

https://app.clubhouse.io/vtex/story/33685/show-more-css-handles

#### How should this be manually tested?

[Workspace](https://kiwi--garmin.myvtex.com/monitor-cardiaco-gps-garmin-forerunner-45/p?skuId=20)


#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/12702016/76889554-8ffd9380-6864-11ea-8324-11d03e5c43ac.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
