### PR TITLE
Feature/lazy infocard bg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Allow `info-card` background to be loaded lazily.
 
 ## [3.109.1] - 2020-04-06
 ### Fixed

--- a/react/__mocks__/vtex.render-runtime.js
+++ b/react/__mocks__/vtex.render-runtime.js
@@ -28,3 +28,9 @@ export const ExtensionPoint = ({ id }) => (
 export const useRuntime = () => runtime
 
 export const useChildBlock = () => true
+
+export const useExperimentalLazyImagesContext = () => {
+  return {
+    lazyLoad: false
+  }
+}

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -130,19 +130,20 @@ const InfoCard = ({
     : {}
 
   const containerClasses = classNames(
-    `${handles.infoCardContainer} items-center relative`,
+    `${handles.infoCardContainer} items-center`,
     {
       [`flex-ns ${flexOrderToken} bg-base ph2-ns pb2 justify-between`]: !isFullModeStyle,
       [`bg-center bb b--muted-4 flex ${justifyToken}`]: isFullModeStyle,
-      'lazysizes': lazyLoad,
+      'relative': lazyLoad
     }
   )
 
   const textContainerClasses = classNames(
-    `${handles.infoCardTextContainer} flex flex-column mw-100 relative z-1`,
+    `${handles.infoCardTextContainer} flex flex-column mw-100`,
     {
       [`w-50-ns ph3-s ${itemsToken} ${paddingClass}`]: !isFullModeStyle,
       [`mh8-ns mh4-s w-40-ns ${itemsToken}`]: isFullModeStyle,
+      'relative z-1': lazyLoad
     }
   )
 

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -180,9 +180,9 @@ const InfoCard = ({
           /** TODO: Currently, it just checks if its under a LazyImages
            * context and inserts a regular image, relying on render runtime
            * to actually make it lazy.
-           * It should be considered if it should just do this always, 
-           * making this logic simpler, but must be aware of pontential
-           * breaking changes and must be tested thoroughly. 
+           * In the future, it should be considered to always do this instead,
+           * making this logic simpler, but one must be aware of pontential
+           * breaking changes, and the change must be tested thoroughly. 
            */
           <img
             src={finalImageUrl}

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -4,7 +4,7 @@ import { bool, string, oneOf } from 'prop-types'
 import { values } from 'ramda'
 import React, { memo, useMemo } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
-import { useRuntime, useExperimentalLazyImages } from 'vtex.render-runtime'
+import { useRuntime, useExperimentalLazyImagesContext } from 'vtex.render-runtime'
 import { formatIOMessage } from 'vtex.native-types'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -95,7 +95,7 @@ const InfoCard = ({
     hints: { mobile },
   } = useRuntime()
 
-  const { lazyLoad } = useExperimentalLazyImages()
+  const { lazyLoad } = useExperimentalLazyImagesContext()
 
   const handles = useCssHandles(CSS_HANDLES)
   const paddingClass =

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -177,7 +177,7 @@ const InfoCard = ({
         data-testid="container"
         id={htmlId}
       >
-        {lazyLoad && (
+        {lazyLoad && isFullModeStyle && (
           /** TODO: Currently, it just checks if its under a LazyImages
            * context and inserts a regular image, relying on render runtime
            * to actually make it lazy.

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -186,7 +186,7 @@ const InfoCard = ({
            */
           <img
             src={finalImageUrl}
-            className="absolute top-0 bottom-0 right-0 left-0"
+            className="absolute w100 h100"
             style={{ objectFit: 'cover' }} />
         )}
         <div className={textContainerClasses}>

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -186,7 +186,7 @@ const InfoCard = ({
            */
           <img
             src={finalImageUrl}
-            className="absolute w100 h100"
+            className="absolute w-100 h-100"
             style={{ objectFit: 'cover' }} />
         )}
         <div className={textContainerClasses}>


### PR DESCRIPTION
#### What problem is this solving?
Lazy loads infocard bg if it's under a lazy load context

Requires https://github.com/vtex-apps/render-runtime/pull/506

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

To test, open the network panel on devtools filtered by images and open https://lbebber--eriksbikeshop.myvtex.com/.

Scroll down and see that images are being loaded as you scroll

Compare with https://lbebber2--eriksbikeshop.myvtex.com/, where doing the same loads a whole bunch of images right off the bat.



#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
