### PR TITLE
Revert changes from PR#732

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `InfoCard`s with no image not being rendered at all.
 
 ## [3.109.2] - 2020-04-07
 ### Changed

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -4,7 +4,10 @@ import { bool, string, oneOf } from 'prop-types'
 import { values } from 'ramda'
 import React, { memo, useMemo } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
-import { useRuntime, useExperimentalLazyImagesContext } from 'vtex.render-runtime'
+import {
+  useRuntime,
+  useExperimentalLazyImagesContext,
+} from 'vtex.render-runtime'
 import { formatIOMessage } from 'vtex.native-types'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -125,16 +128,17 @@ const InfoCard = ({
     formatIOMessage({ id: mobileImageUrl, intl })
   )
 
-  const containerStyle = isFullModeStyle && !lazyLoad
-    ? { backgroundImage: `url(${finalImageUrl})`, backgroundSize: 'cover' }
-    : {}
+  const containerStyle =
+    isFullModeStyle && !lazyLoad
+      ? { backgroundImage: `url(${finalImageUrl})`, backgroundSize: 'cover' }
+      : {}
 
   const containerClasses = classNames(
     `${handles.infoCardContainer} items-center`,
     {
       [`flex-ns ${flexOrderToken} bg-base ph2-ns pb2 justify-between`]: !isFullModeStyle,
       [`bg-center bb b--muted-4 flex ${justifyToken}`]: isFullModeStyle,
-      'relative': lazyLoad
+      relative: lazyLoad,
     }
   )
 
@@ -143,7 +147,7 @@ const InfoCard = ({
     {
       [`w-50-ns ph3-s ${itemsToken} ${paddingClass}`]: !isFullModeStyle,
       [`mh8-ns mh4-s w-40-ns ${itemsToken}`]: isFullModeStyle,
-      'relative z-1': lazyLoad
+      'relative z-1': lazyLoad,
     }
   )
 
@@ -160,10 +164,6 @@ const InfoCard = ({
     () => sanitizeHtml(formatIOMessage({ id: subhead, intl })),
     [intl, subhead]
   )
-
-  if (!imageUrl) {
-    return null
-  }
 
   return (
     <LinkWrapper
@@ -183,12 +183,13 @@ const InfoCard = ({
            * to actually make it lazy.
            * In the future, it should be considered to always do this instead,
            * making this logic simpler, but one must be aware of pontential
-           * breaking changes, and the change must be tested thoroughly. 
+           * breaking changes, and the change must be tested thoroughly.
            */
           <img
             src={finalImageUrl}
             className="absolute w-100 h-100"
-            style={{ objectFit: 'cover' }} />
+            style={{ objectFit: 'cover' }}
+          />
         )}
         <div className={textContainerClasses}>
           {headline && (


### PR DESCRIPTION
#### What problem is this solving?

PR #732 introduced a bug that caused `InfoCard` components with no `imgUrl` to not be rendered at all, even though they might have other content that should be displayed.  

#### How should this be manually tested?

This page has `InfoCard`s that do not contain images:

[Workspace](https://victormiranda--alssports.myvtex.com/application)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
