### PR TITLE
Enable SelectedSeller as a prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-### Added
 -  New prop `selectedSeller` to BuyButton.
 
 ## [3.109.3] - 2020-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - `selectedSeller` added as a prop
 
 ## [3.109.3] - 2020-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- `selectedSeller` added as a prop
 
 ## [3.109.3] - 2020-04-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `selectedSeller` added as a prop
+### Added
+-  New prop `selectedSeller` to BuyButton.
 
 ## [3.109.3] - 2020-04-08
 ### Fixed

--- a/react/components/BuyButton/Wrapper.js
+++ b/react/components/BuyButton/Wrapper.js
@@ -80,6 +80,7 @@ const BuyButtonWrapper = ({
   customToastURL,
   showTooltipOnSkuNotSelected,
   checkoutVersion,
+  selectedSeller
 }) => {
   const orderFormContext = useOrderForm()
   const valuesFromContext = useProduct()
@@ -89,7 +90,7 @@ const BuyButtonWrapper = ({
   const product = valuesFromContext && valuesFromContext.product
   const selectedItem = valuesFromContext && valuesFromContext.selectedItem
   const assemblyOptions = valuesFromContext && valuesFromContext.assemblyOptions
-  const selectedSeller = path(['selectedItem', 'sellers', 0], valuesFromContext)
+  selectedSeller = selectedSeller ? selectedSeller : path(['selectedItem', 'sellers', 0], valuesFromContext)
   const selectedQuantity =
     valuesFromContext && valuesFromContext.selectedQuantity != null
       ? valuesFromContext.selectedQuantity
@@ -99,12 +100,12 @@ const BuyButtonWrapper = ({
     isEmptyContext || propSkuItems != null
       ? propSkuItems
       : EnhancedBuyButton.mapCatalogItemToCart({
-          product,
-          selectedItem,
-          selectedQuantity,
-          selectedSeller,
-          assemblyOptions,
-        })
+        product,
+        selectedItem,
+        selectedQuantity,
+        selectedSeller,
+        assemblyOptions,
+      })
 
   const large = isEmptyContext || propLarge != null ? propLarge : true
 
@@ -112,8 +113,8 @@ const BuyButtonWrapper = ({
     isEmptyContext || propAvailable != null
       ? propAvailable
       : selectedSeller &&
-        selectedSeller.commertialOffer &&
-        selectedSeller.commertialOffer.AvailableQuantity > 0
+      selectedSeller.commertialOffer &&
+      selectedSeller.commertialOffer.AvailableQuantity > 0
 
   const groupsValidArray =
     (assemblyOptions &&


### PR DESCRIPTION
#### What problem is this solving?

Enable te Selected Seller of a item to be defined via prop, making possible to add skus with specific sellers to the cart

#### How should this be manually tested?

https://buybutton--cosmetics2.myvtex.com/sellers/creme---100--vegano-12

Same item, different sellers
Each button will add the specific seller to the cart

#### Checklist/Reminders

- [X] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Some informations on the thread:
https://vtex.slack.com/archives/CDQSTD7N1/p1586203464039000

