### PR TITLE
Add new linkTarget and callToActionLinkTarget props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `callToActionLinkTarget` and `linkTarget` props to the `InfoCard` component.
 
 ## [3.111.0] - 2020-04-23
 ### Added

--- a/docs/InfoCard.md
+++ b/docs/InfoCard.md
@@ -36,19 +36,21 @@ The `infoCard` block allows you to **display content combining image and text** 
 
 | Prop name | Type | Description | Default value |
 | --------- | ---- | ----------- | ------------- |
-| `isFullModeStyle` | `Boolean` | If true, image provided will be used as a background image and text will be displayed over it | false |
-| `textPosition` | `TextPostionEnum` | Choose in which position of the component text will be displayed, left, center or right | `"left"` |
-| `textAlignment` | `TextAlignmentEnum` | Control the text alignment inside component. This prop is ignored if `isFullModeStyle` is true  | `"left"` |
-| `headline` | `String` | Text to be used as headline. If not provided, it will not be rendered | `null` |
-| `subhead` | `String` | Text to be displayed underneath the headline. If not provided, it will not be rendered | `null` |
+| `isFullModeStyle` | `Boolean` | If true, image provided will be used as a background image and text will be displayed over it. | false |
+| `textPosition` | `TextPositionEnum` | Choose in which position of the component text will be displayed, left, center or right. | `"left"` |
+| `textAlignment` | `TextAlignmentEnum` | Control the text alignment inside component. This prop is ignored if `isFullModeStyle` is true.  | `"left"` |
+| `headline` | `String` | Text to be used as headline. If not provided, it will not be rendered. | `null` |
+| `subhead` | `String` | Text to be displayed underneath the headline. If not provided, it will not be rendered. | `null` |
 | `textMode` | `TextModeEnum` | Chooses which text mode should be used to process the text from `headline` and `subhead` props.   | `"html"` |
-| `callToActionMode` | `CallToActionEnum` | Set Call to Action component mode | `"button"` |
-| `callToActionText` | `String` | Text to be displayed inside the CTA component | `""` |
-| `callToActionUrl` | `String` | URL to be redirected when CTA component is clicked | `""` |
-| `imageUrl` | `String` | URL of the image to be used on desktop | `""` |
-| `mobileImageUrl` | `String` |  URL of the image to be used on mobile. If you do not provide any, the desktop image url will be used | `null` |
-| `blockClass` | `String` | Adds an extra class name to ease styling | `null` |
-| `htmlId` | `String` | Adds an ID to the container element | `null` |
+| `callToActionMode` | `CallToActionEnum` | Set Call to Action component mode. | `"button"` |
+| `callToActionText` | `String` | Text to be displayed inside the CTA component. | `""` |
+| `callToActionUrl` | `String` | URL to be redirected when CTA component is clicked. | `""` |
+| `callToActionLinkTarget` | `LinkTargetEnum` | Where to display the linked URL when CTA component is clicked.  | `"_self"` |
+| `imageUrl` | `String` | URL of the image to be used on desktop. | `""` |
+| `mobileImageUrl` | `String` |  URL of the image to be used on mobile. If you do not provide any, the desktop image url will be used. | `null` |
+| `blockClass` | `String` | Adds an extra class name to ease styling. | `null` |
+| `htmlId` | `String` | Adds an ID to the container element. | `null` |
+| `linkTarget` | `LinkTargetEnum` | Where to display the linked URL when `info-card` block is clicked. | `"_self"` |
 
 - Possible values of `TextPositionEnum`:
 
@@ -81,7 +83,16 @@ The `infoCard` block allows you to **display content combining image and text** 
 | HTML | 'html' | The InfoCard component will expect to receive HTML text for `headline` and `subhead` props. |
 | Rich-Text | 'rich-text' | The InfoCard component will expect to receive Markdown text for `headline` and `subhead` props, and will use the [`rich-text` block](https://github.com/vtex-apps/rich-text) to render both. |
 
-:warning: When `textMode` is set to `rich-text`, the CSS handles `infoCardHeadline` and `infoCardSubhead` will not be applied. To customize the headline and subhead text, you should use the CSS handles available in the [`rich-text` block](https://github.com/vtex-apps/rich-text).
+- Possible values of `LinkTargetEnum`:
+
+These values are the same ones supported by HTML5 anchor tags. For more information check its documentation at [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).
+
+| Enum name | Enum value | Description |
+| --------- | ---- | ----------- |
+| Self (default) | '_self' | Open the link in the current browsing context. |
+| Blank | '_blank' | Open the link in a new tab, but users can configure browsers to open a new window instead. |
+| Parent | '_parent' | Open the link in the parent browsing context of the current one. If no parent, behaves as `_self`. |
+| Top | '_top' | Open the link in the topmost browsing context (the "highest" context that’s an ancestor of the current one). If no ancestors, behaves as `_self`. |
 
 ## Customization
 

--- a/react/components/InfoCard/CallToAction.js
+++ b/react/components/InfoCard/CallToAction.js
@@ -7,7 +7,7 @@ import { callActionValues } from './SchemaTypes'
 
 const CSS_HANDLES = ['infoCardCallActionContainer', 'infoCardCallActionText']
 
-const CallToAction = ({ mode, text, url }) => {
+const CallToAction = ({ mode, text, url, linkTarget }) => {
   const handles = useCssHandles(CSS_HANDLES)
 
   if (mode === callActionValues.NONE) {
@@ -30,7 +30,11 @@ const CallToAction = ({ mode, text, url }) => {
   }
 
   return (
-    <Link className={`${handles.infoCardCallActionContainer} mt6 mb6`} to={url}>
+    <Link
+      className={`${handles.infoCardCallActionContainer} mt6 mb6`}
+      target={linkTarget}
+      to={url}
+    >
       <ActionWrapper text={text} mode={mode} />
     </Link>
   )

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -88,6 +88,7 @@ const InfoCard = ({
   callToActionMode,
   callToActionText,
   callToActionUrl,
+  callToActionLinkTarget,
   textPosition,
   textAlignment,
   imageUrl,
@@ -96,6 +97,7 @@ const InfoCard = ({
   intl,
   htmlId,
   textMode,
+  linkTarget,
 }) => {
   const {
     hints: { mobile },
@@ -172,7 +174,7 @@ const InfoCard = ({
     <LinkWrapper
       imageActionUrl={formatIOMessage({ id: imageActionUrl, intl })}
       extraCondition={!isFullModeStyle}
-      linkProps={{ className: 'no-underline' }}
+      linkProps={{ className: 'no-underline', target: linkTarget }}
     >
       <div
         className={containerClasses}
@@ -218,12 +220,14 @@ const InfoCard = ({
             mode={callToActionMode}
             text={formatIOMessage({ id: callToActionText, intl })}
             url={formatIOMessage({ id: callToActionUrl, intl })}
+            linkTarget={callToActionLinkTarget}
           />
         </div>
         {!isFullModeStyle && (
           <div className={`${handles.infoCardImageContainer} w-50-ns`}>
             <LinkWrapper
               imageActionUrl={formatIOMessage({ id: imageActionUrl, intl })}
+              linkProps={{ target: linkTarget }}
             >
               <img
                 className={handles.infoCardImage}
@@ -258,6 +262,9 @@ MemoizedInfoCard.propTypes = {
   intl: intlShape,
   htmlId: string,
   textMode: oneOf(getEnumValues(textModeTypes)),
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
+  linkTarget: oneOf('_self', '_blank', '_parent', '_top'),
+  callToActionLinkTarget: oneOf('_self', '_blank', '_parent', '_top'),
 }
 
 MemoizedInfoCard.defaultProps = {
@@ -272,6 +279,8 @@ MemoizedInfoCard.defaultProps = {
   mobileImageUrl: '',
   textAlignment: textAlignmentTypes.TEXT_ALIGNMENT_LEFT.value,
   textMode: textModeTypes.TEXT_MODE_HTML.value,
+  linkTarget: '_self',
+  callToActionLinkTarget: '_self',
 }
 
 MemoizedInfoCard.schema = {


### PR DESCRIPTION
#### What problem is this solving?

These should enable users to control the `target` attribute use by `<Link />` components rendered by the `InfoCard`.

#### How should this be manually tested?

1. Go to this [Workspace](https://targetblankinfocard--storecomponents.myvtex.com/);
2. Click the image in the `info-card` block below the Shelf;
3. That should cause a new tab to open in https://example.com/ ;
4. Click the CTA button in the InfoCard;
5. This click should not open in a new tab.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
