### PR TITLE
Add css handle to slider bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `swiperBullet` css handle to `ProductImages` pagination bullet.
+
+### Changed
+- Use `vtex/swiper#4.5.2`.
 
 ## [3.111.0] - 2020-04-23
 ### Added

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -67,17 +67,18 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `carouselThumbBorder` |
 | `figure` |
 | `image` |
-| `productImageTag`|
 | `productImagesContainer` (`content` is deprecated) |
 | `productImagesGallerySlide` |
 | `productImagesGallerySwiperContainer` |
+| `productImagesThumb` |
 | `productImagesThumbActive` |
 | `productImagesThumbCaret` |
-| `productImagesThumb` |
 | `productImagesThumbsSwiperContainer` |
+| `productImageTag`|
 | `productVideo` |
+| `swiperBullet` |
 | `swiperCaret` |
 | `thumbImg` |
-| `videoContainer` |
 | `video` |
 | `video`|
+| `videoContainer` |

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -4,30 +4,47 @@ import debounce from 'debounce'
 import classNames from 'classnames'
 import { path, equals } from 'ramda'
 import ReactResizeDetector from 'react-resize-detector'
-
 import { IconCaret } from 'vtex.store-icons'
 import { withCssHandles } from 'vtex.css-handles'
 
 import Video, { getThumbUrl } from '../Video'
 import ProductImage from '../ProductImage'
-
 import styles from '../../styles.css'
 import './global.css'
+
+import ThumbnailSwiper from './ThumbnailSwiper'
+import {
+  THUMBS_ORIENTATION,
+  THUMBS_POSITION_HORIZONTAL,
+} from '../../utils/enums'
 
 /**
  * ReactIdSwiper cannot be SSRendered, so this is a fake swiper that copies some of its classes and HTML layout and render only the first image of the children array.
  */
-const FakeSwiper = ({ children, containerClass, direction = THUMBS_ORIENTATION.HORIZONTAL }) => {
-  const swiperContainerDirection = direction === THUMBS_ORIENTATION.HORIZONTAL ? 'swiper-container-horizontal' : direction === THUMBS_ORIENTATION.VERTICAL ? 'swiper-container-vertical' : ''
+const FakeSwiper = ({
+  children,
+  containerClass,
+  direction = THUMBS_ORIENTATION.HORIZONTAL,
+}) => {
+  const swiperContainerDirection =
+    direction === THUMBS_ORIENTATION.HORIZONTAL
+      ? 'swiper-container-horizontal'
+      : direction === THUMBS_ORIENTATION.VERTICAL
+      ? 'swiper-container-vertical'
+      : ''
   const childrenArray = React.Children.toArray(children)
   if (childrenArray.length === 0) {
     return null
   }
   const child = childrenArray[0]
   const childClass = path(['props', 'className'], child)
-  const newChildClass = childClass ? `${childClass} swiper-slide-active` : childClass
+  const newChildClass = childClass
+    ? `${childClass} swiper-slide-active`
+    : childClass
   return (
-    <div className={`${containerClass} swiper-container-initialized ${swiperContainerDirection}`}>
+    <div
+      className={`${containerClass} swiper-container-initialized ${swiperContainerDirection}`}
+    >
       <div className="swiper-wrapper">
         {React.cloneElement(child, {
           className: newChildClass,
@@ -41,14 +58,7 @@ const FakeSwiper = ({ children, containerClass, direction = THUMBS_ORIENTATION.H
 const Swiper = window.navigator
   ? require('react-id-swiper/lib/ReactIdSwiper').default
   : FakeSwiper
-
 const SwiperModules = window.navigator ? require('swiper/dist/js/swiper') : {}
-
-import ThumbnailSwiper from './ThumbnailSwiper'
-import {
-  THUMBS_ORIENTATION,
-  THUMBS_POSITION_HORIZONTAL,
-} from '../../utils/enums'
 
 const CSS_HANDLES = [
   'carouselContainer',
@@ -59,6 +69,7 @@ const CSS_HANDLES = [
   'swiperCaretNext',
   'swiperCaretPrev',
   'productImagesThumbCaret',
+  'swiperBullet',
 ]
 
 const initialState = {
@@ -104,7 +115,10 @@ class Carousel extends Component {
 
   thumbLoadFinish = () => {
     this.thumbLoadCount++
-    if (!this.props.slides || this.thumbLoadCount === this.props.slides.length) {
+    if (
+      !this.props.slides ||
+      this.thumbLoadCount === this.props.slides.length
+    ) {
       this.setState({ thumbsLoaded: true })
     }
   }
@@ -138,7 +152,7 @@ class Carousel extends Component {
 
   componentDidUpdate(prevProps) {
     const { loaded, activeIndex } = this.state
-    const isVideo = this.isVideo
+    const { isVideo } = this
 
     if (!equals(prevProps.slides, this.props.slides)) {
       this.setInitialVariablesState()
@@ -178,11 +192,18 @@ class Carousel extends Component {
   }
 
   renderSlide = (slide, i) => {
-    const { aspectRatio, maxHeight, zoomMode, zoomFactor, zoomProps: legacyZoomProps } = this.props
+    const {
+      aspectRatio,
+      maxHeight,
+      zoomMode,
+      zoomFactor,
+      zoomProps: legacyZoomProps,
+    } = this.props
 
     // Backwards compatibility
     const { zoomType: legacyZoomType } = legacyZoomProps || {}
-    const isZoomDisabled = legacyZoomType === 'no-zoom' || zoomMode === 'disabled'
+    const isZoomDisabled =
+      legacyZoomType === 'no-zoom' || zoomMode === 'disabled'
 
     switch (slide.type) {
       case 'image':
@@ -225,13 +246,18 @@ class Carousel extends Component {
     return {
       modules: [SwiperModules.Pagination, SwiperModules.Navigation],
       containerClass: `swiper-container ${cssHandles.productImagesGallerySwiperContainer}`,
-      ...(slides.length > 1 && showPaginationDots && {
-        pagination: {
-          el: '.swiper-pagination',
-          clickable: true,
-          bulletActiveClass: 'c-action-primary swiper-pagination-bullet-active',
-        },
-      }),
+      ...(slides.length > 1 &&
+        showPaginationDots && {
+          pagination: {
+            el: '.swiper-pagination',
+            clickable: true,
+            // custom props from vtex/swiper
+            bulletSelector: `.swiper-pagination-bullet`,
+            bulletClass: `swiper-pagination-bullet ${cssHandles.swiperBullet}`,
+            bulletActiveClass:
+              'c-action-primary swiper-pagination-bullet-active',
+          },
+        }),
       ...(slides.length > 1 && {
         navigation: {
           prevEl: '.swiper-caret-prev',
@@ -246,7 +272,9 @@ class Carousel extends Component {
       resistanceRatio: slides.length > 1 ? 0.85 : 0,
       ...(showNavigationArrows && {
         renderNextButton: () => (
-          <span className={`swiper-caret-next pl7 pr2 right-0 ${caretClassName} ${cssHandles.swiperCaret} ${cssHandles.swiperCaretNext}`}>
+          <span
+            className={`swiper-caret-next pl7 pr2 right-0 ${caretClassName} ${cssHandles.swiperCaret} ${cssHandles.swiperCaretNext}`}
+          >
             <IconCaret
               orientation="right"
               size={iconSize}
@@ -255,7 +283,9 @@ class Carousel extends Component {
           </span>
         ),
         renderPrevButton: () => (
-          <span className={`swiper-caret-prev pr7 pl2 left-0 ${caretClassName} ${cssHandles.swiperCaret} ${cssHandles.swiperCaretPrev}`}>
+          <span
+            className={`swiper-caret-prev pr7 pl2 left-0 ${caretClassName} ${cssHandles.swiperCaret} ${cssHandles.swiperCaretPrev}`}
+          >
             <IconCaret
               orientation="left"
               size={iconSize}
@@ -271,12 +301,16 @@ class Carousel extends Component {
         if (this.gallerySwiper !== swiper) {
           this.gallerySwiper = swiper
         }
-      }
+      },
     }
   }
 
   get thumbnailsParams() {
-    const { displayThumbnailsArrows, thumbnailsOrientation, cssHandles } = this.props
+    const {
+      displayThumbnailsArrows,
+      thumbnailsOrientation,
+      cssHandles,
+    } = this.props
 
     const isThumbsVertical =
       thumbnailsOrientation === THUMBS_ORIENTATION.VERTICAL
@@ -356,7 +390,7 @@ class Carousel extends Component {
         if (this.thumbSwiper !== swiper) {
           this.thumbSwiper = swiper
         }
-      }
+      },
     }
   }
 
@@ -405,20 +439,28 @@ class Carousel extends Component {
         swiperParams={this.thumbnailsParams}
         thumbUrls={this.state.thumbUrl}
         position={position}
-        onThumbClick={index => this.gallerySwiper && this.gallerySwiper.slideTo(index)}
+        onThumbClick={index =>
+          this.gallerySwiper && this.gallerySwiper.slideTo(index)
+        }
         thumbnailAspectRatio={thumbnailAspectRatio}
         thumbnailMaxHeight={thumbnailMaxHeight}
       />
     )
 
-    const containerClasses = classNames(cssHandles.carouselContainer, 'relative overflow-hidden w-100', {
-      'flex-ns justify-end-ns': isThumbsVertical &&
-        position === THUMBS_POSITION_HORIZONTAL.LEFT &&
-        hasThumbs,
-      'flex-ns justify-start-ns': isThumbsVertical &&
-        position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
-        hasThumbs,
-    })
+    const containerClasses = classNames(
+      cssHandles.carouselContainer,
+      'relative overflow-hidden w-100',
+      {
+        'flex-ns justify-end-ns':
+          isThumbsVertical &&
+          position === THUMBS_POSITION_HORIZONTAL.LEFT &&
+          hasThumbs,
+        'flex-ns justify-start-ns':
+          isThumbsVertical &&
+          position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
+          hasThumbs,
+      }
+    )
 
     const SliderComponent = slides.length === 1 ? FakeSwiper : Swiper
 
@@ -429,7 +471,10 @@ class Carousel extends Component {
           <ReactResizeDetector handleHeight onResize={this.updateSwiperSize}>
             <SliderComponent {...this.galleryParams} shouldSwiperUpdate>
               {slides.map((slide, i) => (
-                <div key={i} className={`${cssHandles.productImagesGallerySlide} swiper-slide center-all`}>
+                <div
+                  key={i}
+                  className={`${cssHandles.productImagesGallerySlide} swiper-slide center-all`}
+                >
                   {this.renderSlide(slide, i)}
                 </div>
               ))}

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "recompose": "^0.30.0",
     "slick-carousel": "^1.8.1",
     "slugify": "^1.3.4",
-    "swiper": "github:vtex/swiper#4.5.1"
+    "swiper": "github:vtex/swiper#4.5.2"
   },
   "devDependencies": {
     "@apollo/react-testing": "3.1.3",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5652,9 +5652,9 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-"swiper@github:vtex/swiper#4.5.1":
-  version "4.5.1"
-  resolved "https://codeload.github.com/vtex/swiper/tar.gz/c69fde58f538f95904a380e3f9f5c500c26f3dec"
+"swiper@github:vtex/swiper#4.5.2":
+  version "4.5.2"
+  resolved "https://codeload.github.com/vtex/swiper/tar.gz/6a1f202561f8f13d7f4bfdd4689c7770b9bf2b6d"
   dependencies:
     dom7 "^2.1.3"
     ssr-window "^1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

Add a css handle to the pagination bullets of the ProductImages slider.

Story: https://app.clubhouse.io/vtex/story/36117/css-handles-on-dotscontainer

#### How should this be manually tested?

1) https://kiwi--storecomponents.myvtex.com/jumper-best-friend/p
2) `$$('.vtex-store-components-3-x-swiperBullet')` should return two elements

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/80631946-e8f84400-8a2c-11ea-9dea-8dfac2738e00.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
