### PR TITLE
BackToTopButton device specification removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- `BackToTopButton` showing on mobile
+- `BackToTopButton` not being rendered on mobile devices.
 
 ## [3.114.0] - 2020-05-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `BackToTopButton` showing on mobile
+
 ## [3.114.0] - 2020-05-04
 ### Added
 - `callToActionLinkTarget` and `linkTarget` props to the `InfoCard` component.

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -97,7 +97,6 @@
   },
   "back-to-top-button": {
     "render": "client",
-    "device": "desktop",
     "component": "BackToTopButton"
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

`BackToTopButton` wasn't showing on mobile because of the device specification interface. 

#### How should this be manually tested?

[Workspace](https://sebastian--acctglobal.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

✔️ | Type of Change
---|---
✔️ | Bug fix 
_ | New feature 
_ | Breaking change
_ | Technical improvements 
