### PR TITLE
Fix autocomplete behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Autocomplete` closing by clicking on an interactive component inside it.
 
 ## [3.114.3] - 2020-05-07
 ### Fixed

--- a/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
+++ b/react/__tests__/components/__snapshots__/SearchBar.test.js.snap
@@ -45,6 +45,7 @@ exports[`<SearchBar /> should match snapshot 1`] = `
             </label>
           </div>
         </div>
+        <div />
         <div>
           <div
             class="extension-point-autocomplete-result-list"

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -12,10 +12,9 @@ import {
 import { Overlay } from 'vtex.react-portal'
 import { useCssHandles } from 'vtex.css-handles'
 import { intlShape, defineMessages } from 'react-intl'
+
 import styles from '../styles.css'
-
 import AutocompleteResults from '../../AutocompleteResults'
-
 import AutocompleteInput from './AutocompleteInput'
 
 const CSS_HANDLES = ['searchBarInnerContainer']
@@ -160,6 +159,8 @@ const SearchBar = ({
       : props => <AutocompleteResults {...props} />
   }, [isAutocompleteDeclared])
 
+  const autocompleteContainerRef = useRef(null)
+
   return (
     <div
       ref={container}
@@ -229,9 +230,11 @@ const SearchBar = ({
                   onFocus: openAutocompleteOnFocus ? openMenu : undefined,
                 })}
               />
+              <div ref={autocompleteContainerRef} />
               <Overlay
-                alignment={autocompleteAlignment}
                 fullWindow={autocompleteFullWidth}
+                alignment={autocompleteAlignment}
+                target={autocompleteContainerRef.current}
               >
                 <SelectedAutocompleteResults
                   parentContainer={container}


### PR DESCRIPTION
#### What problem is this solving?

The `Autocomplete` component of the new search had a closing behavior when clicking on an interactive component within it, for example, when the product summary had a button to increase the quantity of an item in the cart ([example from unimarc](https://www.loom.com/share/f8185c8cb0d64096afb6ca76ded02291)). This was because we used a library called `Downshift`, which has MouseDown and MouseUp events to recognize clicks outside the dropdown. This library was recognizing clicks inside the autocomplete as being clicks outside because `SearchBar` has an `Overlay` that creates a `Portal` and, therefore, the reference of this component indicates that the click happens outside of `Autocomplete`.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
Before:
![old](https://user-images.githubusercontent.com/20840671/81692661-1d103380-9435-11ea-977c-c6be7c9cf832.gif)

After:
![new](https://user-images.githubusercontent.com/20840671/81692795-5183ef80-9435-11ea-947a-a1c8e6f2835d.gif)



#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
