### PR TITLE
Support on Searchbar for new full text URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for the new free text search URL on the `SearchBar`.
 
 ## [3.116.3] - 2020-06-04
 ### Changed
@@ -46,9 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Back to Top Button added to readme
 
 ## [3.114.5] - 2020-05-13
-
 ### Fixed
-
 - Improve documentation for Buy Button block
 
 ## [3.114.4] - 2020-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Support for the new free text search URL on the `SearchBar`.
+- Support for the new full text search URL on the `SearchBar`.
 
 ## [3.116.3] - 2020-06-04
 ### Changed

--- a/react/components/AutocompleteResults/index.js
+++ b/react/components/AutocompleteResults/index.js
@@ -36,10 +36,10 @@ const getLinkProps = element => {
   if (element.criteria) {
     // This param is only useful to track terms searched
     // See: https://support.google.com/analytics/answer/1012264
-    const paramForSearchTracking = '&_c=' + terms[0]
+    const paramForSearchTracking = '&_c=' + terms[0] + '&_q=' + terms[0]
 
     page = 'store.search'
-    params = { term: terms[0] }
+    params = {}
     query = `map=c,ft&rest=${terms.slice(1).join(',')}` + paramForSearchTracking
   }
 
@@ -119,6 +119,7 @@ const AutocompleteResults = ({
   )
 
   const renderSearchByClick = inputValue => {
+    const query = 'map=ft&_q=' + inputValue
     return customSearchPageUrl ? (
       <Link
         className={getListItemClassNames({
@@ -133,7 +134,7 @@ const AutocompleteResults = ({
       <Link
         page="store.search"
         params={{ term: inputValue }}
-        query="map=ft"
+        query={query}
         className={getListItemClassNames({
           itemIndex: 0,
           highlightedIndex,

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -88,10 +88,11 @@ const SearchBar = ({
           return
         }
 
+        const query = 'map=ft&_q=' + element.term
         navigate({
           page: 'store.search',
           params: { term: element.term },
-          query: 'map=ft',
+          query: query,
         })
         return
       }
@@ -107,7 +108,7 @@ const SearchBar = ({
       if (element.criteria) {
         // This param is only useful to track terms searched
         // See: https://support.google.com/analytics/answer/1012264
-        const paramForSearchTracking = '&_c=' + terms[0]
+        const paramForSearchTracking = '&_c=' + terms[0] + '&_q=' + terms[0]
 
         page = 'store.search'
         params = { term: terms[0] }


### PR DESCRIPTION
#### What problem is this solving?

Add support for our `SearchBar` for the new full-text URL that will make it possible for our stores to have 404 pages. It should only be merged if https://github.com/vtex-apps/store/pull/458 is approved since it does not make sense to merge something that will never be used.

Update: The Store PR will probably be merged someday, and since we need to clean this repository it may be nice to merge this now.

#### How should this be manually tested?

[storecomponents](https://iaronaraujo--storecomponents.myvtex.com/)
[worldwidegolf](https://iaronaraujo--worldwidegolf.myvtex.com/)
[motorolaus](https://iaronaraujo--motorolaus.myvtex.com)
[als](https://iaronaraujo--alssports.myvtex.com/)
[exitocol](https://iaronaraujo--exitocol.myvtex.com/)
[boticario](https://iaronaraujo--boticario.myvtex.com/)
[lionspride](https://iaronaraujo--lionspride.myvtex.com/)

Check that the search bar still works as intended.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
