### PR TITLE
product detail brand link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Brand image link changed to brand slug instead of brand name.
 
 ## [3.115.0] - 2020-05-20
 ### Added

--- a/react/__tests__/components/ProductBrand.test.js
+++ b/react/__tests__/components/ProductBrand.test.js
@@ -16,6 +16,7 @@ const mocks = [
     result: {
       data: {
         brand: {
+          slug: 'billabong',
           imageUrl: '/220310/billabong.jpg'
         }
       },

--- a/react/components/ProductBrand/index.js
+++ b/react/components/ProductBrand/index.js
@@ -87,10 +87,10 @@ const ProductBrand = ({
       {query => {
         const { data } = query
         if (data && data.brand) {
-          const { imageUrl } = data.brand
+          const { imageUrl, slug } = data.brand
           if (imageUrl) {
             const dpi = (window && window.devicePixelRatio) || 1
-            const logoLink = '/' + brandName + '/b'
+            const logoLink = '/' + slug + '/b'
             const logoImage = (
               <img
                 className={`${handles.productBrandLogo}`}

--- a/react/components/ProductBrand/productBrand.gql
+++ b/react/components/ProductBrand/productBrand.gql
@@ -1,5 +1,6 @@
 query Brand($id: Int) {
   brand(id: $id) {
+    slug
     imageUrl
   }
 }


### PR DESCRIPTION
#### What problem is this solving?
Brand icon with link in product details page uses brand name to create brand link. But it should use `brand slug` instead of brand name.

#### How should this be manually tested?
go to the workspace url and click brand icon just above product name. 

[Workspace](https://brandlink--biscoind.myvtex.com/keystone-electronics-8719/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

