### PR TITLE
Fix issue with image not loading in Google Chrome 83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert release v3.110.1 that was making images to not load in Chrome 83.
+
 ## [3.115.1] - 2020-05-28
 
 ### Fixed

--- a/react/components/ProductImages/components/Zoomable/ZoomInPlace.tsx
+++ b/react/components/ProductImages/components/Zoomable/ZoomInPlace.tsx
@@ -98,10 +98,7 @@ const ZoomInPlace: FC<Props> = ({ children, zoomContent, type, factor }) => {
   // Resets position when the image is zoomed out
   useEffect(() => {
     if (!isZoomedIn) {
-      // This value of the scale is because of some really weird bug
-      // in Chrome https://github.com/vtex-apps/store-components/issues/738
-      // Should be reverted to just `1` once the Chrome bug is fixed.
-      setPositionAndScale(0, 0, 1.000001)
+      setPositionAndScale(0, 0, 1)
       containerBounds.current = null
     }
   }, [isZoomedIn])


### PR DESCRIPTION
#### What problem is this solving?

Issue
1. https://newbalance.myvtex.com/Feminino/Tenis/Trilha
2. Then click on a product
3. Image of the product will not load


---

Fixed workspace
1. https://brenovtex--newbalance.myvtex.com/Feminino/Tenis/Trilha
2. Then click on a product
3. Image of the product will load

Fixed in another store:
https://brenovtex--equishopper.myvtex.com/herm-sprenger-maxcontrol-loose-ring-bit-16mm-locking-doubled-joint-stainless-steel-40710/p

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
