### PR TITLE
Transform SearchBarContainer component in a function component + Add …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- if `search-bar` is in a modal it closes after navigation.
 
 ## [3.116.2] - 2020-06-04
+### Changed
+- Bump dependency versions.
 
 ## [3.116.1] - 2020-06-04
+### Fixed
+- Typos in the documentation.
 
 ## [3.116.0] - 2020-06-03
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,8 @@
     "vtex.device-detector": "0.x",
     "vtex.apps-graphql": "2.x",
     "vtex.rich-text": "0.x",
-    "vtex.slider-layout": "0.x"
+    "vtex.slider-layout": "0.x",
+    "vtex.modal-layout": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
…support to close modal after navigation

#### What problem is this solving?

If you use `search-bar` inside a modal that is inside the header, it wouldn't close the modal after search

#### How should this be manually tested?
[Check if it works on motorolaus](https://modalsearch--motorolaus.myvtex.com/)

1. [Workspace miriadeit using the feature](https://klynger--miriadeit.myvtex.com/clothes?__bindingAddress=www.miriade.com/it&_q=clothes&map=ft)
2. Click on the search
3. search for something

To see the problem check the [master workspace](miriadeit.myvtex.com/)



#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
