### PR TITLE
contentType prop to the ProductImages Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `contentType` prop to the ProductImages component.
 
 ## [3.116.5] - 2020-06-08
 ### Fixed

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -50,6 +50,7 @@
 | `thumbnailsOrientation`   | `Enum`    | Choose the orientation of the thumbnails. Can be set to `vertical` or `horizontal`                                 | `vertical`    | 
 | `zoomFactor` | `number` | Sets how much the zoom increases the image size (e.g. `2` will make the zoomed-in image twice as large) | 2 |
 | `zoomMode` | `disabled\|in-place-click\|in-place-hover` | Sets the zoom behavior. | `in-place-click` |
+| `contentType`   | `'all'` &#124; `'images'` &#124; `'videos'`   | Controls the type of content that will be displayed.                               | `'all'`    | 
 
 #### Customization
 

--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -64,6 +64,7 @@ const ProductImagesWrapper = props => {
       contentOrder={contentOrder}
       // Deprecated
       zoomProps={props.zoomProps}
+      contentType={props.contentType}
     />
   )
 }

--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -62,9 +62,9 @@ const ProductImagesWrapper = props => {
       showNavigationArrows={showNavigationArrows}
       showPaginationDots={showPaginationDots}
       contentOrder={contentOrder}
+      contentType={props.contentType}
       // Deprecated
       zoomProps={props.zoomProps}
-      contentType={props.contentType}
     />
   )
 }

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -29,6 +29,7 @@ const ProductImages = ({
   zoomFactor,
   // Deprecated
   zoomProps,
+  contentType = "all"
 }) => {
   if (hiddenImages && !Array.isArray(hiddenImages)) {
     hiddenImages = [hiddenImages]
@@ -38,7 +39,7 @@ const ProductImages = ({
     hiddenImages && hiddenImages.map(text => new RegExp(text, 'i'))
   const handles = useCssHandles(CSS_HANDLES)
 
-  const images = allImages
+  const images = contentType !== 'videos' ? allImages
     .filter(
       image =>
         !image.imageLabel ||
@@ -49,12 +50,14 @@ const ProductImages = ({
       url: image.imageUrls ? image.imageUrls[0] : image.imageUrl,
       alt: image.imageText,
       thumbUrl: image.thumbnailUrl || image.imageUrl,
-    }))
-  const videos = allVideos.map(video => ({
+    })) : []
+
+  const videos = contentType !== 'images'? allVideos.map(video => ({
     type: 'video',
     src: video.videoUrl,
     thumbWidth: 300,
-  }))
+  })) : []
+
   const showVideosFirst = contentOrder === 'videos-first'
 
   const slides = useMemo(() => {

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -27,9 +27,9 @@ const ProductImages = ({
   contentOrder = 'images-first',
   zoomMode,
   zoomFactor,
+  contentType = 'all',
   // Deprecated
   zoomProps,
-  contentType = 'all',
 }) => {
   if (hiddenImages && !Array.isArray(hiddenImages)) {
     hiddenImages = [hiddenImages]
@@ -39,30 +39,30 @@ const ProductImages = ({
     hiddenImages && hiddenImages.map(text => new RegExp(text, 'i'))
   const handles = useCssHandles(CSS_HANDLES)
 
-  const images =
-    contentType !== 'videos'
-      ? allImages
-          .filter(
-            image =>
-              !image.imageLabel ||
-              !excludeImageRegexes.some(regex => regex.test(image.imageLabel))
-          )
-          .map(image => ({
-            type: 'image',
-            url: image.imageUrls ? image.imageUrls[0] : image.imageUrl,
-            alt: image.imageText,
-            thumbUrl: image.thumbnailUrl || image.imageUrl,
-          }))
-      : []
-
-  const videos =
-    contentType !== 'images'
-      ? allVideos.map(video => ({
-          type: 'video',
-          src: video.videoUrl,
-          thumbWidth: 300,
+  const shouldIncludeImages = contentType !== 'videos'
+  const images = shouldIncludeImages
+    ? allImages
+        .filter(
+          image =>
+            !image.imageLabel ||
+            !excludeImageRegexes.some(regex => regex.test(image.imageLabel))
+        )
+        .map(image => ({
+          type: 'image',
+          url: image.imageUrls ? image.imageUrls[0] : image.imageUrl,
+          alt: image.imageText,
+          thumbUrl: image.thumbnailUrl || image.imageUrl,
         }))
-      : []
+    : []
+
+  const shouldIncludeVideos = contentType !== 'images'
+  const videos = shouldIncludeVideos
+    ? allVideos.map(video => ({
+        type: 'video',
+        src: video.videoUrl,
+        thumbWidth: 300,
+      }))
+    : []
 
   const showVideosFirst = contentOrder === 'videos-first'
 

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -29,7 +29,7 @@ const ProductImages = ({
   zoomFactor,
   // Deprecated
   zoomProps,
-  contentType = "all"
+  contentType = 'all',
 }) => {
   if (hiddenImages && !Array.isArray(hiddenImages)) {
     hiddenImages = [hiddenImages]
@@ -39,24 +39,30 @@ const ProductImages = ({
     hiddenImages && hiddenImages.map(text => new RegExp(text, 'i'))
   const handles = useCssHandles(CSS_HANDLES)
 
-  const images = contentType !== 'videos' ? allImages
-    .filter(
-      image =>
-        !image.imageLabel ||
-        !excludeImageRegexes.some(regex => regex.test(image.imageLabel))
-    )
-    .map(image => ({
-      type: 'image',
-      url: image.imageUrls ? image.imageUrls[0] : image.imageUrl,
-      alt: image.imageText,
-      thumbUrl: image.thumbnailUrl || image.imageUrl,
-    })) : []
+  const images =
+    contentType !== 'videos'
+      ? allImages
+          .filter(
+            image =>
+              !image.imageLabel ||
+              !excludeImageRegexes.some(regex => regex.test(image.imageLabel))
+          )
+          .map(image => ({
+            type: 'image',
+            url: image.imageUrls ? image.imageUrls[0] : image.imageUrl,
+            alt: image.imageText,
+            thumbUrl: image.thumbnailUrl || image.imageUrl,
+          }))
+      : []
 
-  const videos = contentType !== 'images'? allVideos.map(video => ({
-    type: 'video',
-    src: video.videoUrl,
-    thumbWidth: 300,
-  })) : []
+  const videos =
+    contentType !== 'images'
+      ? allVideos.map(video => ({
+          type: 'video',
+          src: video.videoUrl,
+          thumbWidth: 300,
+        }))
+      : []
 
   const showVideosFirst = contentOrder === 'videos-first'
 
@@ -137,6 +143,7 @@ ProductImages.propTypes = {
   contentOrder: PropTypes.oneOf(['images-first', 'videos-first']),
   zoomMode: PropTypes.number,
   zoomFactor: PropTypes.number,
+  contentType: PropTypes.oneOf(['all', 'images', 'videos']),
 }
 
 ProductImages.defaultProps = {


### PR DESCRIPTION
#### What problem is this solving?

I'm building the App Store PDP and I would like to filter the content type of ProductImages component.
The PDP uses the ProductImages block to render images and videos, but both cannot be displayed at the same time and the component doesn’t  allow hidden videos.

The prop `contentType` has three possible values:
`all` ( default ): Show videos and images  
`images`: Show images
`videos`: Show videos

#### How should this be manually tested?

[Workspace](https://pedro--extensions.myvtex.com/google-shopping/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
<img width="770" alt="Screen Shot 2020-06-05 at 10 54 47 AM" src="https://user-images.githubusercontent.com/32311264/83885427-b7098a00-a71c-11ea-88b4-a0325b8a7956.png">

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

