### PR TITLE
remove rest query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- `rest` query string.
+
 ## [3.117.0] - 2020-06-08
 ### Added
 - `contentType` prop to the ProductImages component.

--- a/react/components/AutocompleteResults/index.js
+++ b/react/components/AutocompleteResults/index.js
@@ -39,8 +39,8 @@ const getLinkProps = element => {
     const paramForSearchTracking = '&_c=' + terms[0]
 
     page = 'store.search'
-    params = { term: terms[0] }
-    query = `map=c,ft&rest=${terms.slice(1).join(',')}` + paramForSearchTracking
+    params = { term: terms.join('/') }
+    query = `map=c,ft` + paramForSearchTracking
   }
 
   return { page, params, query }

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -110,9 +110,8 @@ const SearchBar = ({
         const paramForSearchTracking = '&_c=' + terms[0]
 
         page = 'store.search'
-        params = { term: terms[0] }
-        query =
-          `map=c,ft&rest=${terms.slice(1).join(',')}` + paramForSearchTracking
+        params = { term: terms.join('/') }
+        query = `map=c,ft` + paramForSearchTracking
       }
 
       navigate({ page, params, query })


### PR DESCRIPTION
#### What problem is this solving?

The `rest` query string is useless now, this PR removes it from the search bar.

#### How should this be manually tested?

[Workspace](https://hiago--equishopper.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
