### PR TITLE
Including classes on searchBar to identify when is open and/or filled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Classes included to advise when the input is filled and when the result list is opened.
+- Apply modifiers to handle `searchBarInnerContainer` in `SearchBar`.
 
 ## [3.117.2] - 2020-06-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Add
+- Classes included to advise when the input is filled and when the result list is opened.
 
 ## [3.117.2] - 2020-06-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Add
+### Added
 - Classes included to advise when the input is filled and when the result list is opened.
 
 ## [3.117.2] - 2020-06-10

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -186,7 +186,10 @@ const SearchBar = ({
             <div
               className={classNames(
                 'relative-m w-100',
-                applyModifiers(handles.searchBarInnerContainer, [isOpen ? 'opened' : '', inputValue ? 'filled' : '']),
+                applyModifiers(handles.searchBarInnerContainer, [
+                  isOpen ? 'opened' : '',
+                  inputValue ? 'filled' : '',
+                ])
               )}
             >
               <AutocompleteInput

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -17,7 +17,7 @@ import styles from '../styles.css'
 import AutocompleteResults from '../../AutocompleteResults'
 import AutocompleteInput from './AutocompleteInput'
 
-const CSS_HANDLES = ['searchBarInnerContainer']
+const CSS_HANDLES = ['searchBarInnerContainer', 'open', 'hasTerm']
 const SEARCH_DELAY_TIME = 500
 const AUTCOMPLETE_EXTENSION_ID = 'autocomplete-result-list'
 
@@ -186,7 +186,9 @@ const SearchBar = ({
             <div
               className={classNames(
                 'relative-m w-100',
-                handles.searchBarInnerContainer
+                handles.searchBarInnerContainer,
+                isOpen ? handles.open : '',
+                inputValue !== '' ? handles.hasTerm : ''
               )}
             >
               <AutocompleteInput

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -10,14 +10,14 @@ import {
   useChildBlock,
 } from 'vtex.render-runtime'
 import { Overlay } from 'vtex.react-portal'
-import { useCssHandles } from 'vtex.css-handles'
+import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { defineMessages, useIntl } from 'react-intl'
 
 import styles from '../styles.css'
 import AutocompleteResults from '../../AutocompleteResults'
 import AutocompleteInput from './AutocompleteInput'
 
-const CSS_HANDLES = ['searchBarInnerContainer', 'open', 'hasTerm']
+const CSS_HANDLES = ['searchBarInnerContainer']
 const SEARCH_DELAY_TIME = 500
 const AUTCOMPLETE_EXTENSION_ID = 'autocomplete-result-list'
 
@@ -187,8 +187,12 @@ const SearchBar = ({
               className={classNames(
                 'relative-m w-100',
                 handles.searchBarInnerContainer,
-                isOpen ? handles.open : '',
-                inputValue !== '' ? handles.hasTerm : ''
+                isOpen
+                  ? applyModifiers(handles.searchBarInnerContainer, 'opened')
+                  : '',
+                inputValue !== ''
+                  ? applyModifiers(handles.searchBarInnerContainer, 'filled')
+                  : ''
               )}
             >
               <AutocompleteInput

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -186,13 +186,7 @@ const SearchBar = ({
             <div
               className={classNames(
                 'relative-m w-100',
-                handles.searchBarInnerContainer,
-                isOpen
-                  ? applyModifiers(handles.searchBarInnerContainer, 'opened')
-                  : '',
-                inputValue !== ''
-                  ? applyModifiers(handles.searchBarInnerContainer, 'filled')
-                  : ''
+                applyModifiers(handles.searchBarInnerContainer, [isOpen ? 'opened' : '', inputValue ? 'filled' : '']),
               )}
             >
               <AutocompleteInput


### PR DESCRIPTION
#### What problem is this solving?
It includes classes to check if the result list is opened and if the input is filled

#### How should this be manually tested?
Checking if the class "open" will be included when starts to fill the input. And check if the class "hasTerm" is included when there is anything on input.

[Workspace](https://header--zonasul.myvtex.com/) -> search for `file`

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
When just filled (without focus)
![image](https://user-images.githubusercontent.com/6241622/84323453-36e48980-ab4d-11ea-8c44-74ce6e8c87b8.png)
![image](https://user-images.githubusercontent.com/6241622/84323395-1a485180-ab4d-11ea-8fd7-d2b8fb7c4d76.png)

When opened (focus)
![image](https://user-images.githubusercontent.com/6241622/84323288-e5d49580-ab4c-11ea-901b-56eb6f8d7f6d.png)
![image](https://user-images.githubusercontent.com/6241622/84323559-61cedd80-ab4d-11ea-884e-63e7450d18d2.png)



#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
