### PR TITLE
Add feature of opening a modal when ProductImages is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Props `ModalZoom` to `product-images`.
+- Option `'open-modal'` to prop `zoomMode` of `product-images`.
+- `product-images.high-quality-image` block.
 
 ## [3.118.0] - 2020-06-17
 ### Added

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -49,8 +49,52 @@
 | `thumbnailMaxHeight`             | `number`                                   | The max height for the thumbnail image | `true`          |
 | `thumbnailsOrientation`   | `Enum`    | Choose the orientation of the thumbnails. Can be set to `vertical` or `horizontal`                                 | `vertical`    | 
 | `zoomFactor` | `number` | Sets how much the zoom increases the image size (e.g. `2` will make the zoomed-in image twice as large) | 2 |
-| `zoomMode` | `disabled\|in-place-click\|in-place-hover` | Sets the zoom behavior. | `in-place-click` |
+| `zoomMode` | `disabled\|in-place-click\|in-place-hover\|open-modal` | Sets the zoom behavior. | `in-place-click` |
+| `ModalZoom` | `vtex.modal-layout:modal-layout` | The `modal-layout` block that will open when you click in the image and `zoomMode` is `open-modal` | `undefined` |
 | `contentType`   | `'all'` &#124; `'images'` &#124; `'videos'`   | Controls the type of content that will be displayed.                               | `'all'`    | 
+
+### `product-images.high-quality-image` block
+
+This block is meant to be used when you want that the zoom action open a modal with the current image of the `product-images` in it. In order to use you just have to put it inside the block that you will pass in the prop `ModalZoom` of the `product-images`:
+
+
+```jsonc
+{
+  "product-images.high-quality-image": {
+    "props": {
+      "zoomMode": "in-place-click",
+      "zoomFactor": 2
+    }
+  },
+  "modal-layout#product-zoom": {
+    "children": [
+      // you can put any other block inside the modal,
+      // this is just a normal modal
+      "flex-layout.row#product-name",
+      "product-images.high-quality-image"
+    ]
+  },
+  "product-images": {
+    "props": {
+      "ModalZoom": "modal-layout#product-zoom",
+      "zoomMode": "open-modal",
+      "aspectRatio": {
+        "desktop": "auto",
+        "phone": "16:9"
+      }
+    }
+  }
+}
+```
+
+The props of this block are very similar with some props of `product-images`:
+
+| Prop name | Type | Description | Default Value |
+| --- | --- | --- | --- |
+| `zoomMode` | `'disabled'\|'in-place-click'\|'in-place-hover'` | Same as `zoomMode` of `product-images` but it doesn't accept `'open-modal'` | `'disabled'` |
+| `zoomFactor` | `number` | Same as `zoomFactor` from `product-images` | `2` |
+| `aspectRatio` | `string` | Same as in `product-images` | `'auto'` |
+
 
 #### Customization
 
@@ -83,3 +127,5 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `video` |
 | `video`|
 | `videoContainer` |
+| `imgZoom` |
+| `highQualityContainer` |

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -49,13 +49,19 @@
 | `thumbnailMaxHeight`             | `number`                                   | The max height for the thumbnail image | `true`          |
 | `thumbnailsOrientation`   | `Enum`    | Choose the orientation of the thumbnails. Can be set to `vertical` or `horizontal`                                 | `vertical`    | 
 | `zoomFactor` | `number` | Sets how much the zoom increases the image size (e.g. `2` will make the zoomed-in image twice as large) | 2 |
-| `zoomMode` | `disabled\|in-place-click\|in-place-hover\|open-modal` | Sets the zoom behavior. | `in-place-click` |
-| `ModalZoom` | `vtex.modal-layout:modal-layout` | The `modal-layout` block that will open when you click in the image and `zoomMode` is `open-modal` | `undefined` |
-| `contentType`   | `'all'` &#124; `'images'` &#124; `'videos'`   | Controls the type of content that will be displayed.                               | `'all'`    | 
+| `zoomMode` | `enum` | Defines the image zoom behavior. Possible values are: `disabled` (zoom is disabled), `in-place-click`(zoom will be triggered when the image is clicked on), `in-place-hover`(zoom will be triggered when the image is hovered on)  or `open-modal` (image is zoommed using a modal). | `in-place-click` |
+| `ModalZoom` | `enum` | Allows clicking on the product image to open a popup for zooming it. This prop's value must match the name of the block responsible for triggering the modal containing the product image for zooming (e.g. `"modal-layout"`). Notice that the `ModalZoom` prop will work only if the `zoomMode` prop of the `product-image` is set as `open-modal`. To learn more, check out the [Advanced Configuration section](#Advanced-Configuration). | `undefined` |
+| `contentType` | `enum` | Controls the type of content that will be displayed in the block. Possible values are: `images`, `videos`, or `all`. | `all` |
 
-### `product-images.high-quality-image` block
+### Advanced configuration
 
-This block is meant to be used when you want that the zoom action open a modal with the current image of the `product-images` in it. In order to use you just have to put it inside the block that you will pass in the prop `ModalZoom` of the `product-images`:
+In this section, we teach you how to use modal zoom, a property for when you want to open a popup containing the product image for zooming. To use this feature, configure your `product-images` block using the `zoomMode` and `ModalZoom` props with `open-modal` and `modal-layout` set as its values, respectively.
+
+Once both props are correctly configured, declare the `modal-layout` block, responsible for triggering the image in a popup, and the `product-images.high-quality-image` block as its child.
+
+The `product-images.high-quality-image` block is a *special* block, only meant to render a popup containing the `product-image` block's image for zooming. 
+
+Check the following example:
 
 
 ```jsonc
@@ -77,6 +83,7 @@ This block is meant to be used when you want that the zoom action open a modal w
   "product-images": {
     "props": {
       "ModalZoom": "modal-layout#product-zoom",
+      // to use the ModalZoom, the product-images zoomMode value must be set as open-modal
       "zoomMode": "open-modal",
       "aspectRatio": {
         "desktop": "auto",
@@ -87,13 +94,15 @@ This block is meant to be used when you want that the zoom action open a modal w
 }
 ```
 
-The props of this block are very similar with some props of `product-images`:
+Notice that the `product-images.high-quality-image` block must be declared as a child of `modal-layout` and, in addition to that, you can also declare other blocks exported by the [Modal Layout app](https://vtex.io/docs/components/all/vtex.modal-layout) as children.
+
+The following table shows the props allowed by `product-images.high-quality-image`:
 
 | Prop name | Type | Description | Default Value |
 | --- | --- | --- | --- |
-| `zoomMode` | `'disabled'\|'in-place-click'\|'in-place-hover'` | Same as `zoomMode` of `product-images` but it doesn't accept `'open-modal'` | `'disabled'` |
-| `zoomFactor` | `number` | Same as `zoomFactor` from `product-images` | `2` |
-| `aspectRatio` | `string` | Same as in `product-images` | `'auto'` |
+| `zoomMode` | `enum` | Defines the zoom behavior for the `product-images.high-quality-image` block. Possible values are: `disabled` (zoom is disabled), `in-place-click`(zoom will be triggered when the image is clicked on), or `in-place-hover`(zoom will be triggered when the image is hovered on). Different from the `store-images` prop, this one doesn't accept `open-modal` value. | `disabled` |
+| `zoomFactor` | `number` | Sets how much the zoom increases the image size (e.g. `2` will make the zoomed-in image twice as large). | `2` |
+| `aspectRatio` | `string` | Sets the aspect ratio of the image, that is, whether the image should be square, portrait, landscape, etc. The value should follow the [common aspect ratio notation](https://en.wikipedia.org/wiki/Aspect_ratio_(image) i.e. two numbers separated by a colon such as `1:1` for square, `3:4` for upright portrait, or `1920:1080` for even large values).| `auto` |
 
 
 #### Customization
@@ -111,7 +120,9 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `carouselInconCaretRight` |
 | `carouselThumbBorder` |
 | `figure` |
+| `highQualityContainer` |
 | `image` |
+| `imgZoom` |
 | `productImagesContainer` (`content` is deprecated) |
 | `productImagesGallerySlide` |
 | `productImagesGallerySwiperContainer` |
@@ -127,5 +138,3 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `video` |
 | `video`|
 | `videoContainer` |
-| `imgZoom` |
-| `highQualityContainer` |

--- a/package.json
+++ b/package.json
@@ -6,11 +6,14 @@
   "scripts": {
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json}\"",
+    "test": "cd ./react && yarn test",
+    "verify": "yarn lint && yarn test",
     "lint:locales": "intl-equalizer"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "pre-push": "yarn verify"
     }
   },
   "lint-staged": {

--- a/react/HighQualityProductImage.ts
+++ b/react/HighQualityProductImage.ts
@@ -1,0 +1,1 @@
+export { default } from './components/ProductImages/components/HighQualityProductImage'

--- a/react/__mocks__/vtex.modal-layout/index.js
+++ b/react/__mocks__/vtex.modal-layout/index.js
@@ -1,3 +1,0 @@
-export const ModalContext = {
-  useModalDispatch: jest.fn(),
-}

--- a/react/__mocks__/vtex.modal-layout/index.tsx
+++ b/react/__mocks__/vtex.modal-layout/index.tsx
@@ -1,0 +1,49 @@
+import React, { useState, createContext, useContext } from 'react'
+
+export const ModalContext = {
+  useModalDispatch: jest.fn(),
+}
+
+interface TriggerProps {
+  children: React.ReactNode
+}
+
+interface ModalContextMockState {
+  open: boolean
+  toggleOpen?: () => void
+}
+
+const ModalContextMock = createContext<ModalContextMockState>({ open: false })
+
+export function ModalTrigger(props: TriggerProps) {
+  const { children } = props
+  const [open, setOpen] = useState(false)
+
+  const handleClick = () => {
+    setOpen(!open)
+  }
+
+  return (
+    // eslint-disable-next-line react/react-in-jsx-scope, jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
+    <div data-testid="modal-trigger" onClick={handleClick} role="button">
+      <ModalContextMock.Provider value={{ open, toggleOpen: handleClick }}>
+        {children}
+      </ModalContextMock.Provider>
+    </div>
+  )
+}
+
+interface ModalProps {
+  children: React.ReactNode
+}
+
+export function Modal(props: ModalProps) {
+  const { children } = props
+  const { open } = useContext(ModalContextMock)
+
+  if (!open) {
+    return null
+  }
+
+  return <div data-testid="modal-container">{children}</div>
+}

--- a/react/__tests__/components/ProductImages.test.js
+++ b/react/__tests__/components/ProductImages.test.js
@@ -1,12 +1,23 @@
 import React from 'react'
-import { render } from '@vtex/test-tools/react'
+import { render, fireEvent } from '@vtex/test-tools/react'
 import useProduct from 'vtex.product-context/useProduct'
+import { Modal } from 'vtex.modal-layout'
 
 import ProductImages from '../../ProductImages'
 // eslint-disable-next-line jest/no-mocks-import
 import { createItem } from '../../__mocks__/productMock'
+import HighQualityProductImage from '../../HighQualityProductImage'
 
 const mockUseProduct = useProduct
+
+// This works just like a slot passed to product-iamges
+function ModalLayout() {
+  return (
+    <Modal>
+      <HighQualityProductImage />
+    </Modal>
+  )
+}
 
 jest.mock('react-id-swiper/lib/ReactIdSwiper', () => {
   return {
@@ -262,6 +273,70 @@ describe('<ProductImages />', () => {
       const { queryAllByAltText } = renderComponent(props)
       expect(queryAllByAltText('propImageText')).toHaveLength(2)
       expect(queryAllByAltText('propImageText2')).toHaveLength(2)
+    })
+  })
+
+  describe('<HighQualityProductImage />', () => {
+    it('should render if the modal-trigger is clicked', () => {
+      const props = {
+        zoomMode: 'open-modal',
+        ModalZoom: ModalLayout,
+        images: [
+          {
+            imageUrls: ['url2'],
+            thresholds: [1],
+            thumbnailUrl: 'url2',
+            imageText: 'imageText2',
+          },
+        ],
+      }
+      const { getAllByAltText, getByTestId } = render(
+        <ProductImages {...props} />
+      )
+
+      const images = getAllByAltText('imageText2')
+
+      expect(images).toHaveLength(1)
+      fireEvent.click(getByTestId('modal-trigger'), {
+        bubbles: true,
+        cancelable: true,
+      })
+      expect(getAllByAltText('imageText2')).toHaveLength(2)
+    })
+
+    it('should render 2 img[alt="iamgeText2"] if img2 trigger is clicked', () => {
+      const props = {
+        zoomMode: 'open-modal',
+        ModalZoom: ModalLayout,
+        images: [
+          {
+            imageUrls: ['url'],
+            thresholds: [1],
+            thumbnailUrl: 'url',
+            imageText: 'imageText',
+          },
+          {
+            imageUrls: ['url2'],
+            thresholds: [1],
+            thumbnailUrl: 'url2',
+            imageText: 'imageText2',
+          },
+        ],
+      }
+      const { getAllByAltText, getAllByTestId } = render(
+        <ProductImages {...props} />
+      )
+
+      const images = getAllByAltText('imageText2')
+      expect(images).toHaveLength(2)
+      fireEvent.click(getAllByTestId('modal-trigger')[1], {
+        bubbles: true,
+        cancelable: true,
+      })
+
+      // 3 images with the alt because is one image of the trigger,
+      // one image of the thumbs and the image of HighQualityProductImage
+      expect(getAllByAltText('imageText2')).toHaveLength(3)
     })
   })
 })

--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -62,6 +62,7 @@ const ProductImagesWrapper = props => {
       showNavigationArrows={showNavigationArrows}
       showPaginationDots={showPaginationDots}
       contentOrder={contentOrder}
+      ModalZoomElement={props.ModalZoom}
       contentType={props.contentType}
       // Deprecated
       zoomProps={props.zoomProps}

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -199,6 +199,7 @@ class Carousel extends Component {
       maxHeight,
       zoomMode,
       zoomFactor,
+      ModalZoomElement,
       zoomProps: legacyZoomProps,
     } = this.props
 
@@ -213,9 +214,10 @@ class Carousel extends Component {
           <ProductImage
             src={slide.url}
             alt={slide.alt}
-            aspectRatio={aspectRatio}
             maxHeight={maxHeight}
             zoomFactor={zoomFactor}
+            aspectRatio={aspectRatio}
+            ModalZoomElement={ModalZoomElement}
             zoomMode={isZoomDisabled ? 'disabled' : zoomMode}
           />
         )
@@ -500,6 +502,7 @@ Carousel.propTypes = {
       bestUrlIndex: PropTypes.number,
     })
   ),
+  ModalZoomElement: PropTypes.any,
   displayThumbnailsArrows: PropTypes.bool,
 }
 

--- a/react/components/ProductImages/components/HighQualityProductImage.tsx
+++ b/react/components/ProductImages/components/HighQualityProductImage.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react'
 import classnames from 'classnames'
 import { useCssHandles } from 'vtex.css-handles'
 
+import styles from '../styles.css'
 import { imageUrl } from '../utils/aspectRatioUtil'
 import ProductImageContext from './ProductImageContext'
 import Zoomable, { ZoomMode as ZoomModeComplete } from './Zoomable'
@@ -11,25 +12,38 @@ const IMAGE_SIZES = [800, 1200, 1400]
 const DEFAULT_SIZE = 1200
 const MAX_SIZE = 4096
 
-type ZoomMode = Exclude<ZoomModeComplete, 'open-modal'>
 type AspectRatio = string | number
+type ZoomMode = Exclude<ZoomModeComplete, 'open-modal'>
 
 interface Props {
   zoomMode?: ZoomMode
   zoomFactor?: number
   aspectRatio?: AspectRatio
-  maxHeight?: number | string
 }
 
-const CSS_HANDLES = ['highQualityContainer', 'imgZoom'] as const
+function validateZoomMode(zoomMode: ZoomModeComplete): ZoomMode {
+  if (
+    zoomMode !== 'disabled' &&
+    zoomMode !== 'in-place-click' &&
+    zoomMode !== 'in-place-hover'
+  ) {
+    console.warn(
+      `You passed a wrong value to prop zoomMode \`${zoomMode}\` using 'disabled' instead`
+    )
+    return 'disabled'
+  }
+
+  return zoomMode
+}
+
+const CSS_HANDLES = [
+  'imgZoom',
+  'productImageTag',
+  'highQualityContainer',
+] as const
 
 function HighQualityProductImage(props: Props) {
-  const {
-    zoomFactor = 2,
-    maxHeight,
-    aspectRatio = 'auto',
-    zoomMode = 'in-place-click',
-  } = props
+  const { zoomFactor = 2, aspectRatio = 'auto', zoomMode = 'disabled' } = props
   const handles = useCssHandles(CSS_HANDLES)
   const context = useContext(ProductImageContext)
 
@@ -54,10 +68,16 @@ function HighQualityProductImage(props: Props) {
     'w-100 h-100 overflow-hidden'
   )
 
+  const imgClasses = classnames(
+    handles.productImageTag,
+    styles.highQualityProductImageImgElement,
+    'w-100 h-100'
+  )
+
   return (
     <div className={containerClasses}>
       <Zoomable
-        mode={zoomMode}
+        mode={validateZoomMode(zoomMode)}
         factor={zoomFactor}
         zoomContent={
           // eslint-disable-next-line jsx-a11y/alt-text
@@ -88,13 +108,7 @@ function HighQualityProductImage(props: Props) {
           title={alt}
           loading="lazy"
           srcSet={srcSet}
-          className={handles.imgZoom}
-          style={{
-            width: '100%',
-            height: '100%',
-            maxHeight: maxHeight ?? 'unset',
-            objectFit: 'contain',
-          }}
+          className={imgClasses}
           // See comment regarding sizes below
           sizes="(max-width: 64.1rem) 100vw, 50vw"
           src={imageUrl(src, DEFAULT_SIZE * zoomFactor, MAX_SIZE, aspectRatio)}

--- a/react/components/ProductImages/components/HighQualityProductImage.tsx
+++ b/react/components/ProductImages/components/HighQualityProductImage.tsx
@@ -1,0 +1,107 @@
+import React, { useContext } from 'react'
+import classnames from 'classnames'
+import { useCssHandles } from 'vtex.css-handles'
+
+import { imageUrl } from '../utils/aspectRatioUtil'
+import ProductImageContext from './ProductImageContext'
+import Zoomable, { ZoomMode as ZoomModeComplete } from './Zoomable'
+
+// Same logic of the fixed values of ProductImages, but bigger values
+const IMAGE_SIZES = [800, 1200, 1400]
+const DEFAULT_SIZE = 1200
+const MAX_SIZE = 4096
+
+type ZoomMode = Exclude<ZoomModeComplete, 'open-modal'>
+type AspectRatio = string | number
+
+interface Props {
+  zoomMode?: ZoomMode
+  zoomFactor?: number
+  aspectRatio?: AspectRatio
+  maxHeight?: number | string
+}
+
+const CSS_HANDLES = ['highQualityContainer', 'imgZoom'] as const
+
+function HighQualityProductImage(props: Props) {
+  const {
+    zoomFactor = 2,
+    maxHeight,
+    aspectRatio = 'auto',
+    zoomMode = 'in-place-click',
+  } = props
+  const handles = useCssHandles(CSS_HANDLES)
+  const context = useContext(ProductImageContext)
+
+  if (!context) {
+    console.warn(
+      "You're using a HighQualityProductImage out of a ProductImageContext"
+    )
+    return null
+  }
+
+  if (!('src' in context)) {
+    return null
+  }
+
+  const { alt, src } = context
+  const srcSet = IMAGE_SIZES.map(
+    size => `${imageUrl(src, size, MAX_SIZE, aspectRatio)} ${size}w`
+  ).join(',')
+
+  const containerClasses = classnames(
+    handles.highQualityContainer,
+    'w-100 h-100 overflow-hidden'
+  )
+
+  return (
+    <div className={containerClasses}>
+      <Zoomable
+        mode={zoomMode}
+        factor={zoomFactor}
+        zoomContent={
+          // eslint-disable-next-line jsx-a11y/alt-text
+          <img
+            // This img element is just for zoom
+            role="presentation"
+            className={handles.imgZoom}
+            style={{
+              // Resets possible resizing done via CSS
+              maxWidth: 'unset',
+              width: `${zoomFactor * 100}%`,
+              height: `${zoomFactor * 100}%`,
+              objectFit: 'contain',
+            }}
+            // See comment regarding sizes below
+            sizes="(max-width: 64.1rem) 100vw, 50vw"
+            src={imageUrl(
+              src,
+              DEFAULT_SIZE * zoomFactor,
+              MAX_SIZE,
+              aspectRatio
+            )}
+          />
+        }
+      >
+        <img
+          alt={alt}
+          title={alt}
+          loading="lazy"
+          srcSet={srcSet}
+          className={handles.imgZoom}
+          style={{
+            width: '100%',
+            height: '100%',
+            maxHeight: maxHeight ?? 'unset',
+            objectFit: 'contain',
+          }}
+          // See comment regarding sizes below
+          sizes="(max-width: 64.1rem) 100vw, 50vw"
+          src={imageUrl(src, DEFAULT_SIZE * zoomFactor, MAX_SIZE, aspectRatio)}
+        />
+      </Zoomable>
+    </div>
+  )
+}
+
+export default HighQualityProductImage

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -18,7 +18,7 @@ interface Props {
   zoomMode: ZoomMode
   zoomFactor: number
   aspectRatio?: AspectRatio
-  maxHeight?: number
+  maxHeight?: number | string
   ModalZoomElement?: typeof Modal
 }
 

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -1,8 +1,10 @@
 import React, { FC, useMemo, useRef } from 'react'
+import { Modal } from 'vtex.modal-layout'
 import { useCssHandles } from 'vtex.css-handles'
 
 import Zoomable, { ZoomMode } from './Zoomable'
 import { imageUrl } from '../utils/aspectRatioUtil'
+import ProductImageContext from './ProductImageContext'
 
 const IMAGE_SIZES = [600, 800, 1200]
 const DEFAULT_SIZE = 800
@@ -15,6 +17,7 @@ interface Props {
   zoomFactor: number
   aspectRatio?: AspectRatio
   maxHeight?: number
+  ModalZoomElement?: typeof Modal
 }
 
 type AspectRatio = string | number
@@ -24,10 +27,11 @@ const CSS_HANDLES = ['productImage', 'productImageTag']
 const ProductImage: FC<Props> = ({
   src,
   alt,
-  zoomMode = ZoomMode.InPlaceClick,
   zoomFactor = 2,
-  aspectRatio = 'auto',
   maxHeight = 600,
+  ModalZoomElement,
+  aspectRatio = 'auto',
+  zoomMode = ZoomMode.InPlaceClick,
 }) => {
   const srcSet = useMemo(
     () =>
@@ -37,14 +41,16 @@ const ProductImage: FC<Props> = ({
     [src, aspectRatio]
   )
   const handles = useCssHandles(CSS_HANDLES)
-
   const imageRef = useRef(null)
+
+  const imageContext = useMemo(() => ({}), [])
 
   return (
     <div className={handles.productImage}>
       <Zoomable
         mode={zoomMode}
         factor={zoomFactor}
+        ModalZoomElement={ModalZoomElement}
         zoomContent={
           // eslint-disable-next-line jsx-a11y/alt-text
           <img
@@ -67,32 +73,34 @@ const ProductImage: FC<Props> = ({
           />
         }
       >
-        <img
-          ref={imageRef}
-          className={handles.productImageTag}
-          style={{
-            width: '100%',
-            height: '100%',
-            maxHeight: maxHeight || 'unset',
-            objectFit: 'contain',
-          }}
-          src={imageUrl(src, DEFAULT_SIZE, MAX_SIZE, aspectRatio)}
-          srcSet={srcSet}
-          alt={alt}
-          title={alt}
-          loading="lazy"
-          // WIP
-          // The value of the "sizes" attribute means: if the window has at most 64.1rem of width,
-          // the image will be of a width of 100vw. Otherwise, the
-          // image will be 50vw wide.
-          // This size is used for picking the best available size
-          // given the ones from the srcset above.
-          //
-          // This is WIP because it is a guess: we are assuming
-          // the image will be of a certain size, but it should be
-          // probably be gotten from flex-layout or something.
-          sizes="(max-width: 64.1rem) 100vw, 50vw"
-        />
+        <ProductImageContext.Provider value={imageContext}>
+          <img
+            ref={imageRef}
+            className={handles.productImageTag}
+            style={{
+              width: '100%',
+              height: '100%',
+              maxHeight: maxHeight || 'unset',
+              objectFit: 'contain',
+            }}
+            src={imageUrl(src, DEFAULT_SIZE, MAX_SIZE, aspectRatio)}
+            srcSet={srcSet}
+            alt={alt}
+            title={alt}
+            loading="lazy"
+            // WIP
+            // The value of the "sizes" attribute means: if the window has at most 64.1rem of width,
+            // the image will be of a width of 100vw. Otherwise, the
+            // image will be 50vw wide.
+            // This size is used for picking the best available size
+            // given the ones from the srcset above.
+            //
+            // This is WIP because it is a guess: we are assuming
+            // the image will be of a certain size, but it should be
+            // probably be gotten from flex-layout or something.
+            sizes="(max-width: 64.1rem) 100vw, 50vw"
+          />
+        </ProductImageContext.Provider>
       </Zoomable>
     </div>
   )

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -31,7 +31,7 @@ const ProductImage: FC<Props> = ({
   maxHeight = 600,
   ModalZoomElement,
   aspectRatio = 'auto',
-  zoomMode = ZoomMode.InPlaceClick,
+  zoomMode = 'in-place-click',
 }) => {
   const srcSet = useMemo(
     () =>

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -4,7 +4,9 @@ import { useCssHandles } from 'vtex.css-handles'
 
 import Zoomable, { ZoomMode } from './Zoomable'
 import { imageUrl } from '../utils/aspectRatioUtil'
-import ProductImageContext from './ProductImageContext'
+import ProductImageContext, {
+  State as ProductImageState,
+} from './ProductImageContext'
 
 const IMAGE_SIZES = [600, 800, 1200]
 const DEFAULT_SIZE = 800
@@ -43,37 +45,45 @@ const ProductImage: FC<Props> = ({
   const handles = useCssHandles(CSS_HANDLES)
   const imageRef = useRef(null)
 
-  const imageContext = useMemo(() => ({}), [])
+  const imageContext: ProductImageState = useMemo(
+    () => ({
+      src,
+      alt,
+    }),
+    [alt, src]
+  )
 
   return (
-    <div className={handles.productImage}>
-      <Zoomable
-        mode={zoomMode}
-        factor={zoomFactor}
-        ModalZoomElement={ModalZoomElement}
-        zoomContent={
-          // eslint-disable-next-line jsx-a11y/alt-text
-          <img
-            src={imageUrl(
-              src,
-              DEFAULT_SIZE * zoomFactor,
-              MAX_SIZE,
-              aspectRatio
-            )}
-            className={handles.productImageTag}
-            style={{
-              // Resets possible resizing done via CSS
-              maxWidth: 'unset',
-              width: `${zoomFactor * 100}%`,
-              height: `${zoomFactor * 100}%`,
-              objectFit: 'contain',
-            }}
-            // See comment regarding sizes below
-            sizes="(max-width: 64.1rem) 100vw, 50vw"
-          />
-        }
-      >
-        <ProductImageContext.Provider value={imageContext}>
+    <ProductImageContext.Provider value={imageContext}>
+      <div className={handles.productImage}>
+        <Zoomable
+          mode={zoomMode}
+          factor={zoomFactor}
+          ModalZoomElement={ModalZoomElement}
+          zoomContent={
+            // eslint-disable-next-line jsx-a11y/alt-text
+            <img
+              // This img element is just for zoom
+              role="presentation"
+              src={imageUrl(
+                src,
+                DEFAULT_SIZE * zoomFactor,
+                MAX_SIZE,
+                aspectRatio
+              )}
+              className={handles.productImageTag}
+              style={{
+                // Resets possible resizing done via CSS
+                maxWidth: 'unset',
+                width: `${zoomFactor * 100}%`,
+                height: `${zoomFactor * 100}%`,
+                objectFit: 'contain',
+              }}
+              // See comment regarding sizes below
+              sizes="(max-width: 64.1rem) 100vw, 50vw"
+            />
+          }
+        >
           <img
             ref={imageRef}
             className={handles.productImageTag}
@@ -100,9 +110,9 @@ const ProductImage: FC<Props> = ({
             // probably be gotten from flex-layout or something.
             sizes="(max-width: 64.1rem) 100vw, 50vw"
           />
-        </ProductImageContext.Provider>
-      </Zoomable>
-    </div>
+        </Zoomable>
+      </div>
+    </ProductImageContext.Provider>
   )
 }
 

--- a/react/components/ProductImages/components/ProductImageContext.ts
+++ b/react/components/ProductImages/components/ProductImageContext.ts
@@ -1,15 +1,10 @@
 import { createContext } from 'react'
 
-type AspectRatio = string | number
-
-interface State {
+export interface State {
   src: string
   alt: string
-  aspectRatio: AspectRatio
 }
 
-const DEFAULT_STATE: Partial<State> = {}
-
-const ProductImageContext = createContext(DEFAULT_STATE)
+const ProductImageContext = createContext<State | object>({})
 
 export default ProductImageContext

--- a/react/components/ProductImages/components/ProductImageContext.ts
+++ b/react/components/ProductImages/components/ProductImageContext.ts
@@ -1,0 +1,15 @@
+import { createContext } from 'react'
+
+type AspectRatio = string | number
+
+interface State {
+  src: string
+  alt: string
+  aspectRatio: AspectRatio
+}
+
+const DEFAULT_STATE: Partial<State> = {}
+
+const ProductImageContext = createContext(DEFAULT_STATE)
+
+export default ProductImageContext

--- a/react/components/ProductImages/components/Zoomable/ModalZoom.tsx
+++ b/react/components/ProductImages/components/Zoomable/ModalZoom.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { ModalTrigger, Modal } from 'vtex.modal-layout'
+
+interface Props {
+  children: React.ReactNode
+  ModalZoomElement: typeof Modal
+}
+
+function ModalZoom(props: Props) {
+  const { children, ModalZoomElement } = props
+
+  return (
+    <ModalTrigger>
+      {children}
+      <ModalZoomElement />
+    </ModalTrigger>
+  )
+}
+
+export default ModalZoom

--- a/react/components/ProductImages/components/Zoomable/index.tsx
+++ b/react/components/ProductImages/components/Zoomable/index.tsx
@@ -5,12 +5,11 @@ import { useDevice } from 'vtex.device-detector'
 import ZoomInPlace from './ZoomInPlace'
 import ModalZoom from './ModalZoom'
 
-export enum ZoomMode {
-  InPlaceClick = 'in-place-click',
-  InPlaceHover = 'in-place-hover',
-  Disabled = 'disabled',
-  OpenModal = 'open-modal',
-}
+export type ZoomMode =
+  | 'in-place-click'
+  | 'in-place-hover'
+  | 'disabled'
+  | 'open-modal'
 
 interface Props {
   mode?: ZoomMode
@@ -24,11 +23,11 @@ const Zoomable: FC<Props> = ({
   factor = 2,
   zoomContent,
   ModalZoomElement,
-  mode = ZoomMode.InPlaceClick,
+  mode = 'in-place-click',
 }) => {
   const { isMobile } = useDevice()
 
-  if (isMobile && mode !== ZoomMode.Disabled) {
+  if (isMobile && mode !== 'disabled') {
     // TODO: Good enough for now, but needs to be a gallery in the future.
     // Preferably photoswipe.com
     return (
@@ -39,19 +38,19 @@ const Zoomable: FC<Props> = ({
   }
 
   switch (mode) {
-    case ZoomMode.InPlaceHover:
+    case 'in-place-hover':
       return (
         <ZoomInPlace type="hover" factor={factor} zoomContent={zoomContent}>
           {children}
         </ZoomInPlace>
       )
-    case ZoomMode.InPlaceClick:
+    case 'in-place-click':
       return (
         <ZoomInPlace type="click" factor={factor} zoomContent={zoomContent}>
           {children}
         </ZoomInPlace>
       )
-    case ZoomMode.OpenModal: {
+    case 'open-modal': {
       if (ModalZoomElement) {
         return (
           <ModalZoom ModalZoomElement={ModalZoomElement}>{children}</ModalZoom>
@@ -59,7 +58,7 @@ const Zoomable: FC<Props> = ({
       }
     }
     // eslint-disable-next-line no-fallthrough
-    case ZoomMode.Disabled:
+    case 'disabled':
     default:
       return <>{children}</>
   }

--- a/react/components/ProductImages/components/Zoomable/index.tsx
+++ b/react/components/ProductImages/components/Zoomable/index.tsx
@@ -1,24 +1,29 @@
 import React, { FC, ReactElement } from 'react'
+import { Modal } from 'vtex.modal-layout'
 import { useDevice } from 'vtex.device-detector'
 
 import ZoomInPlace from './ZoomInPlace'
+import ModalZoom from './ModalZoom'
 
 export enum ZoomMode {
   InPlaceClick = 'in-place-click',
   InPlaceHover = 'in-place-hover',
   Disabled = 'disabled',
+  OpenModal = 'open-modal',
 }
 
 interface Props {
   mode?: ZoomMode
   zoomContent?: ReactElement
   factor?: number
+  ModalZoomElement?: typeof Modal
 }
 
 const Zoomable: FC<Props> = ({
   children,
   factor = 2,
   zoomContent,
+  ModalZoomElement,
   mode = ZoomMode.InPlaceClick,
 }) => {
   const { isMobile } = useDevice()
@@ -46,6 +51,14 @@ const Zoomable: FC<Props> = ({
           {children}
         </ZoomInPlace>
       )
+    case ZoomMode.OpenModal: {
+      if (ModalZoomElement) {
+        return (
+          <ModalZoom ModalZoomElement={ModalZoomElement}>{children}</ModalZoom>
+        )
+      }
+    }
+    // eslint-disable-next-line no-fallthrough
     case ZoomMode.Disabled:
     default:
       return <>{children}</>

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -144,7 +144,12 @@ ProductImages.propTypes = {
   showNavigationArrows: PropTypes.bool,
   showPaginationDots: PropTypes.bool,
   contentOrder: PropTypes.oneOf(['images-first', 'videos-first']),
-  zoomMode: PropTypes.number,
+  zoomMode: PropTypes.oneOf([
+    'disabled',
+    'open-modal',
+    'in-place-click',
+    'in-place-hover',
+  ]),
   zoomFactor: PropTypes.number,
   contentType: PropTypes.oneOf(['all', 'images', 'videos']),
 }

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -27,6 +27,7 @@ const ProductImages = ({
   contentOrder = 'images-first',
   zoomMode,
   zoomFactor,
+  ModalZoomElement,
   contentType = 'all',
   // Deprecated
   zoomProps,
@@ -77,16 +78,17 @@ const ProductImages = ({
       <Carousel
         slides={slides}
         position={position}
-        displayThumbnailsArrows={displayThumbnailsArrows}
-        thumbnailsOrientation={thumbnailsOrientation}
-        aspectRatio={aspectRatio}
-        maxHeight={maxHeight}
-        thumbnailAspectRatio={thumbnailAspectRatio}
-        thumbnailMaxHeight={thumbnailMaxHeight}
-        showNavigationArrows={showNavigationArrows}
-        showPaginationDots={showPaginationDots}
         zoomMode={zoomMode}
+        maxHeight={maxHeight}
         zoomFactor={zoomFactor}
+        aspectRatio={aspectRatio}
+        ModalZoomElement={ModalZoomElement}
+        thumbnailMaxHeight={thumbnailMaxHeight}
+        showPaginationDots={showPaginationDots}
+        thumbnailAspectRatio={thumbnailAspectRatio}
+        showNavigationArrows={showNavigationArrows}
+        thumbnailsOrientation={thumbnailsOrientation}
+        displayThumbnailsArrows={displayThumbnailsArrows}
         // Deprecated
         zoomProps={zoomProps}
       />
@@ -100,6 +102,7 @@ ProductImages.propTypes = {
     THUMBS_POSITION_HORIZONTAL.LEFT,
     THUMBS_POSITION_HORIZONTAL.RIGHT,
   ]),
+  ModalZoomElement: PropTypes.any,
   thumbnailsOrientation: PropTypes.oneOf([
     THUMBS_ORIENTATION.VERTICAL,
     THUMBS_ORIENTATION.HORIZONTAL,

--- a/react/components/ProductImages/styles.css
+++ b/react/components/ProductImages/styles.css
@@ -6,6 +6,11 @@
 
 .productImage { }
 
+.highQualityProductImageImgElement {
+  max-height: unset;
+  object-fit: contain;
+}
+
 .carouselGaleryCursor {
   cursor: url('./components/Carousel/cursor.svg') 8 8, default;
 }

--- a/react/package.json
+++ b/react/package.json
@@ -63,6 +63,7 @@
     "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.24.1/public/@types/vtex.search-graphql",
     "vtex.shipping-estimate-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.0/public/@types/vtex.shipping-estimate-translator",
     "vtex.slider-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.slider-layout@0.11.0/public/@types/vtex.slider-layout",
+    "vtex.modal-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.modal-layout@0.5.1/public/@types/vtex.modal-layout",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.122.0/public/@types/vtex.store-graphql",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons",
     "vtex.store-image": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.4.3/public/@types/vtex.store-image",

--- a/react/typings/vtex.css-handles.d.ts
+++ b/react/typings/vtex.css-handles.d.ts
@@ -1,5 +1,0 @@
-declare module 'vtex.css-handles' {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const useCssHandles: any
-  const applyModifiers: (handle: string, modifier: string | string[]) => string
-}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5473,6 +5473,10 @@ verror@1.10.0:
   version "0.1.3"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.3/public/@types/vtex.format-currency#3544c6ee5c14482da201a198eede4ffba9f19406"
 
+"vtex.modal-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.modal-layout@0.5.1/public/@types/vtex.modal-layout":
+  version "0.5.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.modal-layout@0.5.1/public/@types/vtex.modal-layout#7c6cccb212b9b330ff104a0e1c6dce0c0621542b"
+
 "vtex.modal@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.modal@0.2.1/public/_types/react":
   version "0.2.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.modal@0.2.1/public/_types/react#e60eec32b9814caa0a80f632c4a5ce65606fc254"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -24,6 +24,9 @@
   "product-images": {
     "component": "ProductImages"
   },
+  "product-images.high-quality-image": {
+    "component": "HighQualityProductImage"
+  },
   "product-price": {
     "component": "ProductPrice",
     "content": {


### PR DESCRIPTION
#### What problem is this solving?

As the title says.

#### Note
The code used in the `store-theme` is in the documentation.

#### How should this be manually tested?

1. [Workspace](https://modalzoom--storecomponents.myvtex.com/classic-shoes/p)
2. Click in the image of product images

If you change the images in `product-image` slider and click it should open the modal in the right image.

#### Checklist/Reminders

- [X] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
