### PR TITLE
encode forward slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Encode forward slash in the search term.
 
 ## [3.126.0] - 2020-09-02
 ### Changed

--- a/react/components/AutocompleteResults/index.js
+++ b/react/components/AutocompleteResults/index.js
@@ -11,6 +11,7 @@ import { useCssHandles } from 'vtex.css-handles'
 // eslint-disable-next-line no-unused-vars
 import styles from './styles.css'
 import autocomplete from './queries/autocomplete.gql'
+import encodeForwardSlash from '../../utils/encodeForwardSlash'
 
 const MIN_RESULTS_WIDTH = 320
 const CSS_HANDLES = [
@@ -69,6 +70,7 @@ const AutocompleteResults = ({
   } = useRuntime()
 
   const handles = useCssHandles(CSS_HANDLES)
+  const encodedInputValue = encodeForwardSlash(inputValue)
 
   const listStyle = useMemo(
     () => ({
@@ -165,7 +167,7 @@ const AutocompleteResults = ({
               <li
                 {...getItemProps({
                   key: `ft${inputValue}`,
-                  item: { term: inputValue },
+                  item: { term: encodedInputValue },
                   index: 0,
                   onClick: handleItemClick,
                 })}
@@ -183,7 +185,7 @@ const AutocompleteResults = ({
                     {fullTextSearchLabel}
                   </a>
                 ) : (
-                  renderSearchByClick(inputValue)
+                  renderSearchByClick(encodedInputValue)
                 )}
               </li>
 

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -5,6 +5,7 @@ import { ModalContext } from 'vtex.modal-layout'
 import { useRuntime } from 'vtex.render-runtime'
 
 import SearchBar from './components/SearchBar'
+import encodeForwardSlash from '../../utils/encodeForwardSlash'
 
 const { useModalDispatch } = ModalContext
 
@@ -54,7 +55,7 @@ function SearchBarContainer(props) {
   }, [])
 
   const handleGoToSearchPage = useCallback(() => {
-    const search = inputValue
+    const search = encodeForwardSlash(inputValue)
 
     if (attemptPageTypeSearch) {
       window.location.href = `/${search}`

--- a/react/utils/encodeForwardSlash.js
+++ b/react/utils/encodeForwardSlash.js
@@ -1,0 +1,12 @@
+/**
+ * Encode all "/" by using $2F instead of %2F
+ * Since "/" is a special character in URL, it can not be encoded normally,
+ * @export
+ * @param {string} str
+ * @returns {string}
+ */
+const encodeForwardSlash = str => {
+  return str.replace(/\//gi, "$2F")
+}
+
+export default encodeForwardSlash

--- a/react/utils/encodeForwardSlash.js
+++ b/react/utils/encodeForwardSlash.js
@@ -6,7 +6,7 @@
  * @returns {string}
  */
 const encodeForwardSlash = str => {
-  return str.replace(/\//gi, "$2F")
+  return str.replace(/\//gi, '$2F')
 }
 
 export default encodeForwardSlash


### PR DESCRIPTION
#### What problem is this solving?

Currently, it is not possible to search for a term that contains "/" because it is not being encoded. For example, if you search for `3-48m/s br nl` the result will be the following

![image](https://user-images.githubusercontent.com/40380674/84977370-95d37100-b100-11ea-8826-70fb074b8d84.png)

It is not possible to encode the "/" with "%2F" because of [this](https://github.com/vtex/rewriter/blob/872e028b814de2ade81917dd73cb16f1394a29d1/node/utils/paths.ts#L21) function that will guarantee that no encoded term will pass.

My team and I decided to use another sequence of characters to encode it: `$2F`.

#### How to test it?

[Workspace](https://searchslashbug--storecomponents.myvtex.com/top$2fs?map=ft

#### Describe alternatives you've considered, if any.

I've tried really hard to keep the usual "code" for the `/`. But while   [this](https://github.com/vtex/rewriter/blob/872e028b814de2ade81917dd73cb16f1394a29d1/node/utils/paths.ts#L21) function is in the rewriter it will be impossible.

#### Related to / Depends on

https://github.com/vtex-apps/store/pull/465

