### PR TITLE
Fix open-modal zoom option of ProductImages in mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `open-modal` zoom option of `product-images` not working in mobile.
 
 ## [3.119.2] - 2020-06-23
 ### Fixed

--- a/react/components/ProductImages/components/Zoomable/index.tsx
+++ b/react/components/ProductImages/components/Zoomable/index.tsx
@@ -27,7 +27,7 @@ const Zoomable: FC<Props> = ({
 }) => {
   const { isMobile } = useDevice()
 
-  if (isMobile && mode !== 'disabled') {
+  if (isMobile && mode !== 'disabled' && mode !== 'open-modal') {
     // TODO: Good enough for now, but needs to be a gallery in the future.
     // Preferably photoswipe.com
     return (


### PR DESCRIPTION
#### What problem is this solving?

As the title says.

#### How to test it?

1. [Workspace](https://klynger--storecomponents.myvtex.com/classic-shoes/p)
2. Put in mobile
3. Click in the image

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/8517023/85721138-78d20b80-b6c7-11ea-8603-9f5b3eba4256.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
