### PR TITLE
Fix/lazyload infocard bg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where the background image of infocard component wouldn't be adjustable via CSS when lazyloaded.
 
 ## [3.119.3] - 2020-06-25
 ### Fixed

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -136,6 +136,11 @@ const InfoCard = ({
   const containerStyle =
     isFullModeStyle && !lazyLoad
       ? { backgroundImage: `url(${finalImageUrl})`, backgroundSize: 'cover' }
+      : { backgroundSize: 'cover' }
+
+  const containerAttributes = 
+    isFullModeStyle && lazyLoad
+      ? { 'data-bg': finalImageUrl }
       : {}
 
   const containerClasses = classNames(
@@ -143,7 +148,7 @@ const InfoCard = ({
     {
       [`flex-ns ${flexOrderToken} bg-base ph2-ns pb2 justify-between`]: !isFullModeStyle,
       [`bg-center bb b--muted-4 flex ${justifyToken}`]: isFullModeStyle,
-      relative: lazyLoad,
+      'lazyload': lazyLoad,
     }
   )
 
@@ -152,7 +157,6 @@ const InfoCard = ({
     {
       [`w-50-ns ph3-s ${itemsToken} ${paddingClass}`]: !isFullModeStyle,
       [`mh8-ns mh4-s w-40-ns ${itemsToken}`]: isFullModeStyle,
-      'relative z-1': lazyLoad,
     }
   )
 
@@ -181,22 +185,8 @@ const InfoCard = ({
         style={containerStyle}
         data-testid="container"
         id={htmlId}
+        {...containerAttributes}
       >
-        {lazyLoad && isFullModeStyle && (
-          /** TODO: Currently, it just checks if its under a LazyImages
-           * context and inserts a regular image, relying on render runtime
-           * to actually make it lazy.
-           * In the future, it should be considered to always do this instead,
-           * making this logic simpler, but one must be aware of potential
-           * breaking changes, and the change must be tested thoroughly.
-           */
-          // eslint-disable-next-line jsx-a11y/alt-text
-          <img
-            src={finalImageUrl}
-            className="absolute w-100 h-100"
-            style={{ objectFit: 'cover' }}
-          />
-        )}
         <div className={textContainerClasses}>
           {headline &&
             (textMode === 'html' ? (

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -134,9 +134,14 @@ const InfoCard = ({
   )
 
   const containerStyle =
-    isFullModeStyle && !lazyLoad
-      ? { backgroundImage: `url(${finalImageUrl})`, backgroundSize: 'cover' }
-      : { backgroundSize: 'cover' }
+    isFullModeStyle
+      ? {
+        /* If lazyloaded, the background image comes from the `data-bg` attribute
+         * below. Otherwise, sets it here as background-image */
+        ...(!lazyLoad && { backgroundImage: `url(${finalImageUrl})`}),
+        backgroundSize: 'cover',
+      }
+      : {}
 
   const containerAttributes = 
     isFullModeStyle && lazyLoad

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -133,27 +133,24 @@ const InfoCard = ({
     formatIOMessage({ id: mobileImageUrl, intl })
   )
 
-  const containerStyle =
-    isFullModeStyle
-      ? {
+  const containerStyle = isFullModeStyle
+    ? {
         /* If lazyloaded, the background image comes from the `data-bg` attribute
          * below. Otherwise, sets it here as background-image */
-        ...(!lazyLoad && { backgroundImage: `url(${finalImageUrl})`}),
+        ...(!lazyLoad && { backgroundImage: `url(${finalImageUrl})` }),
         backgroundSize: 'cover',
       }
-      : {}
+    : {}
 
-  const containerAttributes = 
-    isFullModeStyle && lazyLoad
-      ? { 'data-bg': finalImageUrl }
-      : {}
+  const containerAttributes =
+    isFullModeStyle && lazyLoad ? { 'data-bg': finalImageUrl } : {}
 
   const containerClasses = classNames(
     `${handles.infoCardContainer} items-center`,
     {
       [`flex-ns ${flexOrderToken} bg-base ph2-ns pb2 justify-between`]: !isFullModeStyle,
       [`bg-center bb b--muted-4 flex ${justifyToken}`]: isFullModeStyle,
-      'lazyload': lazyLoad,
+      lazyload: lazyLoad,
     }
   )
 


### PR DESCRIPTION
#### What problem is this solving?

Fixes issue where the background image of infocard component wouldn't be adjustable via CSS when lazyloaded (due to it not being a background image at all in that case, being actually an img element)

Requires https://github.com/vtex-apps/render-runtime/pull/542

Before: https://www.worldwidegolfshops.com/ (hover on the links on the header menu)
![Screen Shot 2020-06-30 at 15 02 10](https://user-images.githubusercontent.com/5691711/86160818-b3321300-bae2-11ea-9791-1611277a3b20.png)

After: https://lbebber--worldwidegolf.myvtex.com/
![Screen Shot 2020-06-30 at 14 59 01](https://user-images.githubusercontent.com/5691711/86160823-b7f6c700-bae2-11ea-9d38-f48d31e1aad9.png)