### PR TITLE
Add recursive input values in the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handling of recursive input values in assembly options.
 
 ## [3.119.7] - 2020-07-14
 ### Fixed

--- a/react/components/BuyButton/__mocks__/assemblyOptions.ts
+++ b/react/components/BuyButton/__mocks__/assemblyOptions.ts
@@ -83,18 +83,18 @@ export const customBell: AssemblyOptions = {
       },
     ],
   },
-  "inputValues": {
-    "1-3-lines": {
-      "Line 1": "First line",
-      "Line 2": "Second line",
-      "Line 3": "Third line",
-    }
+  inputValues: {
+    '1-3-lines': {
+      'Line 1': 'First line',
+      'Line 2': 'Second line',
+      'Line 3': 'Third line',
+    },
   },
-  "areGroupsValid": {
-    "add-on_Add-on": true,
-    "text_style_Text Style": true,
-    "engraving_Engraving": true
-  }
+  areGroupsValid: {
+    'add-on_Add-on': true,
+    'text_style_Text Style': true,
+    engraving_Engraving: true,
+  },
 }
 
 export const starColor = {

--- a/react/components/BuyButton/__mocks__/assemblyOptions.ts
+++ b/react/components/BuyButton/__mocks__/assemblyOptions.ts
@@ -83,12 +83,18 @@ export const customBell: AssemblyOptions = {
       },
     ],
   },
-  inputValues: {},
-  areGroupsValid: {
-    'add-on_Add-on': true,
-    'text_style_Text Style': true,
-    engraving_Engraving: true,
+  "inputValues": {
+    "1-3-lines": {
+      "Line 1": "First line",
+      "Line 2": "Second line",
+      "Line 3": "Third line",
+    }
   },
+  "areGroupsValid": {
+    "add-on_Add-on": true,
+    "text_style_Text Style": true,
+    "engraving_Engraving": true
+  }
 }
 
 export const starColor = {

--- a/react/components/BuyButton/assemblyUtils.test.ts
+++ b/react/components/BuyButton/assemblyUtils.test.ts
@@ -63,6 +63,154 @@ test('input values', () => {
     'Back text': 'Verso',
     'Glossy print': true,
   })
+  expect(resultStar).toMatchInlineSnapshot(`
+    Object {
+      "assemblyOptions": Object {
+        "added": Array [],
+        "parentPrice": 450,
+        "removed": Array [],
+      },
+      "options": Array [
+        Object {
+          "assemblyId": "Customization",
+          "inputValues": Object {
+            "Back text": "Verso",
+            "Font": "Sans serif",
+            "Front text": "Frente",
+            "Glossy print": true,
+          },
+        },
+      ],
+    }
+  `)
+})
+
+test('recursive input values', () => {
+  const parentPrice = 450
+  const parentQuantity = 1
+
+  const resultBell = transformAssemblyOptions(
+    customBell.items,
+    customBell.inputValues,
+    parentPrice,
+    parentQuantity
+  )
+
+  expect(resultBell.options).toHaveLength(5)
+
+  const engraving = resultBell.options[4] as ItemOption
+  expect(engraving.options).toHaveLength(1)
+
+  const recursiveInputValue = engraving.options![0] as InputValuesOption
+  expect(recursiveInputValue.assemblyId).toBe('1-3-lines')
+  expect(recursiveInputValue.inputValues).toBe(
+    customBell.inputValues['1-3-lines']
+  )
+  expect(resultBell).toMatchInlineSnapshot(`
+    Object {
+      "assemblyOptions": Object {
+        "added": Array [
+          Object {
+            "choiceType": "TOGGLE",
+            "extraQuantity": 1,
+            "item": Object {
+              "id": "2000588",
+              "name": "Bells add-ons Logo small",
+              "quantity": 1,
+              "sellingPrice": 75,
+              "sellingPriceWithAssemblies": 75,
+            },
+            "normalizedQuantity": 1,
+          },
+          Object {
+            "choiceType": "TOGGLE",
+            "extraQuantity": 1,
+            "item": Object {
+              "id": "2000589",
+              "name": "Bells add-ons Logo big",
+              "quantity": 1,
+              "sellingPrice": 90,
+              "sellingPriceWithAssemblies": 90,
+            },
+            "normalizedQuantity": 1,
+          },
+          Object {
+            "choiceType": "SINGLE",
+            "extraQuantity": 1,
+            "item": Object {
+              "id": "2000592",
+              "name": "Bells add-ons Script",
+              "quantity": 1,
+              "sellingPrice": 15,
+              "sellingPriceWithAssemblies": 15,
+            },
+            "normalizedQuantity": 1,
+          },
+          Object {
+            "choiceType": "SINGLE",
+            "extraQuantity": 1,
+            "item": Object {
+              "assemblyOptions": Object {
+                "added": Array [],
+                "parentPrice": 26,
+                "removed": Array [],
+              },
+              "id": "2000586",
+              "name": "Bells add-ons 1-3 lines",
+              "quantity": 1,
+              "sellingPrice": 26,
+              "sellingPriceWithAssemblies": 26,
+            },
+            "normalizedQuantity": 1,
+          },
+        ],
+        "parentPrice": 450,
+        "removed": Array [],
+      },
+      "options": Array [
+        Object {
+          "assemblyId": "add-on_Add-on",
+          "id": "2000588",
+          "quantity": 1,
+          "seller": "1",
+        },
+        Object {
+          "assemblyId": "add-on_Add-on",
+          "id": "2000589",
+          "quantity": 1,
+          "seller": "1",
+        },
+        Object {
+          "assemblyId": "text_style_Text Style",
+          "id": "2000591",
+          "quantity": 0,
+          "seller": "1",
+        },
+        Object {
+          "assemblyId": "text_style_Text Style",
+          "id": "2000592",
+          "quantity": 1,
+          "seller": "1",
+        },
+        Object {
+          "assemblyId": "engraving_Engraving",
+          "id": "2000586",
+          "options": Array [
+            Object {
+              "assemblyId": "1-3-lines",
+              "inputValues": Object {
+                "Line 1": "First line",
+                "Line 2": "Second line",
+                "Line 3": "Third line",
+              },
+            },
+          ],
+          "quantity": 1,
+          "seller": "1",
+        },
+      ],
+    }
+  `)
 })
 
 test('empty input values should result in empty options', () => {

--- a/react/components/BuyButton/assemblyUtils.ts
+++ b/react/components/BuyButton/assemblyUtils.ts
@@ -117,7 +117,7 @@ export const transformAssemblyOptions = (
       let childrenAddedData = null
 
       if (item.children) {
-        let childInputValues: Record<GroupId, InputValue> = {}
+        const childInputValues: Record<GroupId, InputValue> = {}
 
         // Get every input value of the item and add it as a child
         for (const key in item.children) {
@@ -127,9 +127,11 @@ export const transformAssemblyOptions = (
         // Get all the input values this item is handling
         const handledInputValues = Object.keys(childInputValues)
         // and remove the handled input values from the list
-        assemblyInputValuesKeys = assemblyInputValuesKeys.filter(inputValueKey => {
-          return handledInputValues.includes(inputValueKey)
-        })
+        assemblyInputValuesKeys = assemblyInputValuesKeys.filter(
+          inputValueKey => {
+            return handledInputValues.includes(inputValueKey)
+          }
+        )
 
         childrenAddedData = transformAssemblyOptions(
           item.children,


### PR DESCRIPTION
#### What problem is this solving?

Fix input values when it's inside an assembly option.

#### How to test it?

1. Open https://breno--storecomponents.myvtex.com/custom-bell/p
2. Click Customize in "Bells add-ons 1-3 lines"
3. Click "Add 1-3-Lines"
4. Fill the inputs "Line 1", "Line 2", and "Line 3".
5. Click "Done"
6. Click "Add To Cart"
7. Go to cart page
8. Once in the Cart page open dev tools and type in the console:
`vtexjs.checkout.orderForm.items[2].assemblies`

It should return an object with the values input.

Compare it with master workspace which doesn't have this fix and the last step won't work.

#### Describe alternatives you've considered, if any.

We should refactor the Product Customizer solution. It does not provide enough info for this solution to be future proof. It will break if two products have the same input values for instance.

#### Related to / Depends on

n/a

#### How does this PR make you feel? [:link:](http://giphy.com/)

