### PR TITLE
Adding CSS Handle to active swiperBullet in Product Images Carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.119.8] - 2020-07-14
 ### Added
 - Inserted CSS Handle for active swiperBullet in Product Images Carousel.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 - Inserted CSS Handle for active swiperBullet in Product Images Carousel.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.119.7] - 2020-07-14
+## [3.119.8] - 2020-07-14
 ### Added
 - Inserted CSS Handle for active swiperBullet in Product Images Carousel.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.119.7] - 2020-07-14
+### Added
+- Inserted CSS Handle for active swiperBullet in Product Images Carousel.
+
 ## [3.119.6] - 2020-07-08
 ### Fixed
 - Animation component documentation by adding a deprecation badge and disclaimer.

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -135,7 +135,7 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `productImageTag`|
 | `productVideo` |
 | `swiperBullet` |
-| `swiperBullet--isActive` |
+| `swiperBullet--active` |
 | `swiperCaret` |
 | `thumbImg` |
 | `video` |

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -135,6 +135,7 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `productImageTag`|
 | `productVideo` |
 | `swiperBullet` |
+| `swiperBullet--isActive` |
 | `swiperCaret` |
 | `thumbImg` |
 | `video` |

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 import { path, equals } from 'ramda'
 import ReactResizeDetector from 'react-resize-detector'
 import { IconCaret } from 'vtex.store-icons'
-import { withCssHandles } from 'vtex.css-handles'
+import { withCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import Video, { getThumbUrl } from '../Video'
 import ProductImage from '../ProductImage'
@@ -259,7 +259,7 @@ class Carousel extends Component {
             bulletSelector: `.swiper-pagination-bullet`,
             bulletClass: `swiper-pagination-bullet ${cssHandles.swiperBullet}`,
             bulletActiveClass:
-              `c-action-primary swiper-pagination-bullet-active ${cssHandles.swiperBullet}--isActive`,
+              `c-action-primary swiper-pagination-bullet-active ${applyModifiers(cssHandles.swiperBullet), 'isActive'}`,
           },
         }),
       ...(slides.length > 1 && {

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -259,7 +259,7 @@ class Carousel extends Component {
             bulletSelector: `.swiper-pagination-bullet`,
             bulletClass: `swiper-pagination-bullet ${cssHandles.swiperBullet}`,
             bulletActiveClass:
-              'c-action-primary swiper-pagination-bullet-active',
+              `c-action-primary swiper-pagination-bullet-active ${cssHandles.swiperBullet}--isActive`,
           },
         }),
       ...(slides.length > 1 && {

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -258,8 +258,10 @@ class Carousel extends Component {
             // custom props from vtex/swiper
             bulletSelector: `.swiper-pagination-bullet`,
             bulletClass: `swiper-pagination-bullet ${cssHandles.swiperBullet}`,
-            bulletActiveClass:
-              `c-action-primary swiper-pagination-bullet-active ${applyModifiers(cssHandles.swiperBullet, 'active')}`,
+            bulletActiveClass: `c-action-primary swiper-pagination-bullet-active ${applyModifiers(
+              cssHandles.swiperBullet,
+              'active'
+            )}`,
           },
         }),
       ...(slides.length > 1 && {

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -259,7 +259,7 @@ class Carousel extends Component {
             bulletSelector: `.swiper-pagination-bullet`,
             bulletClass: `swiper-pagination-bullet ${cssHandles.swiperBullet}`,
             bulletActiveClass:
-              `c-action-primary swiper-pagination-bullet-active ${applyModifiers(cssHandles.swiperBullet), 'isActive'}`,
+              `c-action-primary swiper-pagination-bullet-active ${applyModifiers(cssHandles.swiperBullet, 'isActive')}`,
           },
         }),
       ...(slides.length > 1 && {

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -259,7 +259,7 @@ class Carousel extends Component {
             bulletSelector: `.swiper-pagination-bullet`,
             bulletClass: `swiper-pagination-bullet ${cssHandles.swiperBullet}`,
             bulletActiveClass:
-              `c-action-primary swiper-pagination-bullet-active ${applyModifiers(cssHandles.swiperBullet, 'isActive')}`,
+              `c-action-primary swiper-pagination-bullet-active ${applyModifiers(cssHandles.swiperBullet, 'active')}`,
           },
         }),
       ...(slides.length > 1 && {


### PR DESCRIPTION
#### What problem is this solving?

I previous not have access to active swiperBullet to style the component. To be able to style them I needed to add a CSS handle swiperBullet--isActive.

#### How to test it?

You can see and use the new CSS Handle swiperBullet--isActive to style the swiper bullet of the product image

[Workspace](https://hugodev--corebiz.myvtex.com/pouch-pro-plan-perro-adulto-chicken/p)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/20212776/87473409-c3c0ae00-c5f7-11ea-9dc7-a5daf063bd06.png)
