### PR TITLE
Create its own schema to the image interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Create a schema to the interface `image` without the description to remove it from the new CMS.
 
 ## [3.119.10] - 2020-07-15
 ### Fixed

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,5 +1,11 @@
 {
   "definitions": {
+    "Image": {
+      "title": "admin/editor.store-image.title",
+      "properties": {
+        "$ref": "app:vtex.store-image#/definitions/Image/properties"
+      }
+    },
     "InfoCard": {
       "properties": {
         "headline": {

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -95,7 +95,7 @@
   "image": {
     "component": "Image",
     "content": {
-      "$ref": "app:vtex.store-image#/definitions/Image"
+      "$ref": "app:vtex.store-components#/definitions/Image"
     }
   },
   "back-to-top-button": {


### PR DESCRIPTION
#### What problem is this solving?

This needed to be done because we have a new image interface that is `vtex.store-image@0.x:new-image`

#### How to test it?

[new cms with the changes](https://cmscomponents2--storecomponents.myvtex.com/admin/app/new-cms/edit/new)

[site-editor with the changes](https://cmscomponents2--storecomponents.myvtex.com/admin/cms/site-editor/about-us)
[site-editor without the changes](https://storecomponents.myvtex.com/admin/cms/site-editor/about-us)

##### CMS

1. Open the link
2. Click on the Plus button
3. It should list only one image block

##### Site editor

1. Open the workspace
2. Open the Image schema
3. It should be the same with or without the changes


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
