### PR TITLE
Remove unused icons from react-share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Unused icons and buttons from `react-share`.
 
 ## [3.120.1] - 2020-07-16
 ### Changed

--- a/react/__tests__/components/Share.test.js
+++ b/react/__tests__/components/Share.test.js
@@ -10,6 +10,7 @@ describe('<Share />', () => {
 
   it('should be mounted', () => {
     const { asFragment } = renderComponent()
+
     expect(asFragment()).toBeDefined()
   })
 
@@ -19,6 +20,7 @@ describe('<Share />', () => {
         Facebook: true,
       },
     })
+
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -28,6 +30,7 @@ describe('<Share />', () => {
         Twitter: true,
       },
     })
+
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -37,6 +40,7 @@ describe('<Share />', () => {
         WhatsApp: true,
       },
     })
+
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -46,15 +50,7 @@ describe('<Share />', () => {
         Telegram: true,
       },
     })
-    expect(asFragment()).toMatchSnapshot()
-  })
 
-  it('should match the snapshot with Google+', () => {
-    const { asFragment } = renderComponent({
-      social: {
-        'Google+': true,
-      },
-    })
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -64,6 +60,7 @@ describe('<Share />', () => {
         'E-mail': true,
       },
     })
+
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -75,11 +72,13 @@ describe('<Share />', () => {
         Telegram: true,
       },
     })
+
     expect(asFragment()).toMatchSnapshot()
   })
 
   it('should match snapshot Loader', () => {
     const { asFragment } = renderComponent({ loading: true })
+
     expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/react/__tests__/components/__snapshots__/Share.test.js.snap
+++ b/react/__tests__/components/__snapshots__/Share.test.js.snap
@@ -93,37 +93,6 @@ exports[`<Share /> should match the snapshot with Facebook 1`] = `
 </DocumentFragment>
 `;
 
-exports[`<Share /> should match the snapshot with Google+ 1`] = `
-<DocumentFragment>
-  <div
-    class="shareContainer shareLoader"
-  >
-    <svg
-      class="content-loader-mock"
-    >
-      <circle
-        cx="1em"
-        cy="1em"
-        height="2em"
-        r="1em"
-      />
-      <circle
-        cx="3.5em"
-        cy="1em"
-        height="2em"
-        r="1em"
-      />
-      <circle
-        cx="6em"
-        cy="1em"
-        height="2em"
-        r="1em"
-      />
-    </svg>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`<Share /> should match the snapshot with Telegram 1`] = `
 <DocumentFragment>
   <div

--- a/react/components/Share/components/SocialButton.js
+++ b/react/components/Share/components/SocialButton.js
@@ -1,24 +1,29 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import * as ReactShare from 'react-share'
 
-import { SOCIAL_TO_ENUM, SOCIAL_ENUM_TO_COMPONENT } from '../constants/social'
+import { SOCIAL_NAME_MAP, SOCIAL_COMPONENT_MAP } from '../constants/social'
 import styles from '../styles.css'
 
-function resolveMessageProp(message, socialEnum) {
-  const titlePropMessage = [
-    SOCIAL_TO_ENUM.whatsapp,
-    SOCIAL_TO_ENUM.twitter,
-    SOCIAL_TO_ENUM.telegram,
-    SOCIAL_TO_ENUM.pinterest,
-  ]
+const SOCIAL_WITH_TITLE = new Set([
+  SOCIAL_NAME_MAP.whatsapp,
+  SOCIAL_NAME_MAP.twitter,
+  SOCIAL_NAME_MAP.telegram,
+  SOCIAL_NAME_MAP.pinterest,
+])
 
-  return titlePropMessage.includes(socialEnum)
-    ? { title: message }
-    : socialEnum === SOCIAL_TO_ENUM.facebook
-    ? { quote: message }
-    : { body: message }
+function getExtraSocialProps({ message, socialEnum }) {
+  if (!message) return {}
+
+  if (SOCIAL_WITH_TITLE.has(socialEnum)) {
+    return { title: message }
+  }
+
+  if (socialEnum === SOCIAL_NAME_MAP.facebook) {
+    return { quote: message }
+  }
+
+  return { body: message }
 }
 
 export default class SocialButton extends Component {
@@ -54,10 +59,14 @@ export default class SocialButton extends Component {
       iconClass,
       imageUrl,
     } = this.props
-    const socialComponentName = SOCIAL_ENUM_TO_COMPONENT[socialEnum]
-    const SocialComponent = ReactShare[`${socialComponentName}ShareButton`]
-    const SocialIcon = ReactShare[`${socialComponentName}Icon`]
-    const additionalProps = message && resolveMessageProp(message, socialEnum)
+
+    const {
+      SocialNetworkName,
+      SocialComponent,
+      SocialIcon,
+    } = SOCIAL_COMPONENT_MAP[socialEnum]
+
+    const additionalProps = getExtraSocialProps({ message, socialEnum })
 
     const icon = (
       <SocialIcon
@@ -69,7 +78,7 @@ export default class SocialButton extends Component {
 
     /* Pinterest requires imageUrl for the "media" prop, but
      * it might not be loaded yet */
-    if (socialComponentName === SOCIAL_TO_ENUM.pinterest && !imageUrl) {
+    if (SocialNetworkName === SOCIAL_NAME_MAP.pinterest && !imageUrl) {
       return icon
     }
 

--- a/react/components/Share/constants/social.js
+++ b/react/components/Share/constants/social.js
@@ -1,21 +1,45 @@
-export const SOCIAL_TO_ENUM = {
+import * as Social from 'react-share'
+
+export const SOCIAL_NAME_MAP = {
   facebook: 'Facebook',
   whatsapp: 'WhatsApp',
   twitter: 'Twitter',
   telegram: 'Telegram',
-  googleplus: 'Google+',
   email: 'E-mail',
   pinterest: 'Pinterest',
 }
 
-export const SOCIAL_ENUM = Object.values(SOCIAL_TO_ENUM)
+export const SOCIAL_LIST = Object.values(SOCIAL_NAME_MAP)
 
-export const SOCIAL_ENUM_TO_COMPONENT = {
-  [SOCIAL_TO_ENUM.facebook]: 'Facebook',
-  [SOCIAL_TO_ENUM.twitter]: 'Twitter',
-  [SOCIAL_TO_ENUM.telegram]: 'Telegram',
-  [SOCIAL_TO_ENUM.googleplus]: 'GooglePlus',
-  [SOCIAL_TO_ENUM.whatsapp]: 'Whatsapp',
-  [SOCIAL_TO_ENUM.email]: 'Email',
-  [SOCIAL_TO_ENUM.pinterest]: 'Pinterest',
+export const SOCIAL_COMPONENT_MAP = {
+  [SOCIAL_NAME_MAP.facebook]: {
+    SocialNetworkName: SOCIAL_NAME_MAP.facebook,
+    SocialComponent: Social.FacebookShareButton,
+    SocialIcon: Social.FacebookIcon,
+  },
+  [SOCIAL_NAME_MAP.whatsapp]: {
+    SocialNetworkName: SOCIAL_NAME_MAP.whatsapp,
+    SocialComponent: Social.WhatsappShareButton,
+    SocialIcon: Social.WhatsappIcon,
+  },
+  [SOCIAL_NAME_MAP.twitter]: {
+    SocialNetworkName: SOCIAL_NAME_MAP.twitter,
+    SocialComponent: Social.TwitterShareButton,
+    SocialIcon: Social.TwitterIcon,
+  },
+  [SOCIAL_NAME_MAP.telegram]: {
+    SocialNetworkName: SOCIAL_NAME_MAP.telegram,
+    SocialComponent: Social.TelegramShareButton,
+    SocialIcon: Social.TelegramIcon,
+  },
+  [SOCIAL_NAME_MAP.email]: {
+    SocialNetworkName: SOCIAL_NAME_MAP.email,
+    SocialComponent: Social.EmailShareButton,
+    SocialIcon: Social.EmailIcon,
+  },
+  [SOCIAL_NAME_MAP.pinterest]: {
+    SocialNetworkName: SOCIAL_NAME_MAP.pinterest,
+    SocialComponent: Social.PinterestShareButton,
+    SocialIcon: Social.PinterestIcon,
+  },
 }

--- a/react/components/Share/index.js
+++ b/react/components/Share/index.js
@@ -6,7 +6,7 @@ import ContentLoader from 'react-content-loader'
 import { FormattedMessage } from 'react-intl'
 
 import SocialButton from './components/SocialButton'
-import { SOCIAL_ENUM } from './constants/social'
+import { SOCIAL_LIST } from './constants/social'
 import styles from './styles.css'
 
 class Share extends Component {
@@ -52,6 +52,7 @@ class Share extends Component {
       contentLoaderClass,
       ...rest
     } = loaderProps
+
     const loaderStyles = {
       r: '1em',
       height: '2em',
@@ -109,7 +110,7 @@ class Share extends Component {
         properties: {
           ...indexBy(
             prop('title'),
-            SOCIAL_ENUM.map(socialNetwork => ({
+            SOCIAL_LIST.map(socialNetwork => ({
               type: 'boolean',
               title: socialNetwork,
               default: Share.defaultProps.social[socialNetwork],


### PR DESCRIPTION
#### What problem is this solving?

Removes unused components from the final production bundle. Also removed `google+` support since it doesn't exist anymore.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

https://kiwi--storecomponents.myvtex.com/vintage-phone/p

#### Screenshots or example usage:

**Before**
![image](https://user-images.githubusercontent.com/12702016/87791148-31e3bb80-c818-11ea-9783-60790a0aa558.png)

**After**
![image](https://user-images.githubusercontent.com/12702016/87791462-a9194f80-c818-11ea-9231-a21349c5a8f0.png)


9.75kb lighter


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/RNDdIRbOM7hKH9ezKz/giphy.gif)
