### PR TITLE
Fix overriding insane options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent `insane` defaults from being overriden if no extra config was passed.
 
 ## [3.120.2] - 2020-07-17
 ### Removed

--- a/react/modules/sanitizedHTML.tsx
+++ b/react/modules/sanitizedHTML.tsx
@@ -14,7 +14,9 @@ function filter(token: {
   tag: string
   attrs: Record<string, number | undefined | string>
 }) {
-  if (token.tag === 'script') return false
+  if (token.tag === 'script') {
+    return false
+  }
 
   return true
 }
@@ -23,12 +25,13 @@ function sanitizeHTML(
   html: string,
   { allowedAttributes, allowedClasses, allowedTags }: SanitizeOpts = {}
 ) {
-  return insane(html, {
-    filter,
-    allowedTags,
-    allowedClasses,
-    allowedAttributes,
-  })
+  const opts: Record<string, unknown> = { filter }
+
+  if (allowedTags) opts.allowedTags = allowedTags
+  if (allowedClasses) opts.allowedClasses = allowedClasses
+  if (allowedAttributes) opts.allowedAttributes = allowedAttributes
+
+  return insane(html, opts)
 }
 
 function getDangerousSanitizedHTML(html: string, opts: SanitizeOpts = {}) {


### PR DESCRIPTION
#### What problem is this solving?

We're accidentally overriding the default options of `insane`, making it filter EVERY tag.

![image](https://user-images.githubusercontent.com/12702016/87807089-36b36a00-c82e-11ea-9677-615cca2de562.png)


#### How to test it?

Compare 
1) https://kiwi--redoxx.myvtex.com/red-oxx-railroad-patch-hat-92036/p
with 
2) https://redoxx.myvtex.com/red-oxx-railroad-patch-hat-92036/p

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/12702016/87807153-4e8aee00-c82e-11ea-90c0-0a94c435ba11.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/BsQAVgY6ksvIY/giphy.gif)
