### PR TITLE
Allow to render sanitized iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent `insane` from filtering out `iframe`s.
 
 ## [3.120.3] - 2020-07-17
 ### Fixed

--- a/react/__tests__/modules/sanitizedHTML.test.tsx
+++ b/react/__tests__/modules/sanitizedHTML.test.tsx
@@ -15,7 +15,7 @@ test('renders a simple string', () => {
   `)
 })
 
-test('filters out script tags by default', () => {
+test('filters out script tags', () => {
   const { container } = render(
     <SanitizedHTML content="<script>console.log('potato')</script><h1>Hey</h1>" />
   )
@@ -91,6 +91,29 @@ test('filters out tags', () => {
       <h3>
         Let's go
       </h3>
+    </div>
+  `)
+})
+
+test('renders iframes', () => {
+  const { container } = render(
+    <SanitizedHTML
+      content={`<iframe src="https://player.vimeo.com/video/402279141" frameborder="0" 
+      allow="autoplay; fullscreen" allowfullscreen="" style="position: relative; height: 200px; width: 100%;"></iframe>`}
+    />
+  )
+
+  expect(container.firstChild).toMatchInlineSnapshot(`
+    <div
+      style="display: contents;"
+    >
+      <iframe
+        allow="autoplay; fullscreen"
+        allowfullscreen=""
+        frameborder="0"
+        src="https://player.vimeo.com/video/402279141"
+        style="position: relative; height: 200px; width: 100%;"
+      />
     </div>
   `)
 })

--- a/react/modules/sanitizedHTML.tsx
+++ b/react/modules/sanitizedHTML.tsx
@@ -6,26 +6,74 @@ type SanitizeOpts = {
   allowedClasses?: Record<string, string[]>
   allowedTags?: string[]
 }
+
 type SanitizedHTMLProps = SanitizeOpts & {
   content: string
 }
 
-function filter(token: {
-  tag: string
-  attrs: Record<string, number | undefined | string>
-}) {
-  if (token.tag === 'script') {
-    return false
-  }
-
-  return true
+const DEFAULTS = {
+  allowedAttributes: {
+    '*': ['title', 'accesskey'],
+    a: ['href', 'name', 'target', 'aria-label'],
+    iframe: ['frameborder', 'src', 'allowfullscreen', 'allow', 'style'],
+    img: ['src', 'alt', 'title', 'aria-label'],
+  },
+  allowedClasses: {},
+  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedTags: [
+    'a',
+    'abbr',
+    'article',
+    'b',
+    'blockquote',
+    'br',
+    'caption',
+    'code',
+    'del',
+    'details',
+    'div',
+    'em',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'hr',
+    'i',
+    'img',
+    'ins',
+    'iframe',
+    'kbd',
+    'li',
+    'main',
+    'mark',
+    'ol',
+    'p',
+    'pre',
+    'section',
+    'span',
+    'strike',
+    'strong',
+    'sub',
+    'summary',
+    'sup',
+    'table',
+    'tbody',
+    'td',
+    'th',
+    'thead',
+    'tr',
+    'u',
+    'ul',
+  ],
 }
 
 function sanitizeHTML(
   html: string,
   { allowedAttributes, allowedClasses, allowedTags }: SanitizeOpts = {}
 ) {
-  const opts: Record<string, unknown> = { filter }
+  const opts: Record<string, unknown> = { ...DEFAULTS }
 
   if (allowedTags) opts.allowedTags = allowedTags
   if (allowedClasses) opts.allowedClasses = allowedClasses


### PR DESCRIPTION
#### What problem is this solving?

Continuation of #818. `insane` filters out `iframe`s  by default.

#### How to test it?

Compare

https://kiwi--redoxx.myvtex.com/mini-boss-91016/p?skuId=701531

with 

https://redoxx.myvtex.com/mini-boss-91016/p?skuId=701531&2

and see that the descriptions have iframes with videos in them.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![image](https://user-images.githubusercontent.com/12702016/87817979-420f9100-c840-11ea-92aa-d5f65bc0b5d8.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/5bHIZ3ok4UpJS/giphy.gif)
