### PR TITLE
Use originalName in SKU Selector to avoid CSS classes to change based on translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use `originalName` in SKU Selector to avoid CSS classes to vary based on translation.
 
 ## [3.120.5] - 2020-07-21
 ### Fixed

--- a/react/__tests__/components/SKUSelector.test.tsx
+++ b/react/__tests__/components/SKUSelector.test.tsx
@@ -1179,32 +1179,40 @@ describe('<SKUSelector />', () => {
               {
                 field: {
                   name: 'Color',
+                  originalName: 'Color',
                 },
                 values: [
                   {
                     name: 'Black',
+                    originalName: 'Black',
                   },
                   {
                     name: 'Gray',
+                    originalName: 'Gray',
                   },
                   {
                     name: 'Blue',
+                    originalName: 'Blue',
                   },
                 ],
               },
               {
                 field: {
                   name: 'Size',
+                  originalName: 'Size',
                 },
                 values: [
                   {
                     name: '43',
+                    originalName: '43',
                   },
                   {
                     name: '42',
+                    originalName: '42',
                   },
                   {
                     name: '41',
+                    originalName: '41',
                   },
                 ],
               },

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -37,7 +37,10 @@ const getVariationsFromItems = (
   // Transform set back to array
   for (const variationName of variationsNames) {
     const set = variationsSet[variationName]
-    variations[variationName] = Array.from(set)
+    variations[variationName] = {
+      originalName: variationName,
+      values: Array.from(set),
+    }
   }
   return variations
 }
@@ -52,9 +55,10 @@ const getVariationsFromSpecifications = (
       !visibleVariations ||
       visibleVariations.includes(specification.field.name.toLowerCase().trim())
     ) {
-      variations[specification.field.name] = specification.values.map(
-        value => value.name
-      )
+      variations[specification.field.name] = {
+        originalName: specification.field.originalName,
+        values: specification.values.map(value => value.name),
+      }
     }
   }
   return variations
@@ -72,6 +76,7 @@ const useVariations = (
   const variationsSource = isSkuSpecificationsEmpty
     ? skuItems
     : skuSpecifications
+
   const result = useMemo(() => {
     if (
       shouldNotShow ||
@@ -101,6 +106,7 @@ const useVariations = (
     visibleVariations,
     isSkuSpecificationsEmpty,
   ])
+
   return result
 }
 

--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -199,7 +199,7 @@ const variationNameToDisplayVariation = ({
   hideImpossibleCombinations: boolean
 }) => (variationName: string): DisplayVariation => {
   const name = variationName
-  const values = variations[variationName]
+  const { values, originalName } = variations[variationName]
   const options = values
     .map(
       parseOptionNameToDisplayOption({
@@ -213,7 +213,7 @@ const variationNameToDisplayVariation = ({
       })
     )
     .filter(Boolean) as DisplayOption[]
-  return { name, options }
+  return { name, originalName, options }
 }
 
 // Parameters are explained on PropTypes
@@ -303,6 +303,7 @@ const SKUSelector: FC<Props> = ({
       hideImpossibleCombinations,
     ]
   )
+
   const [displayVariations, setDisplayVariations] = useState<
     DisplayVariation[]
   >(() => getAvailableVariations(availableVariationsPayload))

--- a/react/components/SKUSelector/components/Variation.tsx
+++ b/react/components/SKUSelector/components/Variation.tsx
@@ -60,7 +60,7 @@ const Variation: FC<Props> = ({
   sliderDisplayThreshold,
   sliderItemsPerPage,
 }) => {
-  const { name, options } = variation
+  const { originalName, name, options } = variation
 
   const visibleItemsWhenCollapsed = maxItems - ITEMS_VISIBLE_THRESHOLD
 
@@ -75,7 +75,7 @@ const Variation: FC<Props> = ({
     },
   } = useProduct()
 
-  const displayImage = isColor(name)
+  const displayImage = isColor(originalName)
 
   const shouldCollapse = !showAll && options.length > maxItems
 
@@ -89,7 +89,7 @@ const Variation: FC<Props> = ({
     'flex flex-column',
     containerClassesProp,
     styles.skuSelectorSubcontainer,
-    `${styles.skuSelectorSubcontainer}--${slug(name)}`
+    `${styles.skuSelectorSubcontainer}--${slug(originalName)}`
   )
 
   const shouldUseSlider =

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -115,7 +115,7 @@ const useImagesMap = (
         continue
       }
       const imageMap = {} as Record<string, Image | undefined>
-      const variationValues = variations[variationName]
+      const variationValues = variations[variationName].values
       for (const variationValue of variationValues) {
         const item = filteredItems.find(
           sku => sku.variationValues[variationName] === variationValue

--- a/react/components/SKUSelector/types/index.ts
+++ b/react/components/SKUSelector/types/index.ts
@@ -45,7 +45,14 @@ export interface DisplayOption {
 
 export interface DisplayVariation {
   name: string
+  originalName: string
   options: DisplayOption[]
 }
 
-export type Variations = Record<string, string[]>
+export type Variations = Record<
+  string,
+  {
+    originalName: string
+    values: string[]
+  }
+>

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -35,10 +35,12 @@ interface SkuSpecification {
 
 interface SkuSpecificationField {
   name: string
+  originalName: string
 }
 
 interface SkuSpecificationValues {
   name: string
+  originalName: string
 }
 
 declare module 'vtex.product-context/useProduct' {


### PR DESCRIPTION
#### What problem is this solving?

Add fields necessary to fix issue regarding fields being translated and changing the CSS classes applied.

#### How to test it?

Fixed:
https://breno--miriadeit.myvtex.com/?__bindingAddress=www.miriade.com/en
Class with `nero` applied:
![image](https://user-images.githubusercontent.com/284515/88094977-c6c51c80-cb6a-11ea-86e1-234546b9e1c7.png)

Compare it with the current wrong behavior:
https://brenooff--miriadeit.myvtex.com/?__bindingAddress=www.miriade.com/en
Class with `black` was applied
![image](https://user-images.githubusercontent.com/284515/88095294-4226ce00-cb6b-11ea-9296-b94a52cba652.png)

#### Describe alternatives you've considered, if any.

none

#### Related to / Depends on

Depends on: https://github.com/vtex-apps/store-resources/pull/126

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
