### PR TITLE
Insert new CSS Handles to productImages component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Add new `productImageMain` and `productImageZoom` CSS Handles to Product Images component.
+- Add new `productImageTag--zoom` and `productImageTag--main` CSS Handles to Product Images component.
 
 ## [3.121.0] - 2020-07-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add new `productImageMain` and `productImageZoom` CSS Handles to Product Images component.
+
 ## [3.121.0] - 2020-07-27
 ### Added
 - Expose `SanitizedHTML` component.

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -133,8 +133,8 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `productImagesThumbCaret` |
 | `productImagesThumbsSwiperContainer` |
 | `productImageTag`|
-| `productImageMain`|
-| `productImageZoom`|
+| `productImageTag--main`|
+| `productImageTag--zoon`|
 | `productVideo` |
 | `swiperBullet` |
 | `swiperBullet--active` |

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -133,6 +133,8 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `productImagesThumbCaret` |
 | `productImagesThumbsSwiperContainer` |
 | `productImageTag`|
+| `productImageMain`|
+| `productImageZoom`|
 | `productVideo` |
 | `swiperBullet` |
 | `swiperBullet--active` |

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -24,7 +24,7 @@ interface Props {
 
 type AspectRatio = string | number
 
-const CSS_HANDLES = ['productImage', 'productImageTag']
+const CSS_HANDLES = ['productImage', 'productImageTag', 'productImageMain', 'productImageZoom']
 
 const ProductImage: FC<Props> = ({
   src,
@@ -71,7 +71,7 @@ const ProductImage: FC<Props> = ({
                 MAX_SIZE,
                 aspectRatio
               )}
-              className={handles.productImageTag}
+              className={`${handles.productImageTag} ${handles.productImageZoom}`}
               style={{
                 // Resets possible resizing done via CSS
                 maxWidth: 'unset',
@@ -86,7 +86,7 @@ const ProductImage: FC<Props> = ({
         >
           <img
             ref={imageRef}
-            className={handles.productImageTag}
+            className={`${handles.productImageTag} ${handles.productImageMain}`}
             style={{
               width: '100%',
               height: '100%',

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo, useRef } from 'react'
 import { Modal } from 'vtex.modal-layout'
 import { useCssHandles } from 'vtex.css-handles'
 
+import { applyModifiers } from 'vtex.css-handles'
 import Zoomable, { ZoomMode } from './Zoomable'
 import { imageUrl } from '../utils/aspectRatioUtil'
 import ProductImageContext, {
@@ -24,7 +25,7 @@ interface Props {
 
 type AspectRatio = string | number
 
-const CSS_HANDLES = ['productImage', 'productImageTag', 'productImageMain', 'productImageZoom']
+const CSS_HANDLES = ['productImage', 'productImageTag']
 
 const ProductImage: FC<Props> = ({
   src,
@@ -71,7 +72,7 @@ const ProductImage: FC<Props> = ({
                 MAX_SIZE,
                 aspectRatio
               )}
-              className={`${handles.productImageTag} ${handles.productImageZoom}`}
+              className={`${applyModifiers(handles.productImageTag, 'zoom')}`}
               style={{
                 // Resets possible resizing done via CSS
                 maxWidth: 'unset',
@@ -86,7 +87,7 @@ const ProductImage: FC<Props> = ({
         >
           <img
             ref={imageRef}
-            className={`${handles.productImageTag} ${handles.productImageMain}`}
+            className={`${applyModifiers(handles.productImageTag, 'main')}`}
             style={{
               width: '100%',
               height: '100%',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds different classes to the main product image and when the product image receives a zoom effect.

#### What problem is this solving?

Adds different classes to the main product image and when the product image receives a zoom effect. Thus, if the developer wants to apply independent styles to these two sections, it will be possible.

### How should this be manually tested?
- Enter this link: https://task134--unileverb2b.myvtex.com/ligeresa--salsa--tarro-450ml-139/p?skuId=141
- Inspect the main product image. See the `productImagesMain` class has been applied;
- Click on the main product image and Zoom will be applied;
- Inspect the main image again and see that a div will be created below. The image div with Zoom received a `productImagesZoom`.

### Screenshots or example usage
https://cl.ly/b34acdda2137

Types of changes
- [ ] - Bug fix (a non-breaking change which fixes an issue)
- [X] - New feature (a non-breaking change which adds functionality)
- [ ] - Breaking change (fix or feature that would cause existing functionality to change)
- [ ] - Requires change to documentation, which has been updated accordingly.