### PR TITLE
Fix hideImpossibleCombinations rendering a variation with no items attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- SKUSelector `hideImpossibleCombinations` rendering a variation with no items attached.
 
 ## [3.122.2] - 2020-08-04
 ### Changed

--- a/react/__tests__/components/SKUSelector.test.tsx
+++ b/react/__tests__/components/SKUSelector.test.tsx
@@ -1279,4 +1279,133 @@ describe('<SKUSelector />', () => {
     // check comment above the 'it' description
     expect(asFragment()).toMatchSnapshot()
   })
+
+  it('should not show the Yellow variation since there is no items with the Yellow variation', async () => {
+    const defaultSeller = {
+      commertialOffer: { Price: 15, ListPrice: 20, AvailableQuantity: 10 },
+    }
+
+    const firstSku = {
+      itemId: '1',
+      name: 'Gray Shoe',
+      variations: [
+        { name: 'Size', values: ['41'] },
+        { name: 'Color', values: ['Gray'] },
+      ],
+      sellers: [defaultSeller],
+      images: [],
+    }
+
+    mockedUseProduct.mockImplementation(
+      function getProductContext(): ProductContext {
+        return {
+          product: {
+            buyButton: {
+              clicked: false,
+            },
+            skuSelector: {
+              isVisible: true,
+              areAllVariationsSelected: true,
+            },
+            selectedItem: firstSku,
+            selectedQuantity: 1,
+            assemblyOptions: {
+              items: {},
+              areGroupsValid: {},
+              inputValues: {},
+            },
+            skuSpecifications: [
+              {
+                field: {
+                  name: 'Color',
+                  originalName: 'Color',
+                },
+                values: [
+                  {
+                    name: 'Yellow',
+                    originalName: 'Yellow',
+                  },
+                  {
+                    name: 'Black',
+                    originalName: 'Black',
+                  },
+                  {
+                    name: 'Gray',
+                    originalName: 'Gray',
+                  },
+                  {
+                    name: 'Blue',
+                    originalName: 'Blue',
+                  },
+                ],
+              },
+              {
+                field: {
+                  name: 'Size',
+                  originalName: 'Size',
+                },
+                values: [
+                  {
+                    name: '43',
+                    originalName: '43',
+                  },
+                  {
+                    name: '42',
+                    originalName: '42',
+                  },
+                  {
+                    name: '41',
+                    originalName: '41',
+                  },
+                ],
+              },
+            ],
+          },
+        }
+      }
+    )
+
+    const skuItems = [
+      firstSku,
+      {
+        itemId: '2',
+        name: 'Black Shoe',
+        variations: [
+          { name: 'Size', values: ['41', '42', '43'] },
+          { name: 'Color', values: ['Black'] },
+        ],
+        sellers: [defaultSeller],
+        images: [],
+      },
+      {
+        itemId: '3',
+        name: 'Blue Shoe',
+        variations: [
+          { name: 'Size', values: ['41', '42', '43'] },
+          { name: 'Color', values: ['Blue', 'Black'] },
+        ],
+        sellers: [defaultSeller],
+        images: [],
+      },
+      {
+        itemId: '4',
+        name: 'Gray Shoe',
+        variations: [
+          {
+            name: 'Size',
+            values: ['42'],
+          },
+          { name: 'Color', values: ['Gray'] },
+        ],
+        sellers: [defaultSeller],
+        images: [],
+      },
+    ]
+
+    const { queryByText } = render(
+      <SKUSelector skuSelected={skuItems[0]} skuItems={skuItems} maxItems={6} />
+    )
+
+    expect(queryByText('Yellow')).toBeFalsy()
+  })
 })

--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -166,27 +166,6 @@ const parseOptionNameToDisplayOption = ({
     }
   }
 
-  if (hideImpossibleCombinations && isColor(variationName)) {
-    // This is a visual (with picture) variation and should not be hidden.
-    // If the hideImpossibleCombinations is true, we should display it as normal but when pressed it will reset the selected variations.
-    const callbackFn = onSelectItemMemo({
-      name: variationName,
-      value: variationValue.name,
-      skuId: null,
-      isMainAndImpossible: true,
-      possibleItems: skuItems,
-    })
-
-    return {
-      label: variationValue.name,
-      originalName: variationValue.originalName,
-      onSelectItem: callbackFn,
-      image,
-      available: true,
-      impossible: false,
-    }
-  }
-
   if (!hideImpossibleCombinations) {
     // This is a impossible combination and will only appear if the prop allows.
     return {

--- a/react/components/SKUSelector/utils/index.ts
+++ b/react/components/SKUSelector/utils/index.ts
@@ -93,7 +93,6 @@ export const getMainVariationName = (variations: string[]) => {
  * items: skuItems parsed with variations fields
  * Output: item or null, if not present
  */
-
 export const findItemWithSelectedVariations = (
   items: SelectorProductItem[],
   selectedVariations: SelectedVariations
@@ -120,7 +119,6 @@ export const findItemWithSelectedVariations = (
  * items: skuItems parsed with variations fields
  * Output: list of items with those variations
  */
-
 export const findListItemsWithSelectedVariations = (
   items: SelectorProductItem[],
   selectedVariations: SelectedVariations


### PR DESCRIPTION
#### What problem is this solving?

Remove impossible variation from the search page.

#### How to test it?

Showing the scenario with this loom:
https://www.loom.com/share/2f11b9f6ae6c4bcf9f23380d3f8bf9eb


This two workspaces are linked but it needs to change the prop using React Dev Tools as shown in the video:
https://phdro--niazi.myvtex.com/TECIDOS/Artesanato/TNT
https://phdro--babycottonsar.myvtex.com/body%20polo%20pima%20colors?_q=Body%20polo%20Pima%20Colors&map=ft&vt=hjfnd

Also added a unit test to it.

#### Describe alternatives you've considered, if any.

n/a

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/BDMyENtT7C37y/giphy.gif)
