### PR TITLE
sku selector - use originalName to match with visibleVariations props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- SKUSelector: Use `originalName` to match with `visibleVariations` prop.
 
 ## [3.122.0] - 2020-07-29
 

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -1,8 +1,7 @@
 import React, { FC, useMemo, useRef } from 'react'
 import { Modal } from 'vtex.modal-layout'
-import { useCssHandles } from 'vtex.css-handles'
+import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
-import { applyModifiers } from 'vtex.css-handles'
 import Zoomable, { ZoomMode } from './Zoomable'
 import { imageUrl } from '../utils/aspectRatioUtil'
 import ProductImageContext, {

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -176,8 +176,6 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
     props.visibleVariations
   )
 
-  console.log( 'teste VARIATIONS: ', {variations, skuSpecifications, visibleVariations: props.visibleVariations})
-
   useEffect(() => {
     if (dispatch) {
       dispatch({

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -56,7 +56,9 @@ const getVariationsFromSpecifications = (
   for (const specification of skuSpecifications) {
     if (
       !visibleVariations ||
-      visibleVariations.includes(specification.field.originalName.toLowerCase().trim())
+      visibleVariations.includes(
+        specification.field.originalName.toLowerCase().trim()
+      )
     ) {
       variations[specification.field.name] = {
         originalName: specification.field.originalName,

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -56,7 +56,7 @@ const getVariationsFromSpecifications = (
   for (const specification of skuSpecifications) {
     if (
       !visibleVariations ||
-      visibleVariations.includes(specification.field.name.toLowerCase().trim())
+      visibleVariations.includes(specification.field.originalName.toLowerCase().trim())
     ) {
       variations[specification.field.name] = {
         originalName: specification.field.originalName,
@@ -175,6 +175,8 @@ const SKUSelectorWrapper: StorefrontFC<Props> = props => {
     shouldNotShow,
     props.visibleVariations
   )
+
+  console.log( 'teste VARIATIONS: ', {variations, skuSpecifications, visibleVariations: props.visibleVariations})
 
   useEffect(() => {
     if (dispatch) {


### PR DESCRIPTION
#### What problem is this solving?

After we translated the names, I think people using the `visibleVariations` prop started to have problems.

https://fidelis--miriadeit.myvtex.com/sneakers-vally-new-mir/p?__bindingAddress=www.miriade.com/es

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
