### PR TITLE
Allow link, body, html and style tags in product-description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allow `link`, `body`, `html`, and `style` tags in `product-description`.
+- Allow `figure` tag in `SanitizeHtml`.
 
 ## [3.122.3] - 2020-08-04
 ### Fixed

--- a/react/components/ProductDescription/index.js
+++ b/react/components/ProductDescription/index.js
@@ -4,7 +4,7 @@ import { FormattedMessage, injectIntl } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 import { formatIOMessage } from 'vtex.native-types'
 
-import { SanitizedHTML } from '../SanitizedHTML'
+import { SanitizedHTML, DEFAULTS } from '../SanitizedHTML'
 import GradientCollapse from '../GradientCollapse/index'
 
 const CSS_HANDLES = [
@@ -12,6 +12,8 @@ const CSS_HANDLES = [
   'productDescriptionTitle',
   'productDescriptionText',
 ]
+
+const allowedTags = [...DEFAULTS.allowedTags, 'link', 'body', 'html', 'style']
 
 /**
  * Product Description Component.
@@ -39,10 +41,10 @@ const ProductDescription = ({ description, collapseContent, title, intl }) => {
       <div className={`${handles.productDescriptionText} c-muted-1`}>
         {collapseContent ? (
           <GradientCollapse collapseHeight={220}>
-            <SanitizedHTML content={description} />
+            <SanitizedHTML content={description} allowedTags={allowedTags} />
           </GradientCollapse>
         ) : (
-          <SanitizedHTML content={description} />
+          <SanitizedHTML content={description} allowedTags={allowedTags} />
         )}
       </div>
     </div>

--- a/react/components/SanitizedHTML.tsx
+++ b/react/components/SanitizedHTML.tsx
@@ -11,7 +11,7 @@ type SanitizedHTMLProps = SanitizeOpts & {
   content: string
 }
 
-const DEFAULTS = {
+export const DEFAULTS = {
   allowedAttributes: {
     '*': ['id', 'title', 'accesskey', 'class', 'style', 'aria-label'],
     a: ['href', 'name', 'target'],
@@ -33,6 +33,7 @@ const DEFAULTS = {
     'details',
     'div',
     'em',
+    'figure',
     'h1',
     'h2',
     'h3',


### PR DESCRIPTION
#### What problem is this solving?

Fix regression after change to insane when rendering a product description.

#### How to test it?

Fixed workspace | Bug workspace
---|----
![image](https://user-images.githubusercontent.com/284515/89446982-a7fa8480-d72b-11ea-9ee3-6f4fcfd16f51.png) | ![image](https://user-images.githubusercontent.com/284515/89446956-9c0ec280-d72b-11ea-8ee0-22deb5ee88db.png)
https://brenovtex--exitocol.myvtex.com/blue-lexus-120x190-572468/p | https://phdro--exitocol.myvtex.com/blue-lexus-120x190-572468/p

#### Describe alternatives you've considered, if any.

none

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/KbvZsN07K9Hy9ZoyR7/giphy.gif)
