### PR TITLE
Turn off image size reduction of HighQualityProductImageby by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `imageSizes`, `defaultSize`, `maxSize` props to `HighQualityProductImage`.
+
+### Fixed
+- `HighQualityProductImage` reducing image size.
 
 ## [3.122.7] - 2020-08-10
 ### Added

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -105,7 +105,9 @@ The following table shows the props allowed by `product-images.high-quality-imag
 | `zoomMode` | `enum` | Defines the zoom behavior for the `product-images.high-quality-image` block. Possible values are: `disabled` (zoom is disabled), `in-place-click`(zoom will be triggered when the image is clicked on), or `in-place-hover`(zoom will be triggered when the image is hovered on). Different from the `store-images` prop, this one doesn't accept `open-modal` value. | `disabled` |
 | `zoomFactor` | `number` | Sets how much the zoom increases the image size (e.g. `2` will make the zoomed-in image twice as large). | `2` |
 | `aspectRatio` | `string` | Sets the aspect ratio of the image, that is, whether the image should be square, portrait, landscape, etc. The value should follow the [common aspect ratio notation](https://en.wikipedia.org/wiki/Aspect_ratio_(image) i.e. two numbers separated by a colon such as `1:1` for square, `3:4` for upright portrait, or `1920:1080` for even large values).| `auto` |
-
+| `defaultSize` | `number` |  Image default size (in `px`). | `1200` | 
+| `imageSizes` | `[number]` | Image size(s) (in `px`) to be used in the image's [`srcset` HTML attribute](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). If no value is passed to this prop, the `srcset` will use the image original size.  | `undefined` |
+| `maxSize` | `number` | Image maximum size (in `px`) for rendering regardless of the screen size. Notice that this prop only works if you also declare the `imageSizes` prop. | `4096` |
 
 #### Customization
 

--- a/react/components/ProductImages/components/HighQualityProductImage.tsx
+++ b/react/components/ProductImages/components/HighQualityProductImage.tsx
@@ -7,11 +7,6 @@ import { imageUrl } from '../utils/aspectRatioUtil'
 import ProductImageContext from './ProductImageContext'
 import Zoomable, { ZoomMode as ZoomModeComplete } from './Zoomable'
 
-// Same logic of the fixed values of ProductImages, but bigger values
-const IMAGE_SIZES = [800, 1200, 1400]
-const DEFAULT_SIZE = 1200
-const MAX_SIZE = 4096
-
 type AspectRatio = string | number
 type ZoomMode = Exclude<ZoomModeComplete, 'open-modal'>
 
@@ -19,6 +14,9 @@ interface Props {
   zoomMode?: ZoomMode
   zoomFactor?: number
   aspectRatio?: AspectRatio
+  imageSizes?: number[]
+  defaultSize?: number
+  maxSize?: number
 }
 
 function validateZoomMode(zoomMode: ZoomModeComplete): ZoomMode {
@@ -44,7 +42,14 @@ const CSS_HANDLES = [
 ] as const
 
 function HighQualityProductImage(props: Props) {
-  const { zoomFactor = 2, aspectRatio = 'auto', zoomMode = 'disabled' } = props
+  const {
+    imageSizes,
+    maxSize = 4096,
+    zoomFactor = 2,
+    defaultSize = 1200,
+    aspectRatio = 'auto',
+    zoomMode = 'disabled',
+  } = props
   const handles = useCssHandles(CSS_HANDLES)
   const context = useContext(ProductImageContext)
 
@@ -61,9 +66,9 @@ function HighQualityProductImage(props: Props) {
   }
 
   const { alt, src } = context
-  const srcSet = IMAGE_SIZES.map(
-    size => `${imageUrl(src, size, MAX_SIZE, aspectRatio)} ${size}w`
-  ).join(',')
+  const srcSet = imageSizes
+    ?.map(size => `${imageUrl(src, size, maxSize, aspectRatio)} ${size}w`)
+    .join(',')
 
   const containerClasses = classnames(
     handles.highQualityContainer,
@@ -96,12 +101,11 @@ function HighQualityProductImage(props: Props) {
             }}
             // See comment regarding sizes below
             sizes="(max-width: 64.1rem) 100vw, 50vw"
-            src={imageUrl(
-              src,
-              DEFAULT_SIZE * zoomFactor,
-              MAX_SIZE,
-              aspectRatio
-            )}
+            src={
+              imageSizes
+                ? imageUrl(src, defaultSize * zoomFactor, maxSize, aspectRatio)
+                : src
+            }
           />
         }
       >
@@ -113,7 +117,11 @@ function HighQualityProductImage(props: Props) {
           className={imgClasses}
           // See comment regarding sizes below
           sizes="(max-width: 64.1rem) 100vw, 50vw"
-          src={imageUrl(src, DEFAULT_SIZE * zoomFactor, MAX_SIZE, aspectRatio)}
+          src={
+            imageSizes
+              ? imageUrl(src, defaultSize * zoomFactor, maxSize, aspectRatio)
+              : src
+          }
         />
       </Zoomable>
     </div>


### PR DESCRIPTION
#### What problem is this solving?

Turn off image size reduction of HighQualityProductImageby by default and add some prop to reduce the image size if you want

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

1. [Workspace](https://high--tfbsmy.myvtex.com/camiseta-manga-curta-estampa-lobo-85102199/p?skuId=983) //// [master with size reduction](https://tfbsmy.myvtex.com/camiseta-manga-curta-estampa-lobo-85102199/p?skuId=983)
2. Click in the image of `ProducdtImages`
3. You should see the difference of quality between the workspaces

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3oEdv9R4D62GPrVY4g/giphy.gif)
