### PR TITLE
Fix product specifications in multilanguage stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue of product specification in multilanguage stores.
 
 ## [3.123.2] - 2020-08-12
 ### Fixed

--- a/react/components/ProductSpecifications/Wrapper.js
+++ b/react/components/ProductSpecifications/Wrapper.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import useProduct from 'vtex.product-context/useProduct'
-import { isEmpty, propOr, propEq } from 'ramda'
+import { isEmpty, propOr } from 'ramda'
 
 import ProductSpecifications from './index'
 
@@ -12,7 +12,9 @@ const getSpecifications = productContext => {
   const { product } = productContext
   const specificationGroups = propOr([], 'specificationGroups', product)
   const groupWithAll = specificationGroups.find(
-    propEq('name', 'allSpecifications')
+    specificationGroup =>
+      specificationGroup.originalName === 'allSpecifications' ||
+      specificationGroup.name === 'allSpecifications'
   )
 
   const allSpecifications = groupWithAll ? groupWithAll.specifications : []


### PR DESCRIPTION
#### What problem is this solving?

The field `name` is being translated, it should use `originalName` instead.

#### How to test it?

Bug: https://whirlpoolec.myvtex.com/lavadora-carga-superior-18kgs-4/p
Fixed: https://brenovtex--whirlpoolec.myvtex.com/lavadora-carga-superior-18kgs-4/p

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/284515/90199804-1aaed400-ddac-11ea-8ab8-7ac45f0e4483.png)

#### Describe alternatives you've considered, if any.

n/a

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
