### PR TITLE
Add missing CSS Handles to Product Specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New CSS Handles to `product-specifications`:
+  - `specificationsTableRow`
+  - `specificationsTableHead`
+  - `specificationsTableBody`
 
 ## [3.123.8] - 2020-08-26
 ### Fixed

--- a/docs/ProductSpecifications.md
+++ b/docs/ProductSpecifications.md
@@ -56,6 +56,9 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `specificationsTitle`                     |
 | `specificationsTableContainer`            |
 | `specificationsTable`                     |
+| `specificationsTableRow`                  |
+| `specificationsTableHead`                 |
+| `specificationsTableBody`                 |
 | `specificationsTabsContainer`             |
 | `specificationsTab`                       |
 | `specificationsTablePropertyHeading`      |

--- a/docs/ProductSpecifications.md
+++ b/docs/ProductSpecifications.md
@@ -56,9 +56,9 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `specificationsTitle`                     |
 | `specificationsTableContainer`            |
 | `specificationsTable`                     |
-| `specificationsTableRow`                  |
-| `specificationsTableHead`                 |
 | `specificationsTableBody`                 |
+| `specificationsTableHead`                 |
+| `specificationsTableRow`                  |
 | `specificationsTabsContainer`             |
 | `specificationsTab`                       |
 | `specificationsTablePropertyHeading`      |

--- a/react/__tests__/components/__snapshots__/ProductSpecifications.test.js.snap
+++ b/react/__tests__/components/__snapshots__/ProductSpecifications.test.js.snap
@@ -26,8 +26,12 @@ exports[`<ProductSpecifications /> component should match snapshot with table vi
         <table
           class="specificationsTable w-100 bg-base border-collapse"
         >
-          <thead>
-            <tr>
+          <thead
+            class="specificationsTableHead"
+          >
+            <tr
+              class="specificationsTableRow"
+            >
               <th
                 class="specificationsTablePropertyHeading w-50 b--muted-4 bb bt c-muted-2 t-body tl pa5"
               >
@@ -40,8 +44,12 @@ exports[`<ProductSpecifications /> component should match snapshot with table vi
               </th>
             </tr>
           </thead>
-          <tbody>
-            <tr>
+          <tbody
+            class="specificationsTableBody"
+          >
+            <tr
+              class="specificationsTableRow"
+            >
               <td
                 class="specificationItemProperty w-50 b--muted-4 bb pa5"
                 data-specification="test"

--- a/react/components/ProductSpecifications/index.js
+++ b/react/components/ProductSpecifications/index.js
@@ -13,6 +13,9 @@ const CSS_HANDLES = [
   'specificationsTabsContainer',
   'specificationsTitle',
   'specificationsTable',
+  'specificationsTableRow',
+  'specificationsTableHead',
+  'specificationsTableBody',
   'specificationsTab',
   'specificationsTablePropertyHeading',
   'specificationsTableSpecificationHeading',
@@ -109,8 +112,8 @@ const ProductSpecifications = ({
     <table
       className={`${handles.specificationsTable} w-100 bg-base border-collapse`}
     >
-      <thead>
-        <tr>
+      <thead className={handles.specificationsTableHead}>
+        <tr className={handles.specificationsTableRow}>
           <th
             className={`${handles.specificationsTablePropertyHeading} w-50 b--muted-4 bb bt c-muted-2 t-body tl pa5`}
           >
@@ -123,9 +126,9 @@ const ProductSpecifications = ({
           </th>
         </tr>
       </thead>
-      <tbody>
+      <tbody className={handles.specificationsTableBody}>
         {specificationItems.map((specification, i) => (
-          <tr key={i}>
+          <tr className={handles.specificationsTableRow} key={i}>
             <td
               data-specification={specification.property}
               className={`${handles.specificationItemProperty} w-50 b--muted-4 bb pa5`}


### PR DESCRIPTION
#### What problem is this solving?

Make it possible to customize more elements in Product Specifications.

#### How to test it?

https://specs--storecomponents.myvtex.com/classic-shoes/p

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/284515/91083000-f19a0900-e61f-11ea-837b-c173dd3fdde9.png)
<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

n/a

#### Related to / Depends on

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
