### PR TITLE
Add props to UserAddress so that only city, state, and/or postal code can be displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `showStreet`, `showCityAndState`, `showPostalCode`, `showPrefix` props to `UserAddress`
+- CSS handles to `UserAddress`
+
 ## [3.126.1] - 2020-09-03
 ### Fixed
 - Encode forward slash in the search term.

--- a/react/components/UserAddress/AddressInfo.js
+++ b/react/components/UserAddress/AddressInfo.js
@@ -1,23 +1,56 @@
 import React, { Fragment } from 'react'
 import { ExtensionPoint, useChildBlock } from 'vtex.render-runtime'
+import { useCssHandles } from 'vtex.css-handles'
 import { pathOr } from 'ramda'
 import { injectIntl, FormattedMessage } from 'react-intl'
 import { IconLocationMarker } from 'vtex.store-icons'
 
-const AddressInfo = ({ inverted, inline, orderForm, intl }) => {
+const CSS_HANDLES = [
+  'addressInfoIconContainer',
+  'addressInfoTextContainer',
+  'addressInfoPrefixContainer',
+  'addressInfoAddressContainer',
+  'addressInfoDivider',
+  'addressInfoModalContainer',
+]
+
+const AddressInfo = ({
+  inverted,
+  inline,
+  orderForm,
+  intl,
+  showStreet,
+  showCityAndState,
+  showPostalCode,
+  showPrefix,
+}) => {
   const { shippingData } = orderForm
   const hasModal = !!useChildBlock({ id: 'modal' })
+  const handles = useCssHandles(CSS_HANDLES)
 
   if (!shippingData || !shippingData.address) return
 
-  const { street, number, complement, addressType } = shippingData.address
+  const {
+    street,
+    number,
+    complement,
+    addressType,
+    city,
+    state,
+    postalCode,
+  } = shippingData.address
 
-  const displayStreet = number ? `${street}, ${number}` : street
+  let displayStreet = number ? `${street}, ${number}` : street
 
-  const displayAddress =
-    complement && complement !== ''
-      ? `${displayStreet} - ${complement}`
-      : `${displayStreet}`
+  if (complement) displayStreet = `${displayStreet} - ${complement}`
+
+  const displayCityAndState = `${city}, ${state}`
+
+  const displayAddress = `${showStreet ? displayStreet : ''}${
+    showStreet && (showCityAndState || showPostalCode) ? ', ' : ''
+  }${showCityAndState ? displayCityAndState : ''}${
+    showCityAndState && showPostalCode ? ', ' : ''
+  }${showPostalCode ? postalCode : ''}`
 
   const isPickup = addressType === 'pickup'
   const friendlyName = pathOr(
@@ -28,43 +61,53 @@ const AddressInfo = ({ inverted, inline, orderForm, intl }) => {
 
   return (
     <div className={`flex ${inline ? 'items-end' : 'items-center flex-auto'}`}>
-      <div className="flex flex-auto">
+      <div className="flex flex-auto items-center">
         <div
-          className={`mr3 flex items-center ${
+          className={`${
+            handles.addressInfoIconContainer
+          } mr3 flex items-center ${
             inverted ? 'c-on-base--inverted' : 'c-muted-2'
           }`}
         >
           <IconLocationMarker size={27} viewBox="0 0 21 27" />
         </div>
-        <div className="flex flex-auto flex-column">
-          <div
-            className={`t-small ${
-              inverted ? 'c-on-base--inverted' : 'c-muted-2'
-            }`}
-          >
-            {isPickup ? (
-              <FormattedMessage
-                id="store/user-address.pickup"
-                values={{ name: friendlyName }}
-              />
-            ) : (
-              <FormattedMessage id="store/user-address.order" />
-            )}
+        <div
+          className={`${handles.addressInfoTextContainer} flex flex-auto flex-column`}
+        >
+          {showPrefix && (
+            <div
+              className={`${handles.addressInfoPrefixContainer} t-small ${
+                inverted ? 'c-on-base--inverted' : 'c-muted-2'
+              }`}
+            >
+              {isPickup ? (
+                <FormattedMessage
+                  id="store/user-address.pickup"
+                  values={{ name: friendlyName }}
+                />
+              ) : (
+                <FormattedMessage id="store/user-address.order" />
+              )}
+            </div>
+          )}
+          <div className={`${handles.addressInfoAddressContainer} truncate`}>
+            {displayAddress}
           </div>
-          <div className="truncate">{displayAddress}</div>
         </div>
       </div>
       {hasModal && (
         <Fragment>
           <div
-            className={`bl bw1 mh4 ${inline ? 'nb2' : ''} ${
-              inverted ? 'b--on-base--inverted' : 'b--muted-5'
-            }`}
+            className={`${handles.addressInfoDivider} bl bw1 mh4 ${
+              inline ? 'nb2' : ''
+            } ${inverted ? 'b--on-base--inverted' : 'b--muted-5'}`}
             style={{
               height: '1.5rem',
             }}
           />
-          <div className="flex items-center">
+          <div
+            className={`${handles.addressInfoModalContainer} flex items-center`}
+          >
             <ExtensionPoint
               id="modal"
               centered

--- a/react/components/UserAddress/index.js
+++ b/react/components/UserAddress/index.js
@@ -49,7 +49,7 @@ const UserAddress = ({
     </div>
   ) : (
     <div
-      className={`${handles.userAddressContainer} bg-base--inverted c-on-base--inverted flex ph5 pointer pv3`}
+      className={`${handles.userAddressContainer} bg-base--inverted c-on-base--inverted flex ph5 pointer pv3 ml3 mr3`}
     >
       <Container className="flex justify-center w-100 left-0">
         <div className="w-100 mw9 flex">

--- a/react/components/UserAddress/index.js
+++ b/react/components/UserAddress/index.js
@@ -1,14 +1,25 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { graphql } from 'react-apollo'
+import { useCssHandles } from 'vtex.css-handles'
 import ADDRESS_QUERY from 'vtex.store-resources/QueryAddress'
 
 import Container from '../Container'
 import AddressInfo from './AddressInfo'
 
-const UserAddress = ({ variation, addressQuery: addressQueryProp }) => {
+const CSS_HANDLES = ['userAddressContainer']
+
+const UserAddress = ({
+  variation,
+  addressQuery: addressQueryProp,
+  showStreet = true,
+  showCityAndState = false,
+  showPostalCode = false,
+  showPrefix = true,
+}) => {
   const { orderForm } = addressQueryProp
   const { shippingData } = orderForm || {}
+  const handles = useCssHandles(CSS_HANDLES)
 
   if (!orderForm || !shippingData || !shippingData.address) {
     return null
@@ -19,7 +30,7 @@ const UserAddress = ({ variation, addressQuery: addressQueryProp }) => {
 
   return isInline ? (
     <div
-      className="ph5"
+      className={`${handles.userAddressContainer} ph5`}
       style={{
         maxWidth: '30rem',
       }}
@@ -29,17 +40,27 @@ const UserAddress = ({ variation, addressQuery: addressQueryProp }) => {
           inverted={isInverted}
           inline={isInline}
           orderForm={orderForm}
+          showStreet={showStreet}
+          showCityAndState={showCityAndState}
+          showPostalCode={showPostalCode}
+          showPrefix={showPrefix}
         />
       }
     </div>
   ) : (
-    <div className="bg-base--inverted c-on-base--inverted flex ph5 pointer pv3">
+    <div
+      className={`${handles.userAddressContainer} bg-base--inverted c-on-base--inverted flex ph5 pointer pv3`}
+    >
       <Container className="flex justify-center w-100 left-0">
         <div className="w-100 mw9 flex">
           <AddressInfo
             inverted={isInverted}
             inline={isInline}
             orderForm={orderForm}
+            showStreet={showStreet}
+            showCityAndState={showCityAndState}
+            showPostalCode={showPostalCode}
+            showPrefix={showPrefix}
           />
         </div>
       </Container>
@@ -50,6 +71,10 @@ const UserAddress = ({ variation, addressQuery: addressQueryProp }) => {
 UserAddress.propTypes = {
   variation: PropTypes.oneOf(['inline', 'bar']).isRequired,
   addressQuery: PropTypes.object.isRequired,
+  showStreet: PropTypes.bool,
+  showCityAndState: PropTypes.bool,
+  showPostalCode: PropTypes.bool,
+  showPrefix: PropTypes.bool,
 }
 
 const withAddressQuery = graphql(ADDRESS_QUERY, {


### PR DESCRIPTION
#### What problem is this solving?

The US 1st Party Apps team is developing a solution for BOPIS (Pickup in Store) that utilizes the UserAddress component from this repo. Instead of using this component to display a delivery address, we wish to use it to display the user's location -- either their city and state, or their postal code (or both). Their location will affect the availability messaging they are shown on products shelves and the PDP. This PR allows the UserAddress component to display the desired information to the user.

#### How to test it?

The new version is linked here: https://geolocation--sandboxusdev.myvtex.com/
And has been configured to show city, state, postal code, and no "Order to" prefix.

#### Screenshots or example usage:

![geolocation--sandboxusdev myvtex com_](https://user-images.githubusercontent.com/6306265/92159830-06cf1e80-edfc-11ea-9c14-120cecf94ca8.png)
