### PR TITLE
Fixed AddressInfo displaying null when only postalCode is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- AddressInfo showing *null, null* when only postalCode is available
 
 ## [3.126.2] - 2020-09-03
 

--- a/react/components/UserAddress/AddressInfo.js
+++ b/react/components/UserAddress/AddressInfo.js
@@ -44,12 +44,12 @@ const AddressInfo = ({
 
   if (complement) displayStreet = `${displayStreet} - ${complement}`
 
-  const displayCityAndState = `${city}, ${state}`
+  const displayCityAndState = !!city && !!state ? `${city}, ${state}` : ''
 
-  const displayAddress = `${showStreet ? displayStreet : ''}${
+  const displayAddress = `${showStreet ? displayStreet || '' : ''}${
     showStreet && (showCityAndState || showPostalCode) ? ', ' : ''
   }${showCityAndState ? displayCityAndState : ''}${
-    showCityAndState && showPostalCode ? ', ' : ''
+    showCityAndState && showPostalCode ? `${displayCityAndState ? ', ' : ''}` : ''
   }${showPostalCode ? postalCode : ''}`
 
   const isPickup = addressType === 'pickup'

--- a/react/components/UserAddress/AddressInfo.js
+++ b/react/components/UserAddress/AddressInfo.js
@@ -49,7 +49,9 @@ const AddressInfo = ({
   const displayAddress = `${showStreet ? displayStreet || '' : ''}${
     showStreet && (showCityAndState || showPostalCode) ? ', ' : ''
   }${showCityAndState ? displayCityAndState : ''}${
-    showCityAndState && showPostalCode ? `${displayCityAndState ? ', ' : ''}` : ''
+    showCityAndState && showPostalCode
+      ? `${displayCityAndState ? ', ' : ''}`
+      : ''
   }${showPostalCode ? postalCode : ''}`
 
   const isPickup = addressType === 'pickup'


### PR DESCRIPTION
#### What problem is this solving?
Sometimes, when the store uses `shipping-simulator`, it sets only the postalCode, and the `AddressInfo` from the `user-address` interface displays **null, null**

<!--- What is the motivation and context for this change? -->

#### How to test it?

To test the issue, head over to [this page](https://sandboxusdev.myvtex.com/invicta-reserve-bolt-zeus-mens-automatic-53-mm-stainless-steel-case-silver-white-dial-model-27108/p) and simulate shipping to **33327**

To test the fix, head over to [this page](https://wender--sandboxusdev.myvtex.com/invicta-reserve-bolt-zeus-mens-automatic-53-mm-stainless-steel-case-silver-white-dial-model-27108/p)  and simulate shipping to **33327**

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

#### Screenshots or example usage:

Fallback when only postalCode is available
![image](https://user-images.githubusercontent.com/24723/92266820-2e82bd00-eeb6-11ea-875a-459be62d0a5c.png)

Actual error
![image](https://user-images.githubusercontent.com/24723/92266962-7b669380-eeb6-11ea-8292-9596235f3738.png)

Ideal scenario
![image](https://user-images.githubusercontent.com/24723/92266993-8de0cd00-eeb6-11ea-9d63-e135aeee2446.png)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.
To force this scenario, maybe you need to setup manually using postman
![image](https://user-images.githubusercontent.com/24723/92267068-aa7d0500-eeb6-11ea-8726-01a5c5e97278.png)

It only happens once in awhile, testing with different postalCodes maybe works better

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
