### PR TITLE
Dont render when not on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Render BackToTopButton only when visible.
 
 ## [3.126.3] - 2020-09-04
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.126.3",
+  "version": "3.126.4-0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-components",
-  "version": "3.126.4-0",
+  "version": "3.127.0-beta.0",
   "title": "VTEX Store Components",
   "defaultLocale": "pt-BR",
   "description": "The VTEX store components for that render apps can use",

--- a/react/components/BackToTopButton/index.tsx
+++ b/react/components/BackToTopButton/index.tsx
@@ -51,6 +51,10 @@ const BackToTopButton: StorefrontFC<Props> = ({
     }
   }, [scrollY, displayThreshold])
 
+  if (!isShowed) {
+    return null
+  }
+
   return display === 'button' ? (
     <div className={backToTopButtonClasses}>
       <Button onClick={handleBackTop} size="regular">


### PR DESCRIPTION
#### What problem is this solving?
Currently, the BackToTopButton is rendered to the DOM and hidden by using CSS. 

I thinks this is a bad approach, since we spend precious "hydration" time computing a button that will be hidden using CSS. Also, this approach makes it harder to implement techniques like CriticalCSS.

To address this problem, I suggest only rendering the button once it's visible.

#### How to test it?

[Workspace](https://gimenes--carrefourbr.myvtex.com/?__debugCriticalCSS=true)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
