### PR TITLE
Fix content schema paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add full path of content definitions to avoid breaking when extending some interface.
 
 ## [3.127.0] - 2020-09-08
 ### Changed

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -6,7 +6,7 @@
     "component": "SearchBar",
     "allowed": ["autocomplete-result-list", "icon-search", "icon-close"],
     "content": {
-      "$ref": "#/definitions/SearchBar"
+      "$ref": "app:vtex.store-components#/definitions/SearchBar"
     }
   },
   "autocomplete-result-list": {
@@ -30,13 +30,13 @@
   "product-price": {
     "component": "ProductPrice",
     "content": {
-      "$ref": "#/definitions/ProductPrice"
+      "$ref": "app:vtex.store-components#/definitions/ProductPrice"
     }
   },
   "product-description": {
     "component": "ProductDescription",
     "content": {
-      "$ref": "#/definitions/ProductDescription"
+      "$ref": "app:vtex.store-components#/definitions/ProductDescription"
     }
   },
   "product-separator": {
@@ -66,7 +66,7 @@
   "info-card": {
     "component": "InfoCard",
     "content": {
-      "$ref": "#/definitions/InfoCard"
+      "$ref": "app:vtex.store-components#/definitions/InfoCard"
     }
   },
   "user-address": {


### PR DESCRIPTION
#### What problem is this solving?

Avoid having issues like this:
![image](https://user-images.githubusercontent.com/284515/92520283-bc7de100-f1f1-11ea-8062-bb6e79cdd07e.png)

In apps that extends some interface:
https://github.com/vtex-apps/flixmedia/blob/master/store/interfaces.json

#### How to test it?

https://flixmedia--realplaza.myvtex.com/refrigeradora-samsung-no-frost-side-by-side-rs65r5691b4-pe-602l-black-edition-21415/p

#### Screenshots or example usage:

#### Describe alternatives you've considered, if any.

n/a

#### Related to / Depends on
n/a


