### PR TITLE
Updates to support new Shopper Location app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `shouldUpdateOrderForm` prop to `ShippingSimulator`
+- `showIfEmpty` prop to `UserAddress` so that shopper with no address can add one
+- Event listener to `UserAddress` for `locationUpdated` event from `vtex.shopper-location`
+
 ## [3.130.0] - 2020-09-21
 ### Added
 - `product-sku-attributes` interface

--- a/docs/ShippingSimulator.md
+++ b/docs/ShippingSimulator.md
@@ -1,8 +1,8 @@
-📢 Use this project, [contribute](https://github.com/vtex-apps/store-components) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion). 
+📢 Use this project, [contribute](https://github.com/vtex-apps/store-components) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
 
 # Shipping Simulator
 
-The Shipping Simulator block **estimates the shipping fee** based on a zip code input. 
+The Shipping Simulator block **estimates the shipping fee** based on a zip code input.
 
 ![shipping](https://user-images.githubusercontent.com/52087100/70262606-6ddb7c00-1773-11ea-91af-ededfd27aa95.png)
 
@@ -36,34 +36,35 @@ The Shipping Simulator block **estimates the shipping fee** based on a zip code 
   },
 ```
 
-| Prop name          | Type      | Description                   | Default value |
-| ------------------ | --------- | ----------------------------- | ------------- |
-| `skuId`            | `String` | ID of the current product SKU | - |
-| `seller`           | `String` | ID of the product seller      | - |
+| Prop name               | Type      | Description                                                                                   | Default value |
+| ----------------------- | --------- | --------------------------------------------------------------------------------------------- | ------------- |
+| `skuId`                 | `String`  | ID of the current product SKU                                                                 | -             |
+| `seller`                | `String`  | ID of the product seller                                                                      | -             |
+| `shouldUpdateOrderForm` | `Boolean` | Whether interacting with the simulator should update the shopper's address in their orderForm | `true`        |
 
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-| CSS Handles |
-| ---------- | 
-| `shippingContainer` |
-| `shippingContainerLoader` | 
-| `shippingCTA` |
-| `shippingInputLoader` |
-| `shippingNoMessage` |
-| `shippingTable` |
-| `shippingTableBody` |
-| `shippingTableCell` |
+| CSS Handles                         |
+| ----------------------------------- |
+| `shippingContainer`                 |
+| `shippingContainerLoader`           |
+| `shippingCTA`                       |
+| `shippingInputLoader`               |
+| `shippingNoMessage`                 |
+| `shippingTable`                     |
+| `shippingTableBody`                 |
+| `shippingTableCell`                 |
 | `shippingTableCellDeliveryEstimate` |
-| `shippingTableCellDeliveryName` |
-| `shippingTableCellDeliveryPrice` |
-| `shippingTableHead` |
+| `shippingTableCellDeliveryName`     |
+| `shippingTableCellDeliveryPrice`    |
+| `shippingTableHead`                 |
 | `shippingTableHeadDeliveryEstimate` |
-| `shippingTableHeadDeliveryName` |
-| `shippingTableHeadDeliveryPrice` |
-| `shippingTableLabel` |
-| `shippingTableRadioBtn` |
-| `shippingTableRow` |
-| `shippingZipcodeLabel` |
-| `shippingZipcodeLabelLoader` |
+| `shippingTableHeadDeliveryName`     |
+| `shippingTableHeadDeliveryPrice`    |
+| `shippingTableLabel`                |
+| `shippingTableRadioBtn`             |
+| `shippingTableRow`                  |
+| `shippingZipcodeLabel`              |
+| `shippingZipcodeLabelLoader`        |

--- a/messages/context.json
+++ b/messages/context.json
@@ -126,6 +126,7 @@
   "store/user-address.pickup": "Pickup at <address>",
   "store/user-address.order": "Order to <address>",
   "store/user-address.change": "Change address button label",
+  "store/user-address.add": "Set address button label",
   "admin/editor.notification-bar.title": "Notification bar",
   "admin/editor.notification-bar.description": "A component that show any text in a bar style",
   "admin/editor.notification-bar.content.title": "Content",

--- a/messages/en.json
+++ b/messages/en.json
@@ -126,6 +126,7 @@
   "store/user-address.pickup": "Pick up at {name}",
   "store/user-address.order": "Order to",
   "store/user-address.change": "Change",
+  "store/user-address.add": "Add Location",
   "admin/editor.notification-bar.title": "Notification bar",
   "admin/editor.notification-bar.description": "A component that show any text in a bar style",
   "admin/editor.notification-bar.content.title": "Content",

--- a/messages/es.json
+++ b/messages/es.json
@@ -126,6 +126,7 @@
   "store/user-address.pickup": "Recoger en {name}",
   "store/user-address.order": "Orden a",
   "store/user-address.change": "Cambiar",
+  "store/user-address.add": "Añade una ubicación",
   "admin/editor.notification-bar.title": "Notification bar",
   "admin/editor.notification-bar.description": "Un componente que muestra cualquier texto en un estilo de barra",
   "admin/editor.notification-bar.content.title": "Contenido",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -126,6 +126,7 @@
   "store/user-address.pickup": "Retirar em {name}",
   "store/user-address.order": "Enviar para",
   "store/user-address.change": "Alterar",
+  "store/user-address.add": "Adicionar local",
   "admin/editor.notification-bar.title": "Notification bar",
   "admin/editor.notification-bar.description": "Um componente que mostra qualquer texto em um estilo de barra",
   "admin/editor.notification-bar.content.title": "Conteúdo",

--- a/react/components/ShippingSimulator/Wrapper.js
+++ b/react/components/ShippingSimulator/Wrapper.js
@@ -47,6 +47,7 @@ const BaseShippingSimulatorWrapper = ({
   loaderStyles,
   onShippingAddressUpdate = _ => {},
   initialPostalCode = undefined,
+  shouldUpdateOrderForm,
 }) => {
   const [shipping, setShipping] = useState(null)
   const [loading, setLoading] = useState(false)
@@ -83,6 +84,8 @@ const BaseShippingSimulatorWrapper = ({
           setShipping(result.data.shipping)
         })
         .then(() => {
+          if (!shouldUpdateOrderForm) return
+
           return onShippingAddressUpdate?.(rawAddress)
         })
         .catch(error => {
@@ -92,7 +95,15 @@ const BaseShippingSimulatorWrapper = ({
           setLoading(false)
         })
     },
-    [address, client, country, seller, skuId, onShippingAddressUpdate]
+    [
+      address,
+      client,
+      country,
+      seller,
+      skuId,
+      onShippingAddressUpdate,
+      shouldUpdateOrderForm,
+    ]
   )
 
   const isMountedRef = useRef(false)
@@ -132,6 +143,7 @@ const ShippingSimulatorWithOrderForm = ({
   skuId,
   seller,
   loaderStyles,
+  shouldUpdateOrderForm,
 }) => {
   const { updateSelectedAddress } = useOrderShipping()
   const { orderForm } = useOrderForm()
@@ -150,6 +162,7 @@ const ShippingSimulatorWithOrderForm = ({
           : undefined
       }
       onShippingAddressUpdate={updateSelectedAddress}
+      shouldUpdateOrderForm={shouldUpdateOrderForm}
     />
   )
 }
@@ -173,6 +186,8 @@ const ShippingSimulatorWrapper = props => {
   const seller =
     props.seller || productContext?.selectedItem?.sellers?.[0]?.sellerId
 
+  const { shouldUpdateOrderForm = true } = props
+
   if (
     window.__RUNTIME__?.settings?.['vtex.store']
       ?.enableOrderFormOptimization !== true
@@ -195,6 +210,7 @@ const ShippingSimulatorWrapper = props => {
           seller={seller}
           skuId={skuId}
           loaderStyles={props.loaderStyles}
+          shouldUpdateOrderForm={shouldUpdateOrderForm}
         />
       </OrderFormLoader>
     </OrderShippingProvider>

--- a/react/components/UserAddress/AddressInfo.js
+++ b/react/components/UserAddress/AddressInfo.js
@@ -23,12 +23,52 @@ const AddressInfo = ({
   showCityAndState,
   showPostalCode,
   showPrefix,
+  showIfEmpty,
 }) => {
   const { shippingData } = orderForm
   const hasModal = !!useChildBlock({ id: 'modal' })
   const handles = useCssHandles(CSS_HANDLES)
 
-  if (!shippingData || !shippingData.address) return
+  if (!shippingData || !shippingData.address) {
+    if (!showIfEmpty) return
+
+    return (
+      <div
+        className={`flex ${inline ? 'items-end' : 'items-center flex-auto'}`}
+      >
+        <div
+          className={`${
+            handles.addressInfoIconContainer
+          } mr3 flex items-center ${
+            inverted ? 'c-on-base--inverted' : 'c-muted-2'
+          }`}
+        >
+          <IconLocationMarker size={27} viewBox="0 0 21 27" />
+        </div>
+        {hasModal ? (
+          <div
+            className={`${handles.addressInfoModalContainer} flex items-center`}
+          >
+            <ExtensionPoint
+              id="modal"
+              centered
+              buttonLabel={intl.formatMessage({
+                id: 'store/user-address.add',
+              })}
+              buttonClass={
+                inverted ? 'c-on-base--inverted' : 'c-action-primary'
+              }
+              showTopBar={false}
+            />
+          </div>
+        ) : (
+          <div className={`${handles.addressInfoAddressContainer} truncate`}>
+            <FormattedMessage id="store/user-address.add" />
+          </div>
+        )}
+      </div>
+    )
+  }
 
   const {
     street,

--- a/react/components/UserAddress/index.js
+++ b/react/components/UserAddress/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { graphql } from 'react-apollo'
 import { useCssHandles } from 'vtex.css-handles'
 import ADDRESS_QUERY from 'vtex.store-resources/QueryAddress'
@@ -16,12 +16,22 @@ const UserAddress = ({
   showCityAndState = false,
   showPostalCode = false,
   showPrefix = true,
+  showIfEmpty = false,
 }) => {
   const { orderForm } = addressQueryProp
-  const { shippingData } = orderForm || {}
   const handles = useCssHandles(CSS_HANDLES)
 
-  if (!orderForm || !shippingData || !shippingData.address) {
+  useEffect(() => {
+    window.addEventListener('locationUpdated', () => {
+      addressQueryProp.refetch()
+    })
+  }, [addressQueryProp])
+
+  if (
+    !orderForm ||
+    ((!orderForm.shippingData || !orderForm.shippingData.address) &&
+      !showIfEmpty)
+  ) {
     return null
   }
 
@@ -44,6 +54,7 @@ const UserAddress = ({
           showCityAndState={showCityAndState}
           showPostalCode={showPostalCode}
           showPrefix={showPrefix}
+          showIfEmpty={showIfEmpty}
         />
       }
     </div>
@@ -61,6 +72,7 @@ const UserAddress = ({
             showCityAndState={showCityAndState}
             showPostalCode={showPostalCode}
             showPrefix={showPrefix}
+            showIfEmpty={showIfEmpty}
           />
         </div>
       </Container>
@@ -75,6 +87,7 @@ UserAddress.propTypes = {
   showCityAndState: PropTypes.bool,
   showPostalCode: PropTypes.bool,
   showPrefix: PropTypes.bool,
+  showIfEmpty: PropTypes.bool,
 }
 
 const withAddressQuery = graphql(ADDRESS_QUERY, {

--- a/react/components/UserAddress/index.js
+++ b/react/components/UserAddress/index.js
@@ -25,6 +25,12 @@ const UserAddress = ({
     window.addEventListener('locationUpdated', () => {
       addressQueryProp.refetch()
     })
+
+    return () => {
+      window.removeEventListener('locationUpdated', () => {
+        addressQueryProp.refetch()
+      })
+    }
   }, [addressQueryProp])
 
   if (

--- a/react/components/UserAddress/index.js
+++ b/react/components/UserAddress/index.js
@@ -22,14 +22,12 @@ const UserAddress = ({
   const handles = useCssHandles(CSS_HANDLES)
 
   useEffect(() => {
-    window.addEventListener('locationUpdated', () => {
-      addressQueryProp.refetch()
-    })
+    const handleLocationUpdated = () => addressQueryProp.refetch()
+
+    window.addEventListener('locationUpdated', handleLocationUpdated)
 
     return () => {
-      window.removeEventListener('locationUpdated', () => {
-        addressQueryProp.refetch()
-      })
+      window.removeEventListener('locationUpdated', handleLocationUpdated)
     }
   }, [addressQueryProp])
 


### PR DESCRIPTION
#### What problem is this solving?

A few updates to support the Shopper Location app and Buy Online / Pick Up In Store solution that the US 1st Party Apps team is developing.

**Shipping Simulator**
When the Order Form Optimization feature flag is enabled, the shipping simulator component is pre-filled with the postal code from the shopper's orderForm. This is good; however, just the act of rendering this component causes all of the orderForm's address fields other than the postal code to be emptied. This PR adds a prop that controls whether interacting with the shipping simulator modifies the address in the orderForm. 

**User Address**
This PR adds a new prop to this component that allows the component to be rendered even if no shipping address exists in the user's orderForm. If no address exists, the component will render an intl message like "Add Location". I've also tried to adjust the code to add support for the newer `vtex.modal-layout` in addition to keeping legacy support for `vtex.modal`. Finally, I've added an event listener for `locationUpdated` from `vtex.shopper-location` so that the orderForm can be refetched if the shopper changes their address.  

#### How to test it?

[Example workspace with UserAddress in header and ShippingSimulator on PDP](https://geolocation--sandboxusdev.myvtex.com/invicta-reserve-bolt-zeus-mens-automatic-53-mm-stainless-steel-case-silver-white-dial-model-27108/p)
(`vtex.shopper-location` will normally attempt to automatically determine the shopper's location. This feature has been disabled in this workspace in order to demonstrate the behavior when the shopper's address is empty.)

#### Screenshots or example usage:

![shopper-location](https://user-images.githubusercontent.com/6306265/93517027-deb1e600-f8f8-11ea-9e49-6f63e81cd540.gif)
