### PR TITLE
Fix SKU Selector issue with translated store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- SKU Selector issue with translated stores.
 
 ## [3.128.0] - 2020-09-17
 ### Added

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -115,11 +115,12 @@ const useImagesMap = (
     }
 
     const variationNames = Object.keys(variations)
+
     const result: ImageMap = {}
 
     for (const variationName of variationNames) {
       // Today, only "Color" variation should show image, need to find a more resilient way to tell this, waiting for backend
-      if (!isColor(variationName)) {
+      if (!isColor(variations[variationName].originalName)) {
         continue
       }
 


### PR DESCRIPTION
#### What problem is this solving?

Use originalName when finding out which variations are colors.

#### How to test it?

Workspace with the bug:
https://muji.myvtex.com/organiccottonshijirajinbei/p?__bindingAddress=www.muji.eu/fi

Fixed workspace:
https://brenovtex--muji.myvtex.com/organiccottonshijirajinbei/p?__bindingAddress=www.muji.eu/fi


Checking for regressions in the scenario where it's not translated:
https://brenovtex--muji.myvtex.com/organiccottonshijirajinbei/p?__bindingAddress=www.muji.eu/uk

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/284515/93626967-9f4bce00-f9ba-11ea-960a-e6c50bec4a23.png)

#### Describe alternatives you've considered, if any.

n/a

#### Related to / Depends on

n/a

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
