### PR TITLE
Fix/product images zoomout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where product images would zoom out immediately in certain cases.
 
 ## [3.130.1] - 2020-09-21
 

--- a/react/components/ProductImages/components/Zoomable/ZoomInPlace.tsx
+++ b/react/components/ProductImages/components/Zoomable/ZoomInPlace.tsx
@@ -112,10 +112,21 @@ const ZoomInPlace: FC<Props> = ({ children, zoomContent, type, factor }) => {
 
   /* Adds mouse event handlers to the entire document, so that
    * mouse movement is not restricted to just the content element */
-  const handleClickOutside = () => {
-    if (isZoomedIn) {
-      setZoom(false)
+  const handleClickOutside = (event: MouseEvent) => {
+    if (!isZoomedIn) {
+      return
     }
+
+    const isDescendant =
+      containerRef.current &&
+      event.target &&
+      containerRef.current.contains?.(event.target as Node)
+
+    if (isDescendant) {
+      return
+    }
+
+    setZoom(false)
   }
 
   const handleMouseMove = (event: ReactMouseEvent) => {


### PR DESCRIPTION
#### What problem is this solving?
Fixes issue where product images would zoom out immediately in certain cases.

<!--- What is the motivation and context for this change? -->

#### How to test it?

Before:
https://www.carrefour.com.br/iphone-11-apple-amarelo-128gb-mp24794943/p?ak-testab=vtex
Try zooming in on the product image, by clicking on it. It should flicker quickly between zoomed in and zoomed out states

After:
https://lbebber--carrefourbr.myvtex.com/iphone-11-apple-amarelo-128gb-mp24794943/p
The issue shouldn't be present. Try clicking outside the image for good measure.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
