### PR TITLE
Feature/SKU selector item wrapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added a wrapp to `skuSelectorItem` button with a new CSS handles `skuSelectorItemWrapper` in SKU Selector.
+
 ## [3.131.0] - 2020-10-13
 
 ### Added

--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -39,6 +39,7 @@ const CSS_HANDLES = [
   'skuSelectorItem',
   'skuSelectorBadge',
   'skuSelectorItemImage',
+  'skuSelectorItemWrapper',
   'skuSelectorInternalBox',
   'skuSelectorItemTextValue',
   'skuSelectorItemImageValue',
@@ -108,60 +109,62 @@ const SelectorItem: FC<Props> = ({
   }
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onClick}
-      style={containerStyles}
-      className={containerClasses}
-      onKeyDown={e => e.key === 'Enter' && onClick(e)}
-    >
+    <div className={handles.skuSelectorItemWrapper}>
       <div
-        className={classNames(
-          handles.frameAround,
-          'absolute b--action-primary br3 bw1',
-          {
-            ba: isSelected,
-          }
-        )}
-      />
-      <div
-        className={classNames(
-          handles.skuSelectorInternalBox,
-          'w-100 h-100 b--muted-4 br2 b z-1 c-muted-5 flex items-center overflow-hidden',
-          {
-            'hover-b--muted-2': !isSelected && !isImpossible,
-            ba: showBorders,
-          }
-        )}
+        role="button"
+        tabIndex={0}
+        onClick={onClick}
+        style={containerStyles}
+        className={containerClasses}
+        onKeyDown={e => e.key === 'Enter' && onClick(e)}
       >
         <div
-          className={classNames('absolute absolute--fill', {
-            [handles.diagonalCross]: !isAvailable,
-          })}
+          className={classNames(
+            handles.frameAround,
+            'absolute b--action-primary br3 bw1',
+            {
+              ba: isSelected,
+            }
+          )}
         />
         <div
-          className={classNames(handles.valueWrapper, {
-            [`${handles.skuSelectorItemTextValue} c-on-base center pl5 pr5 z-1 t-body`]: !isImage,
-            'h-100': isImage,
-          })}
-        >
-          {isImage && imageUrl ? (
-            <img
-              className={handles.skuSelectorItemImageValue}
-              src={imageUrl}
-              alt={imageLabel as string | undefined}
-            />
-          ) : (
-            variationValue
+          className={classNames(
+            handles.skuSelectorInternalBox,
+            'w-100 h-100 b--muted-4 br2 b z-1 c-muted-5 flex items-center overflow-hidden',
+            {
+              'hover-b--muted-2': !isSelected && !isImpossible,
+              ba: showBorders,
+            }
           )}
+        >
+          <div
+            className={classNames('absolute absolute--fill', {
+              [handles.diagonalCross]: !isAvailable,
+            })}
+          />
+          <div
+            className={classNames(handles.valueWrapper, {
+              [`${handles.skuSelectorItemTextValue} c-on-base center pl5 pr5 z-1 t-body`]: !isImage,
+              'h-100': isImage,
+            })}
+          >
+            {isImage && imageUrl ? (
+              <img
+                className={handles.skuSelectorItemImageValue}
+                src={imageUrl}
+                alt={imageLabel as string | undefined}
+              />
+            ) : (
+              variationValue
+            )}
+          </div>
         </div>
+        {discount > 0 && (
+          <span className={`${handles.skuSelectorBadge} b`}>
+            <FormattedNumber value={discount} style="percent" />
+          </span>
+        )}
       </div>
-      {discount > 0 && (
-        <span className={`${handles.skuSelectorBadge} b`}>
-          <FormattedNumber value={discount} style="percent" />
-        </span>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

Style around the color button of the sku selector.

#### How to test it?

Access the workspace and style around the sku selector color button.

Example CSS class:
```
.vtex-store-components-3-x-skuSelectorSubcontainer--cor .vtex-store-components-3-x-skuSelectorItemWrapper {
    border: 1px solid #000;
    width: 50px;
    height: 50px;
    text-align: center;
    margin-right: 5px;
    padding-top: 15px;
}
```

[Workspace](https://selectorwrapp--samsungbr.myvtex.com/galaxy-note20-ultra/p?skuId=1420)

#### Screenshots or example usage:

Before:
![image](https://user-images.githubusercontent.com/53005772/96740606-5d39f180-1397-11eb-9db3-70e8125befa3.png)

After:
![image](https://user-images.githubusercontent.com/53005772/96740497-45626d80-1397-11eb-98a2-db1b3529a30a.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![hackerman](https://media.giphy.com/media/RyXVu4ZW454IM/giphy.gif)