### PR TITLE
Setting a fixed version for the Swiper package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Navigating between product images using thumbnails was not working 
+
 
 ## [3.131.2] - 2020-11-10
 ### Changed

--- a/react/package.json
+++ b/react/package.json
@@ -30,7 +30,7 @@
     "recompose": "^0.30.0",
     "slick-carousel": "^1.8.1",
     "slugify": "^1.3.4",
-    "swiper": "^6.1.1"
+    "swiper": "6.2.0"
   },
   "devDependencies": {
     "@apollo/react-testing": "3.1.3",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5153,10 +5153,10 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-swiper@^6.1.1:
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.3.5.tgz#7444b680d0fdafe84859825ac3559b5b01bd1916"
-  integrity sha512-MZkkVJ+sXukp6G3Z3BlKayhBjRIQuO1TZaTlH7ooI/0qbH0kkmItFMjFo19nOOsJaDXglA32xqyc9KCtmbJv0w==
+swiper@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.2.0.tgz#f9dafdc2ccb5d6dd2bd728c78db87605329cb50e"
+  integrity sha512-lOQeWRAHXwWPDu6k5cJYkf/eVRq2IUiHpMSGS143PVBg91J+2ZCXwM+Uv2sUckrZn3AMGcpcpnEBqD8Rwz9XGQ==
   dependencies:
     dom7 "^3.0.0-alpha.7"
     ssr-window "^3.0.0-alpha.4"


### PR DESCRIPTION
#### What problem is this solving?

Navigating between product images using the thumbnails was not working properly. The problem was introduced by version `6.3.0` of the swiper lib, so we downgraded it to the `6.2.0` version. 

#### How to test it?

[Workspace](https://master--storecomponents.myvtex.com/everyday-necessaire/p)

#### Screenshots or example usage:

![](https://im3.ezgif.com/tmp/ezgif-3-e7d8a14d87a0.gif)

#### Describe alternatives you've considered, if any.

This is a temporary fix. We should dive deep into the problem and solve its root cause. 
