### PR TITLE
InputSearch instead of Input for the AutocompleteInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `searchInput` prop to `SearchBar`. If true, the autocomplete will be an input type search 
+-  With searchInput=true it solves the problem when you click on the 'ok' button then disappears the results block on iOs platform
+-  With searchInput=true it allows also to have a 'Search button' on the iOs virtual keyboard.
 
 ## [3.131.3] - 2020-11-13
 ### Fixed

--- a/react/__mocks__/vtex.styleguide.js
+++ b/react/__mocks__/vtex.styleguide.js
@@ -61,6 +61,27 @@ export const Input = forwardRef(function Input(
   )
 })
 
+export const InputSearch = forwardRef(function Input(
+  { label, error, errorMessage, isLoading, prefix, suffix, ...props },
+  ref
+) {
+  return (
+    <label>
+      {label}
+      {prefix}
+      <input
+        type="search"
+        data-isloading={isLoading}
+        data-error={error}
+        data-errormessage={errorMessage}
+        ref={ref}
+        {...props}
+      />
+      {suffix}
+    </label>
+  )
+})
+
 export const Button = jest.fn(
   ({ isLoading, variation, block, children, ...props }) => {
     return (

--- a/react/__mocks__/vtex.styleguide.js
+++ b/react/__mocks__/vtex.styleguide.js
@@ -61,7 +61,7 @@ export const Input = forwardRef(function Input(
   )
 })
 
-export const InputSearch = forwardRef(function Input(
+export const InputSearch = forwardRef(function InputSearch(
   { label, error, errorMessage, isLoading, prefix, suffix, ...props },
   ref
 ) {

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { Input } from 'vtex.styleguide'
+import { InputSearch } from 'vtex.styleguide'
 import { ExtensionPoint, useChildBlock } from 'vtex.render-runtime'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { IconSearch, IconClose } from 'vtex.store-icons'
@@ -172,8 +172,20 @@ const AutocompleteInput = ({
   })
 
   return (
+    <form action="#" onSubmit={e => {
+      e.preventDefault()
+      e.stopPropagation()
+      e.nativeEvent.stopImmediatePropagation()
+    }}>
     <div className={handles.autoCompleteOuterContainer}>
       <div className={classContainer}>
+      <InputSearch 
+          ref={inputRef}
+          size="large"
+          value={value}
+          {...restProps}          
+        />
+        {/*        
         <Input
           ref={inputRef}
           size="large"
@@ -183,9 +195,10 @@ const AutocompleteInput = ({
           {...restProps}
           error={Boolean(inputErrorMessage)}
           errorMessage={inputErrorMessage}
-        />
+        /> */}
       </div>
     </div>
+    </form>
   )
 }
 

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -172,31 +172,33 @@ const AutocompleteInput = ({
     [handles.compactMode]: compactMode,
   })
 
-
-  if(searchInput){
+  if (searchInput) {
     return (
-      <form action="#" onSubmit={e => {
-        e.preventDefault()
-        e.stopPropagation()
-        e.nativeEvent.stopImmediatePropagation()
-      }}>
-      <div className={handles.autoCompleteOuterContainer}>
-        <div className={classContainer}>
-        <InputSearch 
-            ref={inputRef}
-            size="large"
-            value={value}
-            {...restProps}          
-          />
+      <form
+        action="#"
+        onSubmit={e => {
+          e.preventDefault()
+          e.stopPropagation()
+          e.nativeEvent.stopImmediatePropagation()
+        }}
+      >
+        <div className={handles.autoCompleteOuterContainer}>
+          <div className={classContainer}>
+            <InputSearch
+              ref={inputRef}
+              size="large"
+              value={value}
+              {...restProps}
+            />
+          </div>
         </div>
-      </div>
       </form>
-    )  
+    )
   }
 
-  return (    
+  return (
     <div className={handles.autoCompleteOuterContainer}>
-      <div className={classContainer}>               
+      <div className={classContainer}>
         <Input
           ref={inputRef}
           size="large"
@@ -252,7 +254,7 @@ AutocompleteInput.propTypes = {
   /** Error message showed in search input */
   inputErrorMessage: PropTypes.string,
   /** If true, the autocomplete will be an input type search */
-  searchInput: PropTypes.bool
+  searchInput: PropTypes.bool,
 }
 
 export default AutocompleteInput

--- a/react/components/SearchBar/components/AutocompleteInput.js
+++ b/react/components/SearchBar/components/AutocompleteInput.js
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { InputSearch } from 'vtex.styleguide'
+import { Input, InputSearch } from 'vtex.styleguide'
 import { ExtensionPoint, useChildBlock } from 'vtex.render-runtime'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { IconSearch, IconClose } from 'vtex.store-icons'
@@ -58,6 +58,7 @@ const AutocompleteInput = ({
   displayMode = 'clear-button',
   openMenu,
   inputErrorMessage,
+  searchInput,
   ...restProps
 }) => {
   const inputRef = useRef(null)
@@ -171,21 +172,31 @@ const AutocompleteInput = ({
     [handles.compactMode]: compactMode,
   })
 
-  return (
-    <form action="#" onSubmit={e => {
-      e.preventDefault()
-      e.stopPropagation()
-      e.nativeEvent.stopImmediatePropagation()
-    }}>
+
+  if(searchInput){
+    return (
+      <form action="#" onSubmit={e => {
+        e.preventDefault()
+        e.stopPropagation()
+        e.nativeEvent.stopImmediatePropagation()
+      }}>
+      <div className={handles.autoCompleteOuterContainer}>
+        <div className={classContainer}>
+        <InputSearch 
+            ref={inputRef}
+            size="large"
+            value={value}
+            {...restProps}          
+          />
+        </div>
+      </div>
+      </form>
+    )  
+  }
+
+  return (    
     <div className={handles.autoCompleteOuterContainer}>
-      <div className={classContainer}>
-      <InputSearch 
-          ref={inputRef}
-          size="large"
-          value={value}
-          {...restProps}          
-        />
-        {/*        
+      <div className={classContainer}>               
         <Input
           ref={inputRef}
           size="large"
@@ -195,10 +206,9 @@ const AutocompleteInput = ({
           {...restProps}
           error={Boolean(inputErrorMessage)}
           errorMessage={inputErrorMessage}
-        /> */}
+        />
       </div>
     </div>
-    </form>
   )
 }
 
@@ -241,6 +251,8 @@ AutocompleteInput.propTypes = {
   displayMode: PropTypes.oneOf(DISPLAY_MODES),
   /** Error message showed in search input */
   inputErrorMessage: PropTypes.string,
+  /** If true, the autocomplete will be an input type search */
+  searchInput: PropTypes.bool
 }
 
 export default AutocompleteInput

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -50,6 +50,7 @@ const SearchBar = ({
   displayMode,
   minSearchTermLength,
   autocompleteFullWidth,
+  searchInput
 }) => {
   const intl = useIntl()
   const container = useRef()
@@ -206,6 +207,7 @@ const SearchBar = ({
                 submitOnIconClick={submitOnIconClick}
                 displayMode={displayMode}
                 openAutocompleteOnFocus={openAutocompleteOnFocus}
+                searchInput={searchInput}
                 openMenu={openMenu}
                 inputErrorMessage={inputErrorMessage}
                 {...getInputProps({
@@ -308,6 +310,8 @@ SearchBar.propTypes = {
   minSearchTermLength: PropTypes.number,
   /** If true, the autocomplete will fill the whole window horizontally */
   autocompleteFullWidth: PropTypes.bool,
+  /** If true, the autocomplete will be an input type search */
+  searchInput: PropTypes.bool
 }
 
 export default SearchBar

--- a/react/components/SearchBar/components/SearchBar.js
+++ b/react/components/SearchBar/components/SearchBar.js
@@ -50,7 +50,7 @@ const SearchBar = ({
   displayMode,
   minSearchTermLength,
   autocompleteFullWidth,
-  searchInput
+  searchInput,
 }) => {
   const intl = useIntl()
   const container = useRef()
@@ -311,7 +311,7 @@ SearchBar.propTypes = {
   /** If true, the autocomplete will fill the whole window horizontally */
   autocompleteFullWidth: PropTypes.bool,
   /** If true, the autocomplete will be an input type search */
-  searchInput: PropTypes.bool
+  searchInput: PropTypes.bool,
 }
 
 export default SearchBar

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -32,6 +32,7 @@ function SearchBarContainer(props) {
     displayMode = 'clear-button',
     minSearchTermLength,
     autocompleteFullWidth = false,
+    searchInput = false
   } = props
 
   const modalDispatch = useModalDispatch()
@@ -115,6 +116,7 @@ function SearchBarContainer(props) {
       displayMode={displayMode}
       minSearchTermLength={minSearchTermLength}
       autocompleteFullWidth={autocompleteFullWidth}
+      searchInput={searchInput}
     />
   )
 }
@@ -154,6 +156,8 @@ SearchBarContainer.propTypes = {
   minSearchTermLength: PropTypes.number,
   /** If true, the autocomplete will fill the whole window horizontally */
   autocompleteFullWidth: PropTypes.bool,
+  /** If true, the autocomplete will be an input type search */
+  searchInput: PropTypes.bool
 }
 
 export default SearchBarContainer

--- a/react/components/SearchBar/index.js
+++ b/react/components/SearchBar/index.js
@@ -32,7 +32,7 @@ function SearchBarContainer(props) {
     displayMode = 'clear-button',
     minSearchTermLength,
     autocompleteFullWidth = false,
-    searchInput = false
+    searchInput = false,
   } = props
 
   const modalDispatch = useModalDispatch()
@@ -157,7 +157,7 @@ SearchBarContainer.propTypes = {
   /** If true, the autocomplete will fill the whole window horizontally */
   autocompleteFullWidth: PropTypes.bool,
   /** If true, the autocomplete will be an input type search */
-  searchInput: PropTypes.bool
+  searchInput: PropTypes.bool,
 }
 
 export default SearchBarContainer


### PR DESCRIPTION
#### What problem is this solving?
First of all, it's about the AutcompleteInput component.
My solution solves the problem when you click on the 'ok' button then disappears the results block
Also, it allows to have a 'Search button' on the iOs virtual keyboard.

<!--- What is the motivation and context for this change? -->
It's because my customers on iOs doesn't understand what happens. They search something, a block appears and shows a product list but when they click on the 'ok' button, the search input lost the focus and disappears the results block. So, my changes can solve 

that.

#### How to test it?
You can test it on https://drimtest2--drimjuguetes.myvtex.com/ 

[Workspace](Link goes here!)

#### Screenshots or example usage:
![PullRequestAutoCompleInput](https://user-images.githubusercontent.com/32361926/99385823-cf87ee00-28d1-11eb-8dc9-c6449c708b0f.jpg)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
BEFORE: 
   For example, you can reproduce the problem on https://www.loja.philips.pt/
AFTER:
   With my changes you can test it on https://drimtest2--drimjuguetes.myvtex.com/ 

#### How does this PR make you feel? [:link:](http://giphy.com/)
https://media.giphy.com/media/mgqefqwSbToPe/giphy.gif

