### PR TITLE
Add preload on ProductImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Preload main image of `ProductImages`
 
 ## [3.134.0] - 2020-12-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Preload main image of `ProductImages`
+- Preload main image of `ProductImages`.
 
 ## [3.134.0] - 2020-12-08
 ### Added

--- a/react/AutocompleteResults.tsx
+++ b/react/AutocompleteResults.tsx
@@ -219,7 +219,7 @@ function AutocompleteResults({
                   // eslint-disable-next-line jsx-a11y/anchor-is-valid
                   <a
                     href="#"
-                    onClick={(event) => event.preventDefault()}
+                    onClick={event => event.preventDefault()}
                     className={getListItemClassNames({
                       itemIndex: 0,
                       highlightedIndex,

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -159,6 +159,7 @@ class Carousel extends Component {
       case 'image':
         return (
           <ProductImage
+            index={i}
             src={slide.url}
             alt={slide.alt}
             maxHeight={maxHeight}

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -13,6 +13,7 @@ const DEFAULT_SIZE = 800
 const MAX_SIZE = 2048
 
 interface Props {
+  index: number
   src: string
   alt: string
   zoomMode: ZoomMode
@@ -27,6 +28,7 @@ type AspectRatio = string | number
 const CSS_HANDLES = ['productImage', 'productImageTag']
 
 const ProductImage: FC<Props> = ({
+  index,
   src,
   alt,
   zoomFactor = 2,
@@ -87,6 +89,7 @@ const ProductImage: FC<Props> = ({
         >
           <img
             ref={imageRef}
+            data-vtex-preload={index === 0 ? 'true' : 'false'}
             className={`${applyModifiers(handles.productImageTag, 'main')}`}
             style={{
               width: '100%',
@@ -98,7 +101,7 @@ const ProductImage: FC<Props> = ({
             srcSet={srcSet}
             alt={alt}
             title={alt}
-            loading="lazy"
+            loading={index === 0 ? 'eager' : 'lazy'}
             // WIP
             // The value of the "sizes" attribute means: if the window has at most 64.1rem of width,
             // the image will be of a width of 100vw. Otherwise, the

--- a/react/components/SearchBar/AutocompleteInput.tsx
+++ b/react/components/SearchBar/AutocompleteInput.tsx
@@ -224,7 +224,7 @@ function AutocompleteInput({
     return (
       <form
         action="#"
-        onSubmit={(e) => {
+        onSubmit={e => {
           e.preventDefault()
           e.stopPropagation()
           e.nativeEvent.stopImmediatePropagation()

--- a/react/components/SearchBar/SearchBar.tsx
+++ b/react/components/SearchBar/SearchBar.tsx
@@ -122,7 +122,7 @@ function SearchBar({
   }, [debouncedSetSearchTerm, inputValue])
 
   const onSelect = useCallback(
-    (element) => {
+    element => {
       if (!element) {
         return
       }
@@ -271,7 +271,7 @@ function SearchBar({
                 openMenu={openMenu}
                 inputErrorMessage={inputErrorMessage}
                 {...getInputProps({
-                  onKeyDown: (event) => {
+                  onKeyDown: event => {
                     // Only call default search function if user doesn't
                     // have any item highlighted in the menu options
                     if (event.key === 'Enter' && highlightedIndex === null) {
@@ -296,6 +296,7 @@ function SearchBar({
                   placeholder,
                   value: inputValue,
                   onChange: onInputChange,
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                   // @ts-expect-error this exists
                   onFocus: openAutocompleteOnFocus ? openMenu : undefined,
                 })}


### PR DESCRIPTION
#### What problem is this solving?

The main image of the `ProductImage`component is the most important content on the PDP. So, the ideia is to prioritize it's loading.

#### How to test it?

[workspace here](https://vitorflg2--dzarm.myvtex.com/camiseta-masculina-slim-tie-dye-6r8c1aen/p?v=30
)
#### Screenshots or example usage:
Before:
<img width="1200" alt="Screen Shot 2020-12-04 at 1 56 13 PM" src="https://user-images.githubusercontent.com/13058968/101192676-2e6f9600-363a-11eb-9a38-89c97a134212.png">

After:
<img width="1247" alt="Screen Shot 2020-12-04 at 1 55 56 PM" src="https://user-images.githubusercontent.com/13058968/101192836-6b3b8d00-363a-11eb-8794-895f1912acb0.png">

<img width="1220" alt="Screen Shot 2020-12-04 at 1 55 40 PM" src="https://user-images.githubusercontent.com/13058968/101192860-755d8b80-363a-11eb-98f3-a97ef2062289.png">

#### Describe alternatives you've considered, if any.

X

#### Related to / Depends on

X

#### How does this PR make you feel? [:link:](http://giphy.com/)

No feelings, :sad-cat: