### PR TITLE
Adding withLink prop to ProductBrand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `withLink` prop on `ProductBrand`. It controls in which cases the component should link to the brand's page.
+### Changed
+- `logoWithLink` prop on `ProductBrand` is now deprecated.
 
 ## [3.135.0] - 2020-12-08
 ### Changed

--- a/docs/ProductBrand.md
+++ b/docs/ProductBrand.md
@@ -41,15 +41,16 @@ The `ProductBrand` is a VTEX block that displays either the **name** or the **lo
 
 ### Configuration
 
-| Prop name | Type | Description |
-| --- | --- | --- |
-| `displayMode` | `String` | You should choose between `logo` or `text`. This will define if the product brand will be displayed by name or logo. |
-| `fallbackToText` | `Boolean` |  This prop should only be used when `displayMode` is set to `logo`. It defines what should be done when the Product Brand was set to display a brand logo but no image was registered in the VTEX admin's Catalog. This prop is set as `true` by default, allowing the logo to be replaced with the brand name in those scenarios. When set as `false`, the store will not show the brand name instead of the brand logo. |
-| `height` | `Number` | It sets the logo height. It should only be used when `displayMode` is set to `logo`. |
-| `excludeBrands` | `Array` | The brand names or brand IDs listed in the array will never be displayed by the Brand component. It is usually useful to hide default or test brand names/logos on the store front. |
-| `logoWithLink` | `boolean` | If the brand logo will have a link that leads to the store's brand page (`true`) ou not (`false`) |
-| `brandName` | `String` | The brand name. If this value is not passed, it will be obtained through the product context. |
-| `brandId` | `Number` | The brand id. If this value is not passed, it will be obtained through the product context. |
+| Prop name | Type | Description | Default value 
+| --- | --- | --- | --- |
+| `displayMode` | `String` | You should choose between `logo` or `text`. This will define if the product brand will be displayed by name or logo. | `logo` |
+| `fallbackToText` | `Boolean` |  This prop should only be used when `displayMode` is set to `logo`. It defines what should be done when the Product Brand was set to display a brand logo but no image was registered in the VTEX admin's Catalog. This prop is set as `true` by default, allowing the logo to be replaced with the brand name in those scenarios. When set as `false`, the store will not show the brand name instead of the brand logo. | `true` |
+| `height` | `Number` | It sets the logo height. It should only be used when `displayMode` is set to `logo`. | `100` |
+| `excludeBrands` | `Array` | The brand names or brand IDs listed in the array will never be displayed by the Brand component. It is usually useful to hide default or test brand names/logos on the store front. | `undefined` |
+| `logoWithLink` | `boolean` | ![https://img.shields.io/badge/-Deprecated-red](https://img.shields.io/badge/-Deprecated-red) Use withLink instead | `false` |
+| `withLink` | `none | logo | text | logoAndText` | In which cases the brand will have a link that leads to the store's brand page. | `none` |
+| `brandName` | `String` | The brand name. If this value is not passed, it will be obtained through the product context. | `undefined` |
+| `brandId` | `Number` | The brand id. If this value is not passed, it will be obtained through the product context. | `undefined` |
 
 ## Customization 
 
@@ -62,5 +63,6 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `productBrandLogo` |
 | `productBrandLogoWrapper` |
 | `productBrandLogoLink` |
+| `productBrandNameLink` |
 | `productBrandLogoSpacer` |
 | `productBrandNameSpacer` |

--- a/docs/ProductBrand.md
+++ b/docs/ProductBrand.md
@@ -43,14 +43,14 @@ The `ProductBrand` is a VTEX block that displays either the **name** or the **lo
 
 | Prop name | Type | Description | Default value 
 | --- | --- | --- | --- |
-| `displayMode` | `String` | You should choose between `logo` or `text`. This will define if the product brand will be displayed by name or logo. | `logo` |
-| `fallbackToText` | `Boolean` |  This prop should only be used when `displayMode` is set to `logo`. It defines what should be done when the Product Brand was set to display a brand logo but no image was registered in the VTEX admin's Catalog. This prop is set as `true` by default, allowing the logo to be replaced with the brand name in those scenarios. When set as `false`, the store will not show the brand name instead of the brand logo. | `true` |
-| `height` | `Number` | It sets the logo height. It should only be used when `displayMode` is set to `logo`. | `100` |
-| `excludeBrands` | `Array` | The brand names or brand IDs listed in the array will never be displayed by the Brand component. It is usually useful to hide default or test brand names/logos on the store front. | `undefined` |
+| `displayMode` | `string` | You should choose between `logo` or `text`. This will define if the product brand will be displayed by name or logo. | `logo` |
+| `fallbackToText` | `boolean` |  This prop should only be used when `displayMode` is set to `logo`. It defines what should be done when the Product Brand was set to display a brand logo but no image was registered in the VTEX admin's Catalog. This prop is set as `true` by default, allowing the logo to be replaced with the brand name in those scenarios. When set as `false`, the store will not show the brand name instead of the brand logo. | `true` |
+| `height` | `number` | It sets the logo height. It should only be used when `displayMode` is set to `logo`. | `100` |
+| `excludeBrands` | `array` | The brand names or brand IDs listed in the array will never be displayed by the Brand component. It is usually useful to hide default or test brand names/logos on the store front. | `undefined` |
 | `logoWithLink` | `boolean` | ![https://img.shields.io/badge/-Deprecated-red](https://img.shields.io/badge/-Deprecated-red) Use withLink instead | `false` |
-| `withLink` | `none | logo | text | logoAndText` | In which cases the brand will have a link that leads to the store's brand page. | `none` |
-| `brandName` | `String` | The brand name. If this value is not passed, it will be obtained through the product context. | `undefined` |
-| `brandId` | `Number` | The brand id. If this value is not passed, it will be obtained through the product context. | `undefined` |
+| `withLink` | `enum` | Defines the scenarios in which the product brand should have a link that leads to its website. Possible values are: `none` (never includes the link), `logo` (includes the link whenever the brand logo is displayed), `text` (includes the link whenever the brand name is displayed), and `logoAndText` (includes the link whenever the brand logo or the brand name is displayed).  | `none` |
+| `brandName` | `string` | The brand name. If no value is declared, the product context should provide the data. | `undefined` |
+| `brandId` | `number` | The brand ID.  If no value is declared, the product context should provide the data. | `undefined` |
 
 ## Customization 
 

--- a/react/ProductBrand.tsx
+++ b/react/ProductBrand.tsx
@@ -3,10 +3,12 @@ import { useQuery } from 'react-apollo'
 import { useProduct } from 'vtex.product-context'
 import { useCssHandles } from 'vtex.css-handles'
 
+import ProductBrandName from './components/ProductBrand/ProductBrandName'
 import { changeImageUrlSize } from './utils/imgUrlHelpers'
 import brandLogoQuery from './graphql/productBrand.gql'
 
 type DisplayModeOptions = 'logo' | 'text'
+type WithLinkOptions = 'none' | 'logo' | 'text' | 'logoAndText'
 
 interface Props {
   /** Brand name */
@@ -25,7 +27,10 @@ interface Props {
   height?: number
   /** CSS Handler */
   blockClass?: string
-  logoWithLink: boolean
+  /** @deprecated use withLink instead */
+  logoWithLink?: boolean
+  /** Whether it should link to the brand's page */
+  withLink?: WithLinkOptions
 }
 
 interface ProductBrandQueryVariables {
@@ -33,18 +38,19 @@ interface ProductBrandQueryVariables {
 }
 
 interface ProductBrandQueryResult {
-  brand: {
+  brand?: {
     imageUrl: string | null
     slug: string
   }
 }
 
-const CSS_HANDLES = [
+export const PRODUCT_BRAND_CSS_HANDLES = [
   'productBrandContainer',
   'productBrandName',
   'productBrandLogo',
   'productBrandLogoWrapper',
   'productBrandLogoLink',
+  'productBrandNameLink',
   'productBrandLogoSpacer',
   'productBrandNameSpacer',
 ] as const
@@ -89,11 +95,12 @@ function ProductBrand({
   height = 100,
   excludeBrands,
   logoWithLink,
+  withLink = 'none',
   brandName: brandNameProp,
   brandId: brandIdProp,
 }: PropsWithChildren<Props>) {
   const { brandName, brandId } = useBrandInfoProps(brandNameProp, brandIdProp)
-  const handles = useCssHandles(CSS_HANDLES)
+  const handles = useCssHandles(PRODUCT_BRAND_CSS_HANDLES)
 
   const { data, loading, error } = useQuery<
     ProductBrandQueryResult,
@@ -102,6 +109,11 @@ function ProductBrand({
     variables: { id: Number(brandId) },
     ssr: false,
   })
+
+  const logoHasLink =
+    withLink === 'logo' || withLink === 'logoAndText' || Boolean(logoWithLink)
+
+  const nameHasLink = withLink === 'text' || withLink === 'logoAndText'
 
   if (!brandName || !brandId) {
     return null
@@ -113,7 +125,11 @@ function ProductBrand({
   }
 
   const brandNameElement = (
-    <span className={`${handles.productBrandName}`}>{brandName}</span>
+    <ProductBrandName
+      brandName={brandName}
+      withLink={nameHasLink}
+      slug={data?.brand?.slug}
+    />
   )
 
   const BrandContainer: FC = ({ children }) => (
@@ -204,7 +220,7 @@ function ProductBrand({
         className={`${handles.productBrandLogoWrapper}`}
       >
         {/** TODO: Use a smarter Image component that handles VTEX image resizing etc. */}
-        {logoWithLink ? (
+        {logoHasLink ? (
           <a
             href={logoLink}
             className={`${handles.productBrandLogoLink}`}

--- a/react/ProductBrand.tsx
+++ b/react/ProductBrand.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, FC } from 'react'
+import React, { FC } from 'react'
 import { useQuery } from 'react-apollo'
 import { useProduct } from 'vtex.product-context'
 import { useCssHandles } from 'vtex.css-handles'
@@ -10,7 +10,7 @@ import brandLogoQuery from './graphql/productBrand.gql'
 type DisplayModeOptions = 'logo' | 'text'
 type WithLinkOptions = 'none' | 'logo' | 'text' | 'logoAndText'
 
-interface Props {
+export interface ProductBrandProps {
   /** Brand name */
   brandName?: string
   /** Brand id */
@@ -58,7 +58,7 @@ export const PRODUCT_BRAND_CSS_HANDLES = [
 const shouldExcludeBrand = (
   brandName: string,
   brandId: number,
-  excludeList: Props['excludeBrands']
+  excludeList: ProductBrandProps['excludeBrands']
 ) => {
   if (Array.isArray(excludeList)) {
     return excludeList.includes(brandName) || excludeList.includes(brandId)
@@ -98,7 +98,7 @@ function ProductBrand({
   withLink = 'none',
   brandName: brandNameProp,
   brandId: brandIdProp,
-}: PropsWithChildren<Props>) {
+}: ProductBrandProps) {
   const { brandName, brandId } = useBrandInfoProps(brandNameProp, brandIdProp)
   const handles = useCssHandles(PRODUCT_BRAND_CSS_HANDLES)
 

--- a/react/__tests__/components/ProductBrand.test.tsx
+++ b/react/__tests__/components/ProductBrand.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, wait } from '@vtex/test-tools/react'
 
 import ProductBrand from '../../ProductBrand'
+import type { ProductBrandProps } from '../../ProductBrand'
 import brandLogoQuery from '../../graphql/productBrand.gql'
 
 const mocks = [
@@ -23,20 +24,35 @@ const mocks = [
   },
 ]
 
-describe('<ProductBrand /> component', () => {
-  const renderComponent = (logoRedirect: boolean) => {
-    const props = {
-      fallbackToText: true,
-      height: 100,
-      excludeBrands: [],
-      logoWithLink: logoRedirect,
-    }
+const mocksWithoutImage = [
+  {
+    request: {
+      query: brandLogoQuery,
+      variables: {
+        id: 2000850,
+      },
+    },
+    result: {
+      data: {
+        brand: {
+          slug: 'billabong',
+        },
+      },
+    },
+  },
+]
 
-    const comp = (
-      <ProductBrand {...props} displayMode="logo" loadingPlaceholder="logo" />
-    )
+describe('<ProductBrand /> component', () => {
+  const renderComponent = (props: ProductBrandProps) => {
+    const comp = <ProductBrand {...props} loadingPlaceholder="logo" />
 
     return render(comp, { graphql: { mocks } })
+  }
+
+  const renderComponentWithoutImage = (props: ProductBrandProps) => {
+    const comp = <ProductBrand {...props} loadingPlaceholder="logo" />
+
+    return render(comp, { graphql: { mocks: mocksWithoutImage } })
   }
 
   beforeEach(() => {
@@ -44,21 +60,106 @@ describe('<ProductBrand /> component', () => {
   })
 
   it('brand image should not have a link', async () => {
-    const { queryByTestId } = renderComponent(false)
+    const { queryByTestId } = renderComponent({})
 
     await wait(() => {
       jest.runAllTimers()
     })
+
     expect(queryByTestId('logo-redirect')).toBeNull()
+    expect(queryByTestId('name-redirect')).toBeNull()
   })
 
-  it('brand image should have a link', async () => {
-    const { getByTestId } = renderComponent(true)
+  it('brand image should be backwards compatible and have a link', async () => {
+    const { queryByTestId } = renderComponent({
+      logoWithLink: true,
+    })
 
     await wait(() => {
       jest.runAllTimers()
     })
 
-    expect(getByTestId('logo-redirect')).toBeDefined()
+    expect(queryByTestId('logo-redirect')).toBeDefined()
+    expect(queryByTestId('name-redirect')).toBeNull()
+  })
+
+  it('brand text should have a link', async () => {
+    const { queryByTestId } = renderComponent({
+      withLink: 'text',
+      displayMode: 'text',
+    })
+
+    await wait(() => {
+      jest.runAllTimers()
+    })
+
+    expect(queryByTestId('logo-redirect')).toBeNull()
+    expect(queryByTestId('name-redirect')).toBeDefined()
+  })
+
+  it('brand text should have a link when withLink equals logoAndText', async () => {
+    const { queryByTestId } = renderComponent({
+      withLink: 'logoAndText',
+      displayMode: 'text',
+    })
+
+    await wait(() => {
+      jest.runAllTimers()
+    })
+
+    expect(queryByTestId('logo-redirect')).toBeNull()
+    expect(queryByTestId('name-redirect')).toBeDefined()
+  })
+
+  it('brand image should have a link when withLink equals logoAndText', async () => {
+    const { queryByTestId } = renderComponent({
+      withLink: 'logoAndText',
+    })
+
+    await wait(() => {
+      jest.runAllTimers()
+    })
+
+    expect(queryByTestId('logo-redirect')).toBeDefined()
+    expect(queryByTestId('name-redirect')).toBeNull()
+  })
+
+  it('brand should fallback to text and not have a link when withLinks equals logo', async () => {
+    const { queryByTestId } = renderComponentWithoutImage({
+      withLink: 'logo',
+    })
+
+    await wait(() => {
+      jest.runAllTimers()
+    })
+
+    expect(queryByTestId('logo-redirect')).toBeNull()
+    expect(queryByTestId('name-redirect')).toBeNull()
+  })
+
+  it('brand should fallback to text and have a link when withLinks equals text', async () => {
+    const { queryByTestId } = renderComponentWithoutImage({
+      withLink: 'text',
+    })
+
+    await wait(() => {
+      jest.runAllTimers()
+    })
+
+    expect(queryByTestId('logo-redirect')).toBeNull()
+    expect(queryByTestId('name-redirect')).toBeDefined()
+  })
+
+  it('brand should fallback to text and have a text link when withLink equals logoAndText', async () => {
+    const { queryByTestId } = renderComponentWithoutImage({
+      withLink: 'logoAndText',
+    })
+
+    await wait(() => {
+      jest.runAllTimers()
+    })
+
+    expect(queryByTestId('logo-redirect')).toBeNull()
+    expect(queryByTestId('name-redirect')).toBeDefined()
   })
 })

--- a/react/components/ProductBrand/ProductBrandName.tsx
+++ b/react/components/ProductBrand/ProductBrandName.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+
+import { PRODUCT_BRAND_CSS_HANDLES } from '../../ProductBrand'
+
+interface Props {
+  brandName: string
+  withLink: boolean
+  slug?: string
+}
+
+function ProductBrandName({ brandName, withLink, slug }: Props) {
+  const handles = useCssHandles(PRODUCT_BRAND_CSS_HANDLES)
+
+  if (withLink && slug) {
+    const nameLink = `/${slug}/b`
+
+    return (
+      <a
+        href={nameLink}
+        className={`${handles.productBrandNameLink}`}
+        data-testid="name-redirect"
+      >
+        <span className={`${handles.productBrandName}`}>{brandName}</span>
+      </a>
+    )
+  }
+
+  return <span className={`${handles.productBrandName}`}>{brandName}</span>
+}
+
+export default ProductBrandName


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the ability to use links when the ProductBrand mode is set to `text` or fallback to text by using the `withLink` prop. It also deprecates the previous `logoWithLink` prop in favor of the new, more flexible one.

#### How to test it?

Any product on this [workspace](https://icaroproductbrand--storecomponents.myvtex.com/).

#### Screenshots or example usage:

<img width="462" alt="Screen Shot 2020-12-04 at 3 10 14 PM" src="https://user-images.githubusercontent.com/8127610/101198820-d1c4a900-3642-11eb-822c-384eecd2a233.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/NVBR6cLvUjV9C/giphy.gif)
