### PR TITLE
Added new classes to 'sku-selector' component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added 
+- new classes to `sku-selector` component
+
 ## [3.138.1] - 2020-12-28
 ### Changed
 - Makes search placeholder translatable

--- a/docs/SKUSelector.md
+++ b/docs/SKUSelector.md
@@ -80,6 +80,8 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `seeMoreButton`                 |
 | `skuSelectorContainer`          |
 | `skuSelectorInternalBox`        |
+| `skuItemAvailable`              |
+| `skuItemNotAvailable`           |
 | `skuSelectorItemImageValue`     |
 | `skuSelectorItemImage`          |
 | `skuSelectorItemTextValue`      |

--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -1,4 +1,5 @@
-import React, { memo, SyntheticEvent, useMemo } from 'react'
+import type { SyntheticEvent } from 'react'
+import React, { memo, useMemo } from 'react'
 import classNames from 'classnames'
 import { FormattedNumber } from 'react-intl'
 
@@ -36,6 +37,8 @@ export const CSS_HANDLES = [
   'frameAround',
   'valueWrapper',
   'diagonalCross',
+  'skuItemAvailable',
+  'skuItemNotAvailable',
   'skuSelectorItem',
   'skuSelectorBadge',
   'skuSelectorItemImage',
@@ -110,7 +113,9 @@ function SelectorItem({
       tabIndex={0}
       onClick={onClick}
       style={containerStyles}
-      className={containerClasses}
+      className={`${containerClasses} ${
+        !isAvailable ? handles.skuItemNotAvailable : handles.skuItemAvailable
+      }`}
       onKeyDown={e => e.key === 'Enter' && onClick(e)}
     >
       <div


### PR DESCRIPTION
#### What problem is this solving?

Insert class in the sku-selector component if the item is available or not.

#### How to test it?

1. Access the available workspace link;

2. See in the HTML structure of the SKUs which different classes will be available depending on the availability of the SKU option.

[Workspace](https://task186--tackoftheday.myvtex.com/weatherbeeta-comfitec-parka-1200d-deluxe-dog-coat-navylime-bnx101725-navylime/p)

#### Screenshots or example usage:

![sku-item-available](https://user-images.githubusercontent.com/55210107/103305746-b1420180-49ea-11eb-82ee-bdef5e085e88.png)

![sku-item-not-available](https://user-images.githubusercontent.com/55210107/103305750-b3a45b80-49ea-11eb-86fc-fbc894482429.png)
