### PR TITLE
Add new keys to product-images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New keys to `product-images`.It prevent render problems when prefetch is enabled.
 
 ## [3.138.1] - 2020-12-28
 ### Changed
@@ -94,7 +96,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.131.3] - 2020-11-13
 ### Fixed
 - Navigating between product images using thumbnails was not working 
-
 
 ## [3.131.2] - 2020-11-10
 ### Changed

--- a/react/components/ProductImages/components/Video/index.js
+++ b/react/components/ProductImages/components/Video/index.js
@@ -32,10 +32,10 @@ function Video(props) {
     <div className={handles.productVideo}>
       {isVimeo(url) && (
         <NoSSR>
-          <Vimeo {...props} cssHandles={handles} />
+          <Vimeo key={url} {...props} cssHandles={handles} />
         </NoSSR>
       )}
-      {isYoutube(url) && <YouTube {...props} cssHandles={handles} />}
+      {isYoutube(url) && <YouTube key={url} {...props} cssHandles={handles} />}
     </div>
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

This is an alternative and a simplest solution for the prefetch problem explained at this [PR](https://github.com/vtex-apps/product-context/pull/46). The first solution was a try to correctly update the first render when the flag is enabled, but even though it was working at the most stores, that not works in all of them(Some problem with Swiper lib and the time the state gets updated). So I have tested a new solution that basically adds keys to the components that are not being re-mounted due react reconciliation(when prefetch is enabled, sometimes the context of the tree gets lost). So I'm explicitly saying to re-mount when the src of the video players(`product-images`) changes.

#### How to test it?

The process below was done at Exito, Samsung, Carrefour, Muji and Polishop..

1) Go to [https://vitorflg--polishop.myvtex.com/aparador-multigroom-evolution-philips/p](https://vitorflg--polishop.myvtex.com/aparador-multigroom-evolution-philips/p)
2) Click on the search icon
3) Search for `airfryer`
4) Hover the airfryer product link for at least 5 seconds and click on it
<img width="1385" alt="Screen Shot 2020-12-21 at 11 10 33 AM" src="https://user-images.githubusercontent.com/13058968/102785742-3428e380-437d-11eb-8d0e-12ffa0ec6f96.png">
5. The video and the images should be ok, with the right data

#### Screenshots or example usage:

X

#### Describe alternatives you've considered, if any.

The alternative is to fix the first render data, explained [here](https://github.com/vtex-apps/product-context/pull/46)

#### Related to / Depends on

<!--- Optional -->

X

![https://media.giphy.com/media/xT0xeyDaXy0vVDwR8I/giphy.gif](https://media.giphy.com/media/xT0xeyDaXy0vVDwR8I/giphy.gif)
