### PR TITLE
Feature/thumb vid class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `thumbVid` cssHandles aditional class on `Product Image` to differ video thumbnails from image thumbnails
+
 ## [3.138.3] - 2021-01-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `thumbVid` cssHandles aditional class on `Product Image` to differ video thumbnails from image thumbnails
+- Modifier `video` to CSS Handle `thumbImg` on `Product Image` to differ video thumbnails from image thumbnails.
 
 ## [3.138.3] - 2021-01-13
 

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -151,6 +151,7 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `swiperCaretNext` |
 | `swiperCaretPrev` |
 | `thumbImg` |
+| `thumbVid` |
 | `video` |
 | `video`|
 | `videoContainer` |

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -151,7 +151,7 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `swiperCaretNext` |
 | `swiperCaretPrev` |
 | `thumbImg` |
-| `thumbVid` |
+| `thumbImg--video` |
 | `video` |
 | `video`|
 | `videoContainer` |

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useMemo } from 'react'
 import classNames from 'classnames'
-import { useCssHandles } from 'vtex.css-handles'
+import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import { IconCaret } from 'vtex.store-icons'
 
@@ -33,7 +33,10 @@ const Thumbnail = props => {
         itemType="http://schema.org/ImageObject"
       >
         <img
-          className={`${handles.thumbImg} ${isVideo ? handles.thumbVid : ''} w-100 h-auto db`}
+          className={`${applyModifiers(
+            handles.thumbImg,
+            isVideo ? 'video' : null
+          )} w-100 h-auto db`}
           itemProp="thumbnail"
           alt={alt}
           src={imageUrl(thumbUrl, THUMB_SIZE, THUMB_MAX_SIZE, aspectRatio)}
@@ -68,7 +71,6 @@ const ThumbnailSwiper = props => {
   } = props
 
   const hasThumbs = slides.length > 1
-
 
   const thumbClassName = classNames(
     `${handles.carouselGaleryThumbs} dn h-auto`,

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -14,6 +14,7 @@ const THUMB_MAX_SIZE = 256
 const CSS_HANDLES = [
   'figure',
   'thumbImg',
+  'thumbVid',
   'productImagesThumb',
   'carouselThumbBorder',
   'carouselGaleryThumbs',
@@ -21,7 +22,7 @@ const CSS_HANDLES = [
 ]
 
 const Thumbnail = props => {
-  const { alt, thumbUrl, handles, aspectRatio = 'auto' } = props
+  const { alt, isVideo, thumbUrl, handles, aspectRatio = 'auto' } = props
 
   return (
     <>
@@ -32,7 +33,7 @@ const Thumbnail = props => {
         itemType="http://schema.org/ImageObject"
       >
         <img
-          className={`${handles.thumbImg} w-100 h-auto db`}
+          className={`${handles.thumbImg} ${isVideo ? handles.thumbVid : ''} w-100 h-auto db`}
           itemProp="thumbnail"
           alt={alt}
           src={imageUrl(thumbUrl, THUMB_SIZE, THUMB_MAX_SIZE, aspectRatio)}
@@ -67,6 +68,7 @@ const ThumbnailSwiper = props => {
   } = props
 
   const hasThumbs = slides.length > 1
+
 
   const thumbClassName = classNames(
     `${handles.carouselGaleryThumbs} dn h-auto`,
@@ -171,6 +173,7 @@ const ThumbnailSwiper = props => {
               }}
             >
               <Thumbnail
+                isVideo={slide.type === 'video'}
                 index={i}
                 handles={handles}
                 alt={slide.alt}


### PR DESCRIPTION
#### What problem is this solving?

I'm adding a aditional className to a thumbnail when it links to a video, such as following:
![image](https://user-images.githubusercontent.com/51974587/104949048-127f4400-599d-11eb-94a4-f32067b2a492.png)


#### How to test it?

I've linked this feature in a workspace down below directly to a product that has both a video and a image. A video thumbnail should have a aditional thumbVid class on it.

![thumbVid](https://user-images.githubusercontent.com/51974587/104948570-46a63500-599c-11eb-8c54-a27e2ea06c05.gif)

[Workspace](https://carafizi--acctglobal.myvtex.com/luiz/p)

#### Screenshots or example usage:

A simple "play" button added using CSS over the thumbnail so a user knows its links to a video.

![image](https://user-images.githubusercontent.com/51974587/104948706-7bb28780-599c-11eb-97a4-430646fc0b40.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![image](https://user-images.githubusercontent.com/51974587/104948952-e2d03c00-599c-11eb-9a61-5a0e8fc06be5.png)