### PR TITLE
Added displayMode 'first-image' and 'showThumbnails' prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `first-image` option for the `displayMode` prop of `product-images`.
+- Added `thumbnailVisibility` prop to `product-images`. When `dysplayMode` is set to `carousel` (default value), it adds the option to hide the thumbnails.
 
 ## [3.151.2] - 2021-08-26
 
@@ -65,7 +68,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.143.1] - 2021-04-28
 ### Fixed
 - Makes main SearchBar placeholder translatable
-
 ## [3.143.0] - 2021-04-19
 ### Added
 - CSS handle class for image link wrapper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.143.1] - 2021-04-28
 ### Fixed
 - Makes main SearchBar placeholder translatable
+
 ## [3.143.0] - 2021-04-19
 ### Added
 - CSS handle class for image link wrapper.

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -47,6 +47,7 @@
 | `position`                | `Enum`    | Set the position of the thumbnails (`left` or `right`). Only used when `thumbnailsOrientation` is `vertical` | `left`        |
 | `showNavigationArrows`             | `boolean`                                   | Controls if the navigation arrows should appear | `true`          |
 | `showPaginationDots`             | `boolean`                                   | Controls if the pagination dots should appear | `true`          |
+| `showThumbnails`             | `boolean`                                   | Controls if the thumbnails should appear in `carousel` displayMode | `true`          |
 | `thumbnailAspectRatio`             | `string`                                   | Sets the aspect ratio of the thumbnail image; For more information about aspect ratio, check the `aspectRatio` prop | `"auto"`          |
 | `thumbnailMaxHeight`             | `number`                                   | Maximum height for the thumbnail image (in pixels). | `150`          |
 | `thumbnailsOrientation`   | `Enum`    | Choose the orientation of the thumbnails. Can be set to `vertical` or `horizontal`                                 | `vertical`    | 
@@ -54,7 +55,7 @@
 | `zoomMode` | `enum` | Defines the image zoom behavior. Possible values are: `disabled` (zoom is disabled), `in-place-click`(zoom will be triggered when the image is clicked on), `in-place-hover`(zoom will be triggered when the image is hovered on)  or `open-modal` (image is zoommed using a modal). | `in-place-click` |
 | `ModalZoom` | `block` | Opens a modal for product image zooming. This prop's value must match the name of the block responsible for triggering the modal containing the product image for zooming (e.g. `modal-layout` from [Modal layout](https://vtex.io/docs/components/all/vtex.modal-layout/) app). Notice that the `ModalZoom` prop will work only if the `zoomMode` prop is set as `open-modal`. To learn more, check out the [Advanced Configuration section](#Advanced-Configuration). | `undefined` |
 | `contentType` | `enum` | Controls the type of content that will be displayed in the block. Possible values are: `images`, `videos`, or `all`. | `all` |
-| `displayMode` | `enum` | Defines how the product media should be displayed. Possible values are `carousel` (displays the product images and videos in a carousel) and `list` (displays only the product images inline, with no extra markup). *Caution*: The `list` value does not display product videos and it is only compatible with the `maxHeight`, `hiddenImages`, `zoomFactor`, `aspectRatio`,`ModalZoomElement`, and `zoomMode` props. | `carousel` |
+| `displayMode` | `enum` | Defines how the product media should be displayed. Possible values are `carousel` (displays the product images and videos in a carousel), `list` (displays only the product images inline, with no extra markup) and `first-image` (displays only the first image available). *Caution*: The `list` and `first-image` values do not display product videos and are only compatible with the `maxHeight`, `hiddenImages`, `zoomFactor`, `aspectRatio`,`ModalZoomElement`, and `zoomMode` props. | `carousel` |
 
 ### Advanced configuration
 

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -47,7 +47,7 @@
 | `position`                | `Enum`    | Set the position of the thumbnails (`left` or `right`). Only used when `thumbnailsOrientation` is `vertical` | `left`        |
 | `showNavigationArrows`             | `boolean`                                   | Controls if the navigation arrows should appear | `true`          |
 | `showPaginationDots`             | `boolean`                                   | Controls if the pagination dots should appear | `true`          |
-| `showThumbnails`             | `boolean`                                   | Controls if the thumbnails should appear in `carousel` displayMode | `true`          |
+| `thumbnailVisibility`             | `visible` or `hidden`                                   | Controls if the thumbnails should appear in `carousel` displayMode | `visible`          |
 | `thumbnailAspectRatio`             | `string`                                   | Sets the aspect ratio of the thumbnail image; For more information about aspect ratio, check the `aspectRatio` prop | `"auto"`          |
 | `thumbnailMaxHeight`             | `number`                                   | Maximum height for the thumbnail image (in pixels). | `150`          |
 | `thumbnailsOrientation`   | `Enum`    | Choose the orientation of the thumbnails. Can be set to `vertical` or `horizontal`                                 | `vertical`    | 

--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -16,7 +16,7 @@ const ProductImagesWrapper = props => {
     showPaginationDots,
     contentOrder,
     placeholder,
-    showThumbnails
+    showThumbnails,
   } = useResponsiveValues(
     pick(
       [

--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -16,6 +16,7 @@ const ProductImagesWrapper = props => {
     showPaginationDots,
     contentOrder,
     placeholder,
+    showThumbnails
   } = useResponsiveValues(
     pick(
       [
@@ -23,6 +24,7 @@ const ProductImagesWrapper = props => {
         'maxHeight',
         'showNavigationArrows',
         'showPaginationDots',
+        'showThumbnails',
         'contentOrder',
         'placeholder',
       ],
@@ -88,6 +90,7 @@ const ProductImagesWrapper = props => {
       thumbnailMaxHeight={props.thumbnailMaxHeight}
       showNavigationArrows={showNavigationArrows}
       showPaginationDots={showPaginationDots}
+      showThumbnails={showThumbnails}
       contentOrder={contentOrder}
       ModalZoomElement={props.ModalZoom}
       contentType={props.contentType}

--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -16,7 +16,6 @@ const ProductImagesWrapper = props => {
     showPaginationDots,
     contentOrder,
     placeholder,
-    showThumbnails,
   } = useResponsiveValues(
     pick(
       [
@@ -24,7 +23,6 @@ const ProductImagesWrapper = props => {
         'maxHeight',
         'showNavigationArrows',
         'showPaginationDots',
-        'showThumbnails',
         'contentOrder',
         'placeholder',
       ],
@@ -90,7 +88,7 @@ const ProductImagesWrapper = props => {
       thumbnailMaxHeight={props.thumbnailMaxHeight}
       showNavigationArrows={showNavigationArrows}
       showPaginationDots={showPaginationDots}
-      showThumbnails={showThumbnails}
+      thumbnailVisibility={props.thumbnailVisibility}
       contentOrder={contentOrder}
       ModalZoomElement={props.ModalZoom}
       contentType={props.contentType}

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -258,11 +258,13 @@ class Carousel extends Component {
         'ml-20-ns w-80-ns pl5-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.LEFT &&
-          ((hasThumbs && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE) || !hasSlides),
+          ((hasThumbs && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE) ||
+            !hasSlides),
         'mr-20-ns w-80-ns pr5-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
-          ((hasThumbs && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE) || !hasSlides),
+          ((hasThumbs && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE) ||
+            !hasSlides),
       }
     )
 
@@ -316,7 +318,9 @@ class Carousel extends Component {
 
     return (
       <div className={containerClasses} aria-hidden="true">
-        {isThumbsVertical && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE && thumbnailSwiper}
+        {isThumbsVertical &&
+          thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE &&
+          thumbnailSwiper}
         <div className={imageClasses}>
           {!this.state.thumbSwiper?.destroyed && (
             <Swiper
@@ -373,7 +377,9 @@ class Carousel extends Component {
             </Swiper>
           )}
 
-          {!isThumbsVertical && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE && thumbnailSwiper}
+          {!isThumbsVertical &&
+            thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE &&
+            thumbnailSwiper}
         </div>
       </div>
     )
@@ -394,7 +400,7 @@ Carousel.propTypes = {
   displayThumbnailsArrows: PropTypes.bool,
   thumbnailVisibility: PropTypes.oneOf([
     THUMBS_VISIBILITY.VISIBLE,
-    THUMBS_VISIBILITY.HIDDEN
+    THUMBS_VISIBILITY.HIDDEN,
   ]),
 }
 

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -290,11 +290,13 @@ class Carousel extends Component {
         'flex-ns justify-end-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.LEFT &&
-          hasThumbs && showThumbnails,
+          hasThumbs &&
+          showThumbnails,
         'flex-ns justify-start-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
-          hasThumbs && showThumbnails,
+          hasThumbs &&
+          showThumbnails,
       }
     )
 
@@ -313,8 +315,7 @@ class Carousel extends Component {
 
     return (
       <div className={containerClasses} aria-hidden="true">
-        {(isThumbsVertical && showThumbnails) && thumbnailSwiper}
-      
+        {isThumbsVertical && showThumbnails && thumbnailSwiper}
         <div className={imageClasses}>
           {!this.state.thumbSwiper?.destroyed && (
             <Swiper
@@ -371,7 +372,7 @@ class Carousel extends Component {
             </Swiper>
           )}
 
-          {(!isThumbsVertical && showThumbnails) && thumbnailSwiper}
+          {!isThumbsVertical && showThumbnails && thumbnailSwiper}
         </div>
       </div>
     )
@@ -390,7 +391,7 @@ Carousel.propTypes = {
   ),
   ModalZoomElement: PropTypes.any,
   displayThumbnailsArrows: PropTypes.bool,
-  showThumbnails: PropTypes.bool
+  showThumbnails: PropTypes.bool,
 }
 
 export default withCssHandles(CSS_HANDLES)(Carousel)

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -234,6 +234,7 @@ class Carousel extends Component {
       zoomProps: { zoomType },
       showPaginationDots = true,
       showNavigationArrows = true,
+      showThumbnails = true,
       displayThumbnailsArrows = false,
     } = this.props
 
@@ -256,11 +257,11 @@ class Carousel extends Component {
         'ml-20-ns w-80-ns pl5-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.LEFT &&
-          (hasThumbs || !hasSlides),
+          ((hasThumbs && showThumbnails) || !hasSlides),
         'mr-20-ns w-80-ns pr5-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
-          (hasThumbs || !hasSlides),
+          ((hasThumbs && showThumbnails) || !hasSlides),
       }
     )
 
@@ -289,11 +290,11 @@ class Carousel extends Component {
         'flex-ns justify-end-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.LEFT &&
-          hasThumbs,
+          hasThumbs && showThumbnails,
         'flex-ns justify-start-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
-          hasThumbs,
+          hasThumbs && showThumbnails,
       }
     )
 
@@ -312,8 +313,8 @@ class Carousel extends Component {
 
     return (
       <div className={containerClasses} aria-hidden="true">
-        {isThumbsVertical && thumbnailSwiper}
-
+        {(isThumbsVertical && showThumbnails) && thumbnailSwiper}
+      
         <div className={imageClasses}>
           {!this.state.thumbSwiper?.destroyed && (
             <Swiper
@@ -370,7 +371,7 @@ class Carousel extends Component {
             </Swiper>
           )}
 
-          {!isThumbsVertical && thumbnailSwiper}
+          {(!isThumbsVertical && showThumbnails) && thumbnailSwiper}
         </div>
       </div>
     )
@@ -389,6 +390,7 @@ Carousel.propTypes = {
   ),
   ModalZoomElement: PropTypes.any,
   displayThumbnailsArrows: PropTypes.bool,
+  showThumbnails: PropTypes.bool
 }
 
 export default withCssHandles(CSS_HANDLES)(Carousel)

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -15,6 +15,7 @@ import ImagePlaceholder from './ImagePlaceholder'
 import {
   THUMBS_ORIENTATION,
   THUMBS_POSITION_HORIZONTAL,
+  THUMBS_VISIBILITY,
 } from '../../utils/enums'
 import styles from './swiper.scoped.css'
 
@@ -234,7 +235,7 @@ class Carousel extends Component {
       zoomProps: { zoomType },
       showPaginationDots = true,
       showNavigationArrows = true,
-      showThumbnails = true,
+      thumbnailVisibility,
       displayThumbnailsArrows = false,
     } = this.props
 
@@ -257,11 +258,11 @@ class Carousel extends Component {
         'ml-20-ns w-80-ns pl5-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.LEFT &&
-          ((hasThumbs && showThumbnails) || !hasSlides),
+          ((hasThumbs && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE) || !hasSlides),
         'mr-20-ns w-80-ns pr5-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
-          ((hasThumbs && showThumbnails) || !hasSlides),
+          ((hasThumbs && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE) || !hasSlides),
       }
     )
 
@@ -291,12 +292,12 @@ class Carousel extends Component {
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.LEFT &&
           hasThumbs &&
-          showThumbnails,
+          thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE,
         'flex-ns justify-start-ns':
           isThumbsVertical &&
           position === THUMBS_POSITION_HORIZONTAL.RIGHT &&
           hasThumbs &&
-          showThumbnails,
+          thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE,
       }
     )
 
@@ -315,7 +316,7 @@ class Carousel extends Component {
 
     return (
       <div className={containerClasses} aria-hidden="true">
-        {isThumbsVertical && showThumbnails && thumbnailSwiper}
+        {isThumbsVertical && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE && thumbnailSwiper}
         <div className={imageClasses}>
           {!this.state.thumbSwiper?.destroyed && (
             <Swiper
@@ -372,7 +373,7 @@ class Carousel extends Component {
             </Swiper>
           )}
 
-          {!isThumbsVertical && showThumbnails && thumbnailSwiper}
+          {!isThumbsVertical && thumbnailVisibility === THUMBS_VISIBILITY.VISIBLE && thumbnailSwiper}
         </div>
       </div>
     )
@@ -391,7 +392,10 @@ Carousel.propTypes = {
   ),
   ModalZoomElement: PropTypes.any,
   displayThumbnailsArrows: PropTypes.bool,
-  showThumbnails: PropTypes.bool,
+  thumbnailVisibility: PropTypes.oneOf([
+    THUMBS_VISIBILITY.VISIBLE,
+    THUMBS_VISIBILITY.HIDDEN
+  ]),
 }
 
 export default withCssHandles(CSS_HANDLES)(Carousel)

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -93,7 +93,7 @@ const ProductImages = ({
 
   const containerClass = `${productImagesContainerClass} ${handles.content} w-100`
 
-  if (displayMode === DISPLAY_MODE.LIST)
+  if (displayMode === DISPLAY_MODE.LIST) {
     return (
       <div className={containerClass}>
         {images.map(({ url, alt }, index) => (
@@ -110,21 +110,25 @@ const ProductImages = ({
         ))}
       </div>
     )
+  }
 
-  if (displayMode === DISPLAY_MODE.FIRST_IMAGE && images.length)
+  const { url, alt } = images?.[0]
+
+  if (displayMode === DISPLAY_MODE.FIRST_IMAGE && images.length) {
     return (
       <div className={containerClass}>
-          <ProductImage
-            src={images[0].url}
-            alt={images[0].alt}
-            maxHeight={maxHeight}
-            zoomFactor={zoomFactor}
-            aspectRatio={aspectRatio}
-            ModalZoomElement={ModalZoomElement}
-            zoomMode={isZoomDisabled ? 'disabled' : zoomMode}
-          />
+        <ProductImage
+          src={url}
+          alt={alt}
+          maxHeight={maxHeight}
+          zoomFactor={zoomFactor}
+          aspectRatio={aspectRatio}
+          ModalZoomElement={ModalZoomElement}
+          zoomMode={isZoomDisabled ? 'disabled' : zoomMode}
+        />
       </div>
-    ) 
+    )
+  }
 
   return (
     <div className={containerClass}>
@@ -201,7 +205,7 @@ ProductImages.propTypes = {
   showPaginationDots: PropTypes.bool,
   thumbnailVisibility: PropTypes.oneOf([
     THUMBS_VISIBILITY.VISIBLE,
-    THUMBS_VISIBILITY.HIDDEN
+    THUMBS_VISIBILITY.HIDDEN,
   ]),
   contentOrder: PropTypes.oneOf(['images-first', 'videos-first']),
   zoomMode: PropTypes.oneOf([
@@ -213,8 +217,8 @@ ProductImages.propTypes = {
   zoomFactor: PropTypes.number,
   contentType: PropTypes.oneOf(['all', 'images', 'videos']),
   displayMode: PropTypes.oneOf([
-    DISPLAY_MODE.CAROUSEL, 
-    DISPLAY_MODE.LIST, 
+    DISPLAY_MODE.CAROUSEL,
+    DISPLAY_MODE.LIST,
     DISPLAY_MODE.FIRST_IMAGE,
   ]),
 }

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -27,6 +27,7 @@ const ProductImages = ({
   thumbnailMaxHeight,
   showNavigationArrows,
   showPaginationDots,
+  showThumbnails,
   contentOrder = 'images-first',
   zoomMode,
   zoomFactor,
@@ -109,6 +110,21 @@ const ProductImages = ({
       </div>
     )
 
+  else if (displayMode === DISPLAY_MODE.FIRST_IMAGE)
+  return (
+    <div className={containerClass}>
+        <ProductImage
+          src={images[0].url}
+          alt={images[0].alt}
+          maxHeight={maxHeight}
+          zoomFactor={zoomFactor}
+          aspectRatio={aspectRatio}
+          ModalZoomElement={ModalZoomElement}
+          zoomMode={isZoomDisabled ? 'disabled' : zoomMode}
+        />
+    </div>
+  ) 
+
   return (
     <div className={containerClass}>
       <Carousel
@@ -126,6 +142,7 @@ const ProductImages = ({
         showNavigationArrows={showNavigationArrows}
         thumbnailsOrientation={thumbnailsOrientation}
         displayThumbnailsArrows={displayThumbnailsArrows}
+        showThumbnails={showThumbnails}
         // Deprecated
         zoomProps={zoomProps}
       />
@@ -181,6 +198,7 @@ ProductImages.propTypes = {
   thumbnailMaxHeight: PropTypes.number,
   showNavigationArrows: PropTypes.bool,
   showPaginationDots: PropTypes.bool,
+  showThumbnails: PropTypes.bool,
   contentOrder: PropTypes.oneOf(['images-first', 'videos-first']),
   zoomMode: PropTypes.oneOf([
     'disabled',
@@ -190,7 +208,7 @@ ProductImages.propTypes = {
   ]),
   zoomFactor: PropTypes.number,
   contentType: PropTypes.oneOf(['all', 'images', 'videos']),
-  displayMode: PropTypes.oneOf([DISPLAY_MODE.CAROUSEL, DISPLAY_MODE.LIST]),
+  displayMode: PropTypes.oneOf([DISPLAY_MODE.CAROUSEL, DISPLAY_MODE.LIST, DISPLAY_MODE.FIRST_IMAGE]),
 }
 
 ProductImages.defaultProps = {

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -112,9 +112,9 @@ const ProductImages = ({
     )
   }
 
-  const { url, alt } = images?.[0]
-
   if (displayMode === DISPLAY_MODE.FIRST_IMAGE && images.length) {
+    const { url, alt } = images?.[0]
+
     return (
       <div className={containerClass}>
         <ProductImage

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -109,8 +109,7 @@ const ProductImages = ({
         ))}
       </div>
     )
-
-  else if (displayMode === DISPLAY_MODE.FIRST_IMAGE)
+  else if (displayMode === DISPLAY_MODE.FIRST_IMAGE && images[0])
   return (
     <div className={containerClass}>
         <ProductImage

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -112,7 +112,7 @@ const ProductImages = ({
     )
   }
 
-  if (displayMode === DISPLAY_MODE.FIRST_IMAGE && images.length) {
+  if (displayMode === DISPLAY_MODE.FIRST_IMAGE && images?.length) {
     const { url, alt } = images?.[0]
 
     return (

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -7,6 +7,7 @@ import ProductImage from './components/ProductImage'
 import {
   THUMBS_ORIENTATION,
   THUMBS_POSITION_HORIZONTAL,
+  THUMBS_VISIBILITY,
   DEFAULT_EXCLUDE_IMAGE_WITH,
   DISPLAY_MODE,
 } from './utils/enums'
@@ -27,7 +28,7 @@ const ProductImages = ({
   thumbnailMaxHeight,
   showNavigationArrows,
   showPaginationDots,
-  showThumbnails,
+  thumbnailVisibility,
   contentOrder = 'images-first',
   zoomMode,
   zoomFactor,
@@ -142,7 +143,7 @@ const ProductImages = ({
         showNavigationArrows={showNavigationArrows}
         thumbnailsOrientation={thumbnailsOrientation}
         displayThumbnailsArrows={displayThumbnailsArrows}
-        showThumbnails={showThumbnails}
+        thumbnailVisibility={thumbnailVisibility}
         // Deprecated
         zoomProps={zoomProps}
       />
@@ -198,7 +199,10 @@ ProductImages.propTypes = {
   thumbnailMaxHeight: PropTypes.number,
   showNavigationArrows: PropTypes.bool,
   showPaginationDots: PropTypes.bool,
-  showThumbnails: PropTypes.bool,
+  thumbnailVisibility: PropTypes.oneOf([
+    THUMBS_VISIBILITY.VISIBLE,
+    THUMBS_VISIBILITY.HIDDEN
+  ]),
   contentOrder: PropTypes.oneOf(['images-first', 'videos-first']),
   zoomMode: PropTypes.oneOf([
     'disabled',
@@ -221,6 +225,7 @@ ProductImages.defaultProps = {
   zoomProps: { zoomType: 'in-page' },
   thumbnailsOrientation: THUMBS_ORIENTATION.VERTICAL,
   displayThumbnailsArrows: false,
+  thumbnailVisibility: THUMBS_VISIBILITY.VISIBLE,
   hiddenImages: DEFAULT_EXCLUDE_IMAGE_WITH,
   displayMode: DISPLAY_MODE.CAROUSEL,
 }

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -109,20 +109,21 @@ const ProductImages = ({
         ))}
       </div>
     )
-  else if (displayMode === DISPLAY_MODE.FIRST_IMAGE && images[0])
-  return (
-    <div className={containerClass}>
-        <ProductImage
-          src={images[0].url}
-          alt={images[0].alt}
-          maxHeight={maxHeight}
-          zoomFactor={zoomFactor}
-          aspectRatio={aspectRatio}
-          ModalZoomElement={ModalZoomElement}
-          zoomMode={isZoomDisabled ? 'disabled' : zoomMode}
-        />
-    </div>
-  ) 
+
+  if (displayMode === DISPLAY_MODE.FIRST_IMAGE && images.length)
+    return (
+      <div className={containerClass}>
+          <ProductImage
+            src={images[0].url}
+            alt={images[0].alt}
+            maxHeight={maxHeight}
+            zoomFactor={zoomFactor}
+            aspectRatio={aspectRatio}
+            ModalZoomElement={ModalZoomElement}
+            zoomMode={isZoomDisabled ? 'disabled' : zoomMode}
+          />
+      </div>
+    ) 
 
   return (
     <div className={containerClass}>
@@ -207,7 +208,11 @@ ProductImages.propTypes = {
   ]),
   zoomFactor: PropTypes.number,
   contentType: PropTypes.oneOf(['all', 'images', 'videos']),
-  displayMode: PropTypes.oneOf([DISPLAY_MODE.CAROUSEL, DISPLAY_MODE.LIST, DISPLAY_MODE.FIRST_IMAGE]),
+  displayMode: PropTypes.oneOf([
+    DISPLAY_MODE.CAROUSEL, 
+    DISPLAY_MODE.LIST, 
+    DISPLAY_MODE.FIRST_IMAGE,
+  ]),
 }
 
 ProductImages.defaultProps = {

--- a/react/components/ProductImages/utils/enums.js
+++ b/react/components/ProductImages/utils/enums.js
@@ -16,7 +16,7 @@ export const DISPLAY_MODE = {
 
 export const THUMBS_VISIBILITY = {
   VISIBLE: 'visible',
-  HIDDEN: 'hidden'
+  HIDDEN: 'hidden',
 }
 
 export const DEFAULT_EXCLUDE_IMAGE_WITH = 'skuvariation'

--- a/react/components/ProductImages/utils/enums.js
+++ b/react/components/ProductImages/utils/enums.js
@@ -11,6 +11,7 @@ export const THUMBS_ORIENTATION = {
 export const DISPLAY_MODE = {
   CAROUSEL: 'carousel',
   LIST: 'list',
+  FIRST_IMAGE: 'first-image'
 }
 
 export const DEFAULT_EXCLUDE_IMAGE_WITH = 'skuvariation'

--- a/react/components/ProductImages/utils/enums.js
+++ b/react/components/ProductImages/utils/enums.js
@@ -14,4 +14,9 @@ export const DISPLAY_MODE = {
   FIRST_IMAGE: 'first-image',
 }
 
+export const THUMBS_VISIBILITY = {
+  VISIBLE: 'visible',
+  HIDDEN: 'hidden'
+}
+
 export const DEFAULT_EXCLUDE_IMAGE_WITH = 'skuvariation'

--- a/react/components/ProductImages/utils/enums.js
+++ b/react/components/ProductImages/utils/enums.js
@@ -11,7 +11,7 @@ export const THUMBS_ORIENTATION = {
 export const DISPLAY_MODE = {
   CAROUSEL: 'carousel',
   LIST: 'list',
-  FIRST_IMAGE: 'first-image'
+  FIRST_IMAGE: 'first-image',
 }
 
 export const DEFAULT_EXCLUDE_IMAGE_WITH = 'skuvariation'


### PR DESCRIPTION
#### What problem is this solving?

On the product-images app, you cand choose to show only one image instead of just carousel and list. And you can also choose to hide thumbnails when carousel is selected.

#### How to test it?

On the link below, you cand see the app linked and using the setting "showThumbnails": false
https://storecomponents--iviteb.myvtex.com/playstation-5/p

[Workspace](https://storecomponents--iviteb.myvtex.com/playstation-5/p)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/73105476/105028567-d9f17000-5a59-11eb-87b9-af0d80293fbd.png)
![image](https://user-images.githubusercontent.com/73105476/105028603-e4ac0500-5a59-11eb-8ca4-d7ff3935dad7.png)


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
