### PR TITLE
Feature/figure vid class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Modifier `video` to CSS Handle `figure` on `Product Image` to differ video thumbnails from image thumbnails.
 
 ## [3.139.0] - 2021-01-19
 

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -128,6 +128,7 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `carouselInconCaretRight` |
 | `carouselThumbBorder` |
 | `figure` |
+| `figure--video` |
 | `highQualityContainer` |
 | `image` |
 | `imgZoom` |

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -27,7 +27,9 @@ const Thumbnail = props => {
   return (
     <>
       <figure
-        className={handles.figure}
+        className={`${applyModifiers(handles.figure,
+          isVideo ? 'video' : null
+        )}`}
         itemProp="associatedMedia"
         itemScope
         itemType="http://schema.org/ImageObject"


### PR DESCRIPTION
#### What problem is this solving?

The inability to differ a Image thumbnail from a video thumbnail. Despite sounding like the same PR as this one #912 , i created another because i figured out there is no way to use ::before adding a background image on a `<img>` tag because its closes itself, so a additional modifier is needed on a parent class.

#### How to test it?

Just check if there is a aditional class when there is a video: 
![image](https://user-images.githubusercontent.com/51974587/105366642-544afd00-5bde-11eb-9b3f-fb5221937585.png)


[Workspace](https://carafizi--acctglobal.myvtex.com/luiz/p)

#### Screenshots or example usage:

Fading a video and adding a play button over it:
![image](https://user-images.githubusercontent.com/51974587/105367824-a2accb80-5bdf-11eb-9a09-a1c386bfbb5d.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/l46CyJmS9KUbokzsI/giphy.gif)
