### PR TITLE
Fix searches with slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Searches with slash.
 
 ## [3.141.1] - 2021-02-17
 ### Fixed

--- a/react/AutocompleteResults.tsx
+++ b/react/AutocompleteResults.tsx
@@ -11,7 +11,6 @@ import type { PropGetters } from 'downshift'
 
 import './AutocompleteResults.css'
 import autocomplete from './graphql/autocomplete.gql'
-import encodeForwardSlash from './utils/encodeForwardSlash'
 
 const MIN_RESULTS_WIDTH = 320
 const CSS_HANDLES = [
@@ -114,7 +113,7 @@ function AutocompleteResults({
   } = useRuntime()
 
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
-  const encodedInputValue = encodeForwardSlash(inputValue)
+  const encodedInputValue = encodeURIComponent(inputValue)
 
   const listStyle = useMemo(
     () => ({

--- a/react/SearchBar.tsx
+++ b/react/SearchBar.tsx
@@ -10,7 +10,6 @@ import SearchBar, {
 } from './components/SearchBar/SearchBar'
 import { CSS_HANDLES as AutocompleteInputCssHandles } from './components/SearchBar/AutocompleteInput'
 import { SearchBarCssHandlesProvider } from './components/SearchBar/SearchBarCssHandles'
-import encodeForwardSlash from './utils/encodeForwardSlash'
 
 const { useModalDispatch } = ModalContext
 
@@ -113,7 +112,7 @@ function SearchBarContainer(props: Props) {
   }, [])
 
   const handleGoToSearchPage = useCallback(() => {
-    const search = encodeForwardSlash(inputValue)
+    const search = encodeURIComponent(inputValue)
 
     if (attemptPageTypeSearch) {
       window.location.href = `/${search}`

--- a/react/utils/encodeForwardSlash.ts
+++ b/react/utils/encodeForwardSlash.ts
@@ -1,9 +1,0 @@
-/**
- * Encode all "/" by using $2F instead of %2F
- * Since "/" is a special character in URL, it can not be encoded normally,
- */
-const encodeForwardSlash = (str: string) => {
-  return str.replace(/\//gi, '$2F')
-}
-
-export default encodeForwardSlash


### PR DESCRIPTION
#### What problem is this solving?
now, the problem of searching with slash will be solved directly in the rewriter, so that it also works with facet selection and not just full text. 
Therefore, we no longer need to put this encoded value for the slash here, it's only necessary to make the standard encode so the rewriter can differentiate the slash from the query in the url.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
[Before](https://biscoind.myvtex.com/3-48m$2fs?_q=3-48m$2Fs&map=ft)
[After](https://encodeurl--biscoind.myvtex.com/3-48m%2fs?_q=3-48m/s&map=ft)
- note the value encoded in the URL

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

Depends on: https://github.com/vtex/rewriter/pull/186

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
