### PR TITLE
add css handler class for image link wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Added css handler class for image link wrapper
+
 ## [3.142.0] - 2021-03-09
 ### Added
 - Push `newsletterInput` pixel event when newsletter is mounted

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -69,6 +69,7 @@ const getImageUrl = (isMobile, imageUrl, mobileImageUrl) =>
   !!mobileImageUrl && isMobile ? mobileImageUrl : imageUrl
 
 const CSS_HANDLES = [
+  'infoCardImageLinkWrapper',
   'infoCardContainer',
   'infoCardTextContainer',
   'infoCardHeadline',
@@ -153,6 +154,8 @@ const InfoCard = ({
     }
   )
 
+  const linkWrapperClasses = classNames(`${handles.infoCardImageLinkWrapper} no-underline`)
+
   const textContainerClasses = classNames(
     `${handles.infoCardTextContainer} flex flex-column mw-100`,
     {
@@ -169,7 +172,7 @@ const InfoCard = ({
     <LinkWrapper
       imageActionUrl={formatIOMessage({ id: imageActionUrl, intl })}
       extraCondition={!isFullModeStyle}
-      linkProps={{ className: 'no-underline', target: linkTarget }}
+      linkProps={{ className: linkWrapperClasses, target: linkTarget }}
     >
       <div
         className={containerClasses}

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -156,7 +156,7 @@ const InfoCard = ({
 
   const linkWrapperClasses = classNames(
     `${handles.infoCardImageLinkWrapper} no-underline`
-    )
+  )
 
   const textContainerClasses = classNames(
     `${handles.infoCardTextContainer} flex flex-column mw-100`,

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -154,7 +154,9 @@ const InfoCard = ({
     }
   )
 
-  const linkWrapperClasses = classNames(`${handles.infoCardImageLinkWrapper} no-underline`)
+  const linkWrapperClasses = classNames(
+    `${handles.infoCardImageLinkWrapper} no-underline`
+    )
 
   const textContainerClasses = classNames(
     `${handles.infoCardTextContainer} flex flex-column mw-100`,


### PR DESCRIPTION
#### What problem is this solving?
Add css handler class to InfoCard image link wrapper, This will allow developer to add styles to wrapped link element.

#### Screenshots or example usage:
