### PR TITLE
Makes the SearchBar placeholder translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Makes the SearchBar placeholder translatable
 
 ## [3.142.1] - 2021-03-30
 ### Fixed

--- a/react/components/SearchBar/SearchBar.tsx
+++ b/react/components/SearchBar/SearchBar.tsx
@@ -196,7 +196,7 @@ function SearchBar({
 
   const fallback = (
     <AutocompleteInput
-      placeholder={formatIOMessage({ id: placeholder, intl })}
+      placeholder={formatIOMessage({ id: placeholder, intl }) as string}
       onInputChange={onInputChange}
       inputValue={inputValue}
       hasIconLeft={hasIconLeft}

--- a/react/components/SearchBar/SearchBar.tsx
+++ b/react/components/SearchBar/SearchBar.tsx
@@ -16,6 +16,7 @@ import AutocompleteResults from '../../AutocompleteResults'
 import type { Props as AutocompleteResultsProps } from '../../AutocompleteResults'
 import AutocompleteInput from './AutocompleteInput'
 import { useSearchBarCssHandles } from './SearchBarCssHandles'
+import { formatIOMessage } from 'vtex.native-types'
 
 export const CSS_HANDLES = ['searchBarInnerContainer'] as const
 
@@ -195,7 +196,7 @@ function SearchBar({
 
   const fallback = (
     <AutocompleteInput
-      placeholder={placeholder}
+      placeholder={formatIOMessage({ id: placeholder, intl })}
       onInputChange={onInputChange}
       inputValue={inputValue}
       hasIconLeft={hasIconLeft}

--- a/react/components/SearchBar/SearchBar.tsx
+++ b/react/components/SearchBar/SearchBar.tsx
@@ -10,13 +10,13 @@ import {
 } from 'vtex.render-runtime'
 import { Overlay } from 'vtex.react-portal'
 import { defineMessages, useIntl } from 'react-intl'
+import { formatIOMessage } from 'vtex.native-types'
 
 import styles from './SearchBar.css'
 import AutocompleteResults from '../../AutocompleteResults'
 import type { Props as AutocompleteResultsProps } from '../../AutocompleteResults'
 import AutocompleteInput from './AutocompleteInput'
 import { useSearchBarCssHandles } from './SearchBarCssHandles'
-import { formatIOMessage } from 'vtex.native-types'
 
 export const CSS_HANDLES = ['searchBarInnerContainer'] as const
 


### PR DESCRIPTION
#### What problem is this solving?
The SearchBar placeholder was not being translated in multi-language stores.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://fox2--unileverb2b.myvtex.com/?cultureInfo=en-US)

When entering the english page the SearchBar placeholder should be translated and its translation should be editable in the site-editor.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
