### PR TITLE
Bug - swiper destroyed resulting in typerror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Check if the swiper is not destroyed before rendering, which could cause the whole product UI to crash
+
 ## [3.142.2] - 2021-04-09
 ### Fixed
 - Makes the SearchBar placeholder translatable

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -315,58 +315,60 @@ class Carousel extends Component {
         {isThumbsVertical && thumbnailSwiper}
 
         <div className={imageClasses}>
-          <Swiper
-            onSwiper={instance => this.setState({ gallerySwiper: instance })}
-            className={handles.productImagesGallerySwiperContainer}
-            threshold={10}
-            resistanceRatio={slides.length > 1 ? 0.85 : 0}
-            onSlideChange={this.handleSlideChange}
-            updateOnWindowResize
-            {...this.galleryParams}
-          >
-            {slides.map((slide, i) => (
-              <SwiperSlide
-                key={`slider-${i}`}
-                className={`${handles.productImagesGallerySlide} swiper-slide center-all`}
-              >
-                {this.renderSlide(slide, i)}
-              </SwiperSlide>
-            ))}
-
-            <div
-              key="pagination"
-              className={classNames(styles['swiper-pagination'], {
-                dn: slides.length === 1 || !showPaginationDots,
-              })}
-            />
-
-            <div
-              className={classNames({
-                dn: slides.length === 1 || !showNavigationArrows,
-              })}
+          {!this.state.thumbSwiper?.destroyed && (
+            <Swiper
+              onSwiper={instance => this.setState({ gallerySwiper: instance })}
+              className={handles.productImagesGallerySwiperContainer}
+              threshold={10}
+              resistanceRatio={slides.length > 1 ? 0.85 : 0}
+              onSlideChange={this.handleSlideChange}
+              updateOnWindowResize
+              {...this.galleryParams}
             >
-              <span
-                key="caret-next"
-                className={`swiper-caret-next pl7 pr2 right-0 ${CARET_CLASSNAME} ${handles.swiperCaret} ${handles.swiperCaretNext}`}
+              {slides.map((slide, i) => (
+                <SwiperSlide
+                  key={`slider-${i}`}
+                  className={`${handles.productImagesGallerySlide} swiper-slide center-all`}
+                >
+                  {this.renderSlide(slide, i)}
+                </SwiperSlide>
+              ))}
+
+              <div
+                key="pagination"
+                className={classNames(styles['swiper-pagination'], {
+                  dn: slides.length === 1 || !showPaginationDots,
+                })}
+              />
+
+              <div
+                className={classNames({
+                  dn: slides.length === 1 || !showNavigationArrows,
+                })}
               >
-                <IconCaret
-                  orientation="right"
-                  size={CARET_ICON_SIZE}
-                  className={styles.carouselIconCaretRight}
-                />
-              </span>
-              <span
-                key="caret-prev"
-                className={`swiper-caret-prev pr7 pl2 left-0 ${CARET_CLASSNAME} ${handles.swiperCaret} ${handles.swiperCaretPrev}`}
-              >
-                <IconCaret
-                  orientation="left"
-                  size={CARET_ICON_SIZE}
-                  className={styles.carouselIconCaretLeft}
-                />
-              </span>
-            </div>
-          </Swiper>
+                <span
+                  key="caret-next"
+                  className={`swiper-caret-next pl7 pr2 right-0 ${CARET_CLASSNAME} ${handles.swiperCaret} ${handles.swiperCaretNext}`}
+                >
+                  <IconCaret
+                    orientation="right"
+                    size={CARET_ICON_SIZE}
+                    className={styles.carouselIconCaretRight}
+                  />
+                </span>
+                <span
+                  key="caret-prev"
+                  className={`swiper-caret-prev pr7 pl2 left-0 ${CARET_CLASSNAME} ${handles.swiperCaret} ${handles.swiperCaretPrev}`}
+                >
+                  <IconCaret
+                    orientation="left"
+                    size={CARET_ICON_SIZE}
+                    className={styles.carouselIconCaretLeft}
+                  />
+                </span>
+              </div>
+            </Swiper>
+          )}
 
           {!isThumbsVertical && thumbnailSwiper}
         </div>


### PR DESCRIPTION
#### What problem is this solving?

The whole product UI is crashing when the swiper is being destroyed and re-used 
![9e8c083a-eae7-4815-99ae-3e4a6ec91d2c](https://user-images.githubusercontent.com/68231117/115002584-99b15a80-9ead-11eb-8798-7073fcb5bdbb.jpg)

<!--- What is the motivation and context for this change? -->

#### How to test it?
To test, go on the product page, then click a product in the carousel ('Clientii care au vizualizat acest produs s-au uitat si la') below and the product UI will crash


This is a dev workspace with the binding on the production store - `distributie.dacris.net/` 
[Dev workspace](https://doru--dacris.myvtex.com/capsator-metalic-20-coli-negru/p?__bindingAddress=distributie.dacris.net/)
[Production Workspace](https://distributie.dacris.net/prosop-hartie-sanify-derulare-centrala-2-straturi-600-gr/p)

#### Screenshots or example usage:
Before:
![image](https://user-images.githubusercontent.com/68231117/115003064-1cd2b080-9eae-11eb-97c5-4bc33d62c250.png)

After:
![image](https://user-images.githubusercontent.com/68231117/115003100-26f4af00-9eae-11eb-88bd-ebe59f355c37.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/l2RsBhyCSu5Y5XU3Zf/giphy.gif)
