### PR TITLE
Makes the SearchBar placeholder translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Makes main SearchBar placeholder translatable
 
 ## [3.143.0] - 2021-04-19
 ### Added

--- a/react/components/SearchBar/SearchBar.tsx
+++ b/react/components/SearchBar/SearchBar.tsx
@@ -295,7 +295,7 @@ function SearchBar({
                   },
                   placeholder: formatIOMessage({
                     id: placeholder,
-                    intl
+                    intl,
                   }) as string,
                   value: inputValue,
                   onChange: onInputChange,

--- a/react/components/SearchBar/SearchBar.tsx
+++ b/react/components/SearchBar/SearchBar.tsx
@@ -293,7 +293,10 @@ function SearchBar({
                       hideInputErrorMessage()
                     }
                   },
-                  placeholder: formatIOMessage({ id: placeholder, intl }) as string,
+                  placeholder: formatIOMessage({
+                    id: placeholder,
+                    intl
+                  }) as string,
                   value: inputValue,
                   onChange: onInputChange,
                   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/react/components/SearchBar/SearchBar.tsx
+++ b/react/components/SearchBar/SearchBar.tsx
@@ -293,7 +293,7 @@ function SearchBar({
                       hideInputErrorMessage()
                     }
                   },
-                  placeholder,
+                  placeholder: formatIOMessage({ id: placeholder, intl }) as string,
                   value: inputValue,
                   onChange: onInputChange,
                   // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
#### What problem is this solving?

Currently only the fallback component is translating the placeholder text. This PR makes the main SearchBar placeholder translatable too.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://fox--unileverb2b.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
