### PR TITLE
✨Added a prop in the product description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `ProductDescription` - Add `showTitle` prop.
+- `showTitle` prop to `ProductDescription` component.
 
 ## [3.143.1] - 2021-04-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ProductDescription` - Add `showTitle` prop.
 
 ## [3.143.1] - 2021-04-28
 ### Fixed

--- a/docs/ProductDescription.md
+++ b/docs/ProductDescription.md
@@ -39,6 +39,7 @@ This Component can be imported and used by any VTEX App.
 | `collapseContent` | `Boolean` | If true, whenever the product description is too big, it will collapse and show a "Show More" button. When false, it will never collapse and will always show the whole description. | `true` |
 | `title`           | `string`  | Defines a custom title for the description section. | `undefined` |
 | `classes` | `CustomCSSClasses` | Used to override default CSS handles. To better understand how this prop works, we recommend reading about it [here](https://github.com/vtex-apps/css-handles#usecustomclasses). Note that this is only useful if you're using this block as a React component. | `undefined` |
+| `showTitle`           | `boolean`  | Define whether or not to show the title. | `true` |
 
 ## Customization
 

--- a/react/ProductDescription.tsx
+++ b/react/ProductDescription.tsx
@@ -68,7 +68,7 @@ function ProductDescription(props: PropsWithChildren<Props>) {
 
   return (
     <div className={handles.productDescriptionContainer}>
-      {showTitle ? (
+      {showTitle && (
         <FormattedMessage id="store/product-description.title">
           {txt => (
             <h2
@@ -78,7 +78,7 @@ function ProductDescription(props: PropsWithChildren<Props>) {
             </h2>
           )}
         </FormattedMessage>
-      ) : null}
+      )}
 
       <div className={`${handles.productDescriptionText} c-muted-1`}>
         {collapseContent ? (

--- a/react/ProductDescription.tsx
+++ b/react/ProductDescription.tsx
@@ -20,7 +20,7 @@ type Props = {
   description?: string
   /** Section title */
   title?: string
-  /** Define whether or not to show the title*/
+  /** Define whether or not to show the title */
   showTitle?: boolean
   /** Define if content should start collapsed or not */
   collapseContent?: boolean
@@ -70,7 +70,7 @@ function ProductDescription(props: PropsWithChildren<Props>) {
     <div className={handles.productDescriptionContainer}>
       {showTitle ? (
         <FormattedMessage id="store/product-description.title">
-          {(txt) => (
+          {txt => (
             <h2
               className={`${handles.productDescriptionTitle} t-heading-5 mb5 mt0`}
             >

--- a/react/ProductDescription.tsx
+++ b/react/ProductDescription.tsx
@@ -20,6 +20,8 @@ type Props = {
   description?: string
   /** Section title */
   title?: string
+  /** Define whether or not to show the title*/
+  showTitle?: boolean
   /** Define if content should start collapsed or not */
   collapseContent?: boolean
   /** Used to override default CSS handles */
@@ -62,19 +64,21 @@ function ProductDescription(props: PropsWithChildren<Props>) {
     return null
   }
 
-  const { collapseContent = true, title } = props
+  const { collapseContent = true, showTitle = true, title } = props
 
   return (
     <div className={handles.productDescriptionContainer}>
-      <FormattedMessage id="store/product-description.title">
-        {txt => (
-          <h2
-            className={`${handles.productDescriptionTitle} t-heading-5 mb5 mt0`}
-          >
-            {title ? formatIOMessage({ id: title, intl }) : txt}
-          </h2>
-        )}
-      </FormattedMessage>
+      {showTitle ? (
+        <FormattedMessage id="store/product-description.title">
+          {(txt) => (
+            <h2
+              className={`${handles.productDescriptionTitle} t-heading-5 mb5 mt0`}
+            >
+              {title ? formatIOMessage({ id: title, intl }) : txt}
+            </h2>
+          )}
+        </FormattedMessage>
+      ) : null}
 
       <div className={`${handles.productDescriptionText} c-muted-1`}>
         {collapseContent ? (


### PR DESCRIPTION
## Description
A prop has been added so that the user can choose whether or not to render the title of the product description. 

#### Workspace
You can check the setting on false directly in this page.
https://productdesc--itwhirlpool.myvtex.com/lavatrice-a-libera-installazione-a-carica-frontale-whirlpool-9-kg-autodose-9425-859991571330/p

#### Screenshots
When the prop, showTitle, is set as false the title is not rendered:
![image](https://user-images.githubusercontent.com/73878310/117127091-f2cd2980-ad9b-11eb-84ad-b7af8de61585.png)
![image](https://user-images.githubusercontent.com/73878310/117127177-0c6e7100-ad9c-11eb-839b-e195f6b7a0fd.png)
Whereas, if the prop is set as true (default value) the title is shown normally.
![image](https://user-images.githubusercontent.com/73878310/117127504-738c2580-ad9c-11eb-968d-fb467691fcc0.png)
![image](https://user-images.githubusercontent.com/73878310/117127458-653e0980-ad9c-11eb-9d08-cb12559e14a5.png)

#### Version
Starting version: "3.143.1"
New version : "3.144.0"