### PR TITLE
remove onblur and touchmove behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `disableBlurAndTouchEndHandler` prop to the `SearchBar` component.
+
 ## [3.146.0] - 2021-06-28
 ### Added
 - `unavailable` modifier to `valueWrapper` CSS handle.

--- a/docs/SearchBar.md
+++ b/docs/SearchBar.md
@@ -41,6 +41,7 @@ Then, add `search-bar` block into your app theme, as we do in our [Store Header]
 | ~`iconClasses`~           | `String`                                      | ![DEPRECATED](https://img.shields.io/badge/-deprecated-red) ~Custom classes for the search icon~ Use the CSS handle `searchBarIcon`.                                                              | -              |
 | ~`submitOnIconClick`~     | `Boolean`                                     | ![DEPRECATED](https://img.shields.io/badge/-deprecated-red) - ~Define if search icon should submit on click.~ Use the `displayMode` prop instead.                                               | `false`        |
 | `classes` | `CustomCSSClasses` | Used to override default CSS handles. To better understand how this prop works, we recommend reading about it [here](https://github.com/vtex-apps/css-handles#usecustomclasses). Note that this is only useful if you're using this block as a React component. | `undefined` |
+| `disableBlurAndTouchEndHandler` | `Boolean` | The autocomplete can have touchable/clickable components. Interacting with those components may trigger blur and touch events that will close the autcomplete. When set to true, this prop will disable those handlers. | `false` |
 
 ### `DisplayMode`
 

--- a/docs/SearchBar.md
+++ b/docs/SearchBar.md
@@ -41,7 +41,7 @@ Then, add `search-bar` block into your app theme, as we do in our [Store Header]
 | ~`iconClasses`~           | `String`                                      | ![DEPRECATED](https://img.shields.io/badge/-deprecated-red) ~Custom classes for the search icon~ Use the CSS handle `searchBarIcon`.                                                              | -              |
 | ~`submitOnIconClick`~     | `Boolean`                                     | ![DEPRECATED](https://img.shields.io/badge/-deprecated-red) - ~Define if search icon should submit on click.~ Use the `displayMode` prop instead.                                               | `false`        |
 | `classes` | `CustomCSSClasses` | Used to override default CSS handles. To better understand how this prop works, we recommend reading about it [here](https://github.com/vtex-apps/css-handles#usecustomclasses). Note that this is only useful if you're using this block as a React component. | `undefined` |
-| `disableBlurAndTouchEndHandler` | `Boolean` | The autocomplete can have touchable/clickable components. Interacting with those components may trigger blur and touch events that will close the autcomplete. When set to true, this prop will disable those handlers. | `false` |
+| `disableBlurAndTouchEndHandler` | `Boolean` | The autocomplete can have touchable/clickable components. Interacting with those components may trigger blur and touch events that will close the autocomplete. When set to true, this prop will disable those handlers. | `false` |
 
 ### `DisplayMode`
 

--- a/react/SearchBar.tsx
+++ b/react/SearchBar.tsx
@@ -57,7 +57,7 @@ interface Props {
   containerMode: 'overlay' | 'container'
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof SEARCH_BAR_CSS_HANDLES>
-  /** The autocomplete can have touchable/clickable components. Interacting with those components may trigger blur and touch events that will close the autcomplete. When set to true, this prop will disable those handlers */
+  /** The autocomplete can have touchable/clickable components. Interacting with those components may trigger blur and touch events that will close the autocomplete. When set to true, this prop will disable those handlers */
   disableBlurAndTouchEndHandler?: boolean
 }
 

--- a/react/SearchBar.tsx
+++ b/react/SearchBar.tsx
@@ -57,6 +57,8 @@ interface Props {
   containerMode: 'overlay' | 'container'
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof SEARCH_BAR_CSS_HANDLES>
+  /** The autocomplete can have touchable/clickable components. Interacting with those components may trigger blur and touch events that will close the autcomplete. When set to true, this prop will disable those handlers */
+  disableBlurAndTouchEndHandler?: boolean
 }
 
 /**
@@ -85,6 +87,7 @@ function SearchBarContainer(props: Props) {
     autocompleteFullWidth = false,
     inputType = 'text',
     classes,
+    disableBlurAndTouchEndHandler = false,
   } = props
 
   const modalDispatch = useModalDispatch()
@@ -178,6 +181,7 @@ function SearchBarContainer(props: Props) {
         autocompleteFullWidth={autocompleteFullWidth}
         inputType={inputType}
         containerMode={containerMode}
+        disableBlurAndTouchEndHandler={disableBlurAndTouchEndHandler}
       />
     </SearchBarCssHandlesProvider>
   )


### PR DESCRIPTION
#### What problem is this solving?

Autocomplete can have interactive components, such as add to cart, add to wish list, or quantity input. This type of interaction may trigger touch end and blur events that will close the autocomplete in an unwanted way. This PR adds the `disableBlurAndTouchEndHandler` that disables this default behavior.

#### How to test it?

[Workspace disableBlurAndTouchEndHandler off](https://hiago2--gigadigital.myvtex.com/)

![disableOff](https://user-images.githubusercontent.com/40380674/121728333-8395d400-cac3-11eb-8128-6fda1fa65e13.gif)

[Workspace disableBlurAndTouchEndHandler on](https://hiago--gigadigital.myvtex.com/)

![disableOn](https://user-images.githubusercontent.com/40380674/121728344-87c1f180-cac3-11eb-86b1-5d0f2605f002.gif)


