### PR TITLE
Add the property name to SKU Selector dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Name property to SKU selector dropdown.
 
 ## [3.148.0] - 2021-06-30
 

--- a/react/components/SKUSelector/components/SelectVariationMode.tsx
+++ b/react/components/SKUSelector/components/SelectVariationMode.tsx
@@ -41,7 +41,7 @@ function SelectVariationMode(props: VariationSelectModeProps) {
 
   return (
     <div className={styles.skuSelectorSelectContainer}>
-      {/* Warning: don't change this name property because it's used to check on Slider component, to avoid preventDefault of the event trigger by the dropdown */}
+      {/* Warning: don't change the name property. Its value is being checked in the Slider component to avoid a preventDefault call on the event triggered by the dropdown. */}
       <Dropdown
         name="product-summary-sku-selector"
         options={options}

--- a/react/components/SKUSelector/components/SelectVariationMode.tsx
+++ b/react/components/SKUSelector/components/SelectVariationMode.tsx
@@ -41,7 +41,9 @@ function SelectVariationMode(props: VariationSelectModeProps) {
 
   return (
     <div className={styles.skuSelectorSelectContainer}>
+      {/* Warning: don't change this name property because it's used to check on Slider component, to avoid preventDefault of the event trigger by the dropdown */}
       <Dropdown
+        name="product-summary-sku-selector"
         options={options}
         value={selectedItem}
         onChange={handleClick}


### PR DESCRIPTION
#### What problem is this solving?
Fix a bug that the ProductSummarySKUSelector on mode select doesn't open the select dropdown due to that event is default prevented inside the onMouseDown function from the slider with multiples pages.

#### How to test it?
[Fixed Workspace](https://brasileirovtex--dacris.myvtex.com/marker-pentru-tabla-pilot-vboard-master-varf-rotund-2-3-mm/p?__bindingAddress=www.dacris.net/)
[Production workspace](https://dacris.myvtex.com/marker-pentru-tabla-pilot-vboard-master-varf-rotund-2-3-mm/p?__bindingAddress=www.dacris.net/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered if any.
Considered use another HTML property, but the name seems good.

#### Related to / Depends on
https://github.com/vtex-apps/slider/pull/51

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/lgVqVJjPvLAl2/giphy.gif)
