### PR TITLE
Fix buy button to add multiple items (buy together)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `BuyButton` when item has no `skuId`.
+- `BuyButtonMessage` when `children` array is empty.
 
 ## [3.148.1] - 2021-07-08
 ### Added

--- a/react/components/BuyButton/Wrapper.js
+++ b/react/components/BuyButton/Wrapper.js
@@ -165,7 +165,7 @@ const BuyButtonWrapper = ({
       showTooltipOnSkuNotSelected={showTooltipOnSkuNotSelected}
       checkoutUrl={checkoutUrl}
     >
-      {children || (
+      {children && children.length > 0 ? children : (
         <BuyButtonMessage showItemsPrice={showItemsPrice} skuItems={skuItems} />
       )}
     </BuyButton>

--- a/react/components/BuyButton/Wrapper.js
+++ b/react/components/BuyButton/Wrapper.js
@@ -165,7 +165,9 @@ const BuyButtonWrapper = ({
       showTooltipOnSkuNotSelected={showTooltipOnSkuNotSelected}
       checkoutUrl={checkoutUrl}
     >
-      {children && children.length > 0 ? children : (
+      {children && children.length > 0 ? (
+        children
+      ) : (
         <BuyButtonMessage showItemsPrice={showItemsPrice} skuItems={skuItems} />
       )}
     </BuyButton>

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -189,7 +189,8 @@ export const BuyButton = ({
           skuItem =>
             !!items.find(
               ({ id, seller }) =>
-                (id === skuItem.skuId || id === skuItem.id) && seller === skuItem.seller
+                (id === skuItem.skuId || id === skuItem.id) &&
+                seller === skuItem.seller
             )
         )
         await orderFormContext.refetch().catch(() => null)
@@ -201,7 +202,8 @@ export const BuyButton = ({
             skuItem =>
               !!linkStateItems.find(
                 ({ id, seller }) =>
-                  (id === skuItem.skuId || id === skuItem.id) && seller === skuItem.seller
+                  (id === skuItem.skuId || id === skuItem.id) &&
+                  seller === skuItem.seller
               )
           )) ||
         success

--- a/react/components/BuyButton/index.js
+++ b/react/components/BuyButton/index.js
@@ -40,7 +40,7 @@ const isTooltipNeeded = ({ showTooltipOnSkuNotSelected, skuSelector }) => {
 const skuItemToMinicartItem = item => {
   return {
     // Important for the mutation
-    id: item.skuId,
+    id: item.skuId ?? item.id,
     seller: item.seller,
     options: item.options,
     quantity: item.quantity,
@@ -173,7 +173,7 @@ export const BuyButton = ({
         const variables = {
           orderFormId: orderFormContext.orderForm.orderFormId,
           items: skuItems.map(item => ({
-            id: item.skuId,
+            id: item.skuId ?? item.id,
             seller: item.seller,
             options: item.options,
             quantity: item.quantity,
@@ -189,7 +189,7 @@ export const BuyButton = ({
           skuItem =>
             !!items.find(
               ({ id, seller }) =>
-                id === skuItem.skuId && seller === skuItem.seller
+                (id === skuItem.skuId || id === skuItem.id) && seller === skuItem.seller
             )
         )
         await orderFormContext.refetch().catch(() => null)
@@ -201,7 +201,7 @@ export const BuyButton = ({
             skuItem =>
               !!linkStateItems.find(
                 ({ id, seller }) =>
-                  id === skuItem.skuId && seller === skuItem.seller
+                  (id === skuItem.skuId || id === skuItem.id) && seller === skuItem.seller
               )
           )) ||
         success


### PR DESCRIPTION
#### What problem is this solving?

In the buy together shelves, the BuyButton didn't work properly. It expects the `skuItems` item to always come with `skuId`, but in some cases the items only have `id` (which is the same as `skuId`). We need to check if the `skuId` exists, and otherwise use the `id`

Also, in some cases the Wrapper's children may come as an empty array, and when that happened the Wrapper was rendering the empty children, instead of rendering the `BuyButtonMessage`, for this I also added a check on the size of the children.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
[Before](https://recommendation1--calvinklein.myvtex.com/camiseta-feminina-slim-manga-curta-pride-preta-cf1op01bc230_0987/p)
[After](https://recommendation--calvinklein.myvtex.com/camiseta-feminina-slim-manga-curta-pride-preta-cf1op01bc230_0987/p)

#### Screenshots or example usage:

Before:
![before](https://user-images.githubusercontent.com/20840671/124761255-fbf78580-df07-11eb-89b4-a56533f88655.gif)

After:
![after](https://user-images.githubusercontent.com/20840671/124761271-0023a300-df08-11eb-917f-bfa13101f9bd.gif)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
