### PR TITLE
added prop that bring field from Prod SPEC

### DIFF
--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -15,7 +15,7 @@ const ProductImagesWrapper = props => {
     showNavigationArrows,
     showPaginationDots,
     contentOrder,
-    placeholder,
+    placeholder
   } = useResponsiveValues(
     pick(
       [
@@ -91,6 +91,7 @@ const ProductImagesWrapper = props => {
       contentOrder={contentOrder}
       ModalZoomElement={props.ModalZoom}
       contentType={props.contentType}
+      productSpecification={props.productSpecification}
       // Deprecated
       zoomProps={props.zoomProps}
       displayMode={props.displayMode}
@@ -176,7 +177,7 @@ ProductImagesWrapper.getSchema = ({ zoomProps: { zoomType } = {} }) => ({
       type: 'boolean',
       default: false,
       isLayout: true,
-    },
+    }
   },
 })
 

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -148,6 +148,8 @@ class Carousel extends Component {
       zoomFactor,
       ModalZoomElement,
       zoomProps: legacyZoomProps,
+      fieldValue,
+      positionOfSpecification
     } = this.props
 
     // Backwards compatibility
@@ -167,6 +169,8 @@ class Carousel extends Component {
             aspectRatio={aspectRatio}
             ModalZoomElement={ModalZoomElement}
             zoomMode={isZoomDisabled ? 'disabled' : zoomMode}
+            positionOfSpecification={positionOfSpecification}
+            fieldValue={fieldValue}
           />
         )
 

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useMemo, useRef } from 'react'
 import { Modal } from 'vtex.modal-layout'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
-
+import styles from './specificationDiv.css'
 import Zoomable, { ZoomMode } from './Zoomable'
 import { imageUrl } from '../utils/aspectRatioUtil'
 import ProductImageContext, {
@@ -20,7 +20,9 @@ interface Props {
   zoomFactor: number
   aspectRatio?: AspectRatio
   maxHeight?: number | string
-  ModalZoomElement?: typeof Modal
+  ModalZoomElement?: typeof Modal,
+  positionOfSpecification?: number,
+  fieldValue?: string
 }
 
 type AspectRatio = string | number
@@ -36,6 +38,8 @@ const ProductImage: FC<Props> = ({
   ModalZoomElement,
   aspectRatio = 'auto',
   zoomMode = 'in-place-click',
+  positionOfSpecification=0,
+  fieldValue=''
 }) => {
   const srcSet = useMemo(
     () =>
@@ -115,6 +119,11 @@ const ProductImage: FC<Props> = ({
             sizes="(max-width: 64.1rem) 100vw, 50vw"
           />
         </Zoomable>
+        <div className={styles.containerProdSpecification}>
+          <p>
+            {index == positionOfSpecification ? fieldValue : ''}
+          </p>
+        </div>
       </div>
     </ProductImageContext.Provider>
   )

--- a/react/components/ProductImages/components/specificationDiv.css
+++ b/react/components/ProductImages/components/specificationDiv.css
@@ -1,0 +1,39 @@
+.containerProdSpecification {
+  max-width: 528px;
+
+  font-family: 'Gidole';
+  font-style: normal;
+  font-weight: normal;
+  font-size: 12px;
+  line-height: 18px;
+  margin-top: -3px;
+
+  display: flex;
+  align-items: center;
+  text-align: center;
+
+  color: #4e4e4e;
+  padding: 4px 17px;
+
+  background-color: #eaeaea;
+}
+.containerProdSpecification p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+@media (max-width: 1366px) {
+  .containerProdSpecification {
+    max-width: 529px;
+    padding: 0 10px;
+  }
+}
+@media (max-width: 1280px) {
+  .containerProdSpecification {
+    max-width: 521px;
+  }
+}
+@media (max-width: 1024px) {
+  .containerProdSpecification {
+    max-width: 780px;
+  }
+}

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { useCssHandles } from 'vtex.css-handles'
-
+import { useProduct } from 'vtex.product-context'
 import Carousel from './components/Carousel'
 import ProductImage from './components/ProductImage'
 import {
@@ -32,10 +32,13 @@ const ProductImages = ({
   zoomFactor,
   ModalZoomElement,
   contentType = 'all',
+  productSpecification = {},
   // Deprecated
   zoomProps,
   displayMode,
 }) => {
+  const productCtx = useProduct()
+  const { product: productInfo } = productCtx
   if (hiddenImages && !Array.isArray(hiddenImages)) {
     hiddenImages = [hiddenImages]
   }
@@ -54,17 +57,17 @@ const ProductImages = ({
 
     return shouldIncludeImages
       ? allImages
-          .filter(
-            image =>
-              !image.imageLabel ||
-              !excludeImageRegexes.some(regex => regex.test(image.imageLabel))
-          )
-          .map(image => ({
-            type: 'image',
-            url: image.imageUrls ? image.imageUrls[0] : image.imageUrl,
-            alt: image.imageText,
-            thumbUrl: image.thumbnailUrl || image.imageUrl,
-          }))
+        .filter(
+          image =>
+            !image.imageLabel ||
+            !excludeImageRegexes.some(regex => regex.test(image.imageLabel))
+        )
+        .map(image => ({
+          type: 'image',
+          url: image.imageUrls ? image.imageUrls[0] : image.imageUrl,
+          alt: image.imageText,
+          thumbUrl: image.thumbnailUrl || image.imageUrl,
+        }))
       : []
   }, [allImages, contentType, excludeImageRegexes])
 
@@ -73,10 +76,10 @@ const ProductImages = ({
 
     return shouldIncludeVideos
       ? allVideos.map(video => ({
-          type: 'video',
-          src: video.videoUrl,
-          thumbWidth: 300,
-        }))
+        type: 'video',
+        src: video.videoUrl,
+        thumbWidth: 300,
+      }))
       : []
   }, [allVideos, contentType])
 
@@ -85,6 +88,12 @@ const ProductImages = ({
   const slides = useMemo(() => {
     return showVideosFirst ? [...videos, ...images] : [...images, ...videos]
   }, [showVideosFirst, videos, images])
+  let { position: positionOfSpecification, fieldName } = productSpecification
+  let fieldValue=''
+  productInfo.properties.forEach( specification  => {
+    if(specification.name === fieldName) fieldValue = specification.values
+  })
+  positionOfSpecification = positionOfSpecification > slides.length ? slides.length : positionOfSpecification
 
   const { zoomType: legacyZoomType } = zoomProps || {}
   const isZoomDisabled = legacyZoomType === 'no-zoom' || zoomMode === 'disabled'
@@ -126,6 +135,8 @@ const ProductImages = ({
         showNavigationArrows={showNavigationArrows}
         thumbnailsOrientation={thumbnailsOrientation}
         displayThumbnailsArrows={displayThumbnailsArrows}
+        positionOfSpecification={positionOfSpecification}
+        fieldValue={fieldValue}
         // Deprecated
         zoomProps={zoomProps}
       />


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How to test it?

Product specification only shows up in the first picture, name of the field and position is set through blocks 

[Workspace] https://newpdp--homologoutletespacohering.myvtex.com/blusa-basica-feminina-em-algodao-supima-e-manga-flare-4fcan10en/p

#### Screenshots or example usage:
![image](https://user-images.githubusercontent.com/30512726/124806748-6bcf3580-df33-11eb-9d60-65c04bf019a8.png)
![image](https://user-images.githubusercontent.com/30512726/124806646-50fcc100-df33-11eb-9f01-5b2e203958af.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)



![](https://media.giphy.com/media/l3vR1UUnuJU12rzs4/giphy.gif)
