### PR TITLE
Add social media identifier class to SocialButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 - Added social media identifier class to SocialButton
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.149.0] - 2021-07-20
 ### Added
 - Added social media identifier class to SocialButton
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.149.0] - 2021-07-20
+### Added
+- Added social media identifier class to SocialButton
+
 ## [3.148.2] - 2021-07-12
 ### Fixed
 - `BuyButton` when item has no `skuId`.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-config-vtex-react": "^6.7.3",
     "husky": "^4.2.0",
     "lint-staged": "^10.0.2",
-    "prettier": "^2.0.5",
+    "prettier": "2.3.2",
     "typescript": "^3.7.5"
   }
 }

--- a/react/components/Share/components/SocialButton.js
+++ b/react/components/Share/components/SocialButton.js
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import { SOCIAL_NAME_MAP, SOCIAL_COMPONENT_MAP } from '../constants/social'
 import styles from '../styles.css'
+import { slug } from '../../SKUSelector/utils'
 
 const SOCIAL_WITH_TITLE = new Set([
   SOCIAL_NAME_MAP.whatsapp,
@@ -72,7 +73,10 @@ export default class SocialButton extends Component {
       <SocialIcon
         round
         size={size}
-        className={classNames(styles.shareSocialIcon, iconClass)}
+        className={classNames(
+          styles.shareSocialIcon,
+          `${styles.shareSocialIcon}--${slug(SocialNetworkName)}`,
+          iconClass)}
       />
     )
 
@@ -85,7 +89,10 @@ export default class SocialButton extends Component {
     return (
       <SocialComponent
         url={url}
-        className={classNames(styles.shareSocialButton, buttonClass)}
+        className={classNames(
+          styles.shareSocialButton,
+          `${styles.shareSocialButton}--${slug(SocialNetworkName)}`,
+          buttonClass)}
         media={imageUrl}
         {...additionalProps}
       >

--- a/react/components/Share/components/SocialButton.js
+++ b/react/components/Share/components/SocialButton.js
@@ -51,21 +51,11 @@ export default class SocialButton extends Component {
   }
 
   render() {
-    const {
-      url,
-      message,
-      size,
-      socialEnum,
-      buttonClass,
-      iconClass,
-      imageUrl,
-    } = this.props
+    const { url, message, size, socialEnum, buttonClass, iconClass, imageUrl } =
+      this.props
 
-    const {
-      SocialNetworkName,
-      SocialComponent,
-      SocialIcon,
-    } = SOCIAL_COMPONENT_MAP[socialEnum]
+    const { SocialNetworkName, SocialComponent, SocialIcon } =
+      SOCIAL_COMPONENT_MAP[socialEnum]
 
     const additionalProps = getExtraSocialProps({ message, socialEnum })
 
@@ -76,7 +66,8 @@ export default class SocialButton extends Component {
         className={classNames(
           styles.shareSocialIcon,
           `${styles.shareSocialIcon}--${slug(SocialNetworkName)}`,
-          iconClass)}
+          iconClass
+        )}
       />
     )
 
@@ -92,7 +83,8 @@ export default class SocialButton extends Component {
         className={classNames(
           styles.shareSocialButton,
           `${styles.shareSocialButton}--${slug(SocialNetworkName)}`,
-          buttonClass)}
+          buttonClass
+        )}
         media={imageUrl}
         {...additionalProps}
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,10 +2035,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.0.5:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
-  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
+prettier@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
#### What problem is this solving?

We currently can't customize the appearance of social media buttons without a way to identify them individually by name. 
I added classes to the button and icon to make this possible.

#### How to test it?

[Workspace](https://frnqa2--taafrl.myvtex.com/cerveja-duvel-666-gf-330ml/p!)

Just go to any product and check the included classes for customization

#### Screenshots or example usage:

Before:
![image](https://user-images.githubusercontent.com/7140358/125726935-6a3a5cec-739d-467c-a39f-1a477d0e863d.png)

After:
![image](https://user-images.githubusercontent.com/7140358/125726816-b861f743-bcb1-4ed1-a1f1-16ba807f966c.png)

#### Describe alternatives you've considered, if any.

#### Related to / Depends on

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/gLZHNXvnaiHok/giphy.gif)
