### PR TITLE
Update README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
++ ### Fixed
+- Highlight deprecated components on `README.md`: `Animation`, `Categories Highlights`, `Collection Badges`, `Container`, `Discount Badge`, `Gradient Collapse`, `Greeting`and `Slider`.
+
 
 ## [3.149.0] - 2021-07-15
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,16 +71,9 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 
 Below we have a README for each component of this project that explains how to use them.
 
-- [Animation](Animation.md)
 - [Availability Subscriber](AvailabilitySubscriber.md)
 - [Back To Top Button](BackToTopButton.md)
 - [Buy Button](BuyButton.md)
-- [Categories Highlights](CategoriesHighlights.md)
-- [Collection Badges](CollectionBadges.md)
-- [Container](Container.md)
-- [Discount Badge](DiscountBadge.md)
-- [Gradient Collapse](GradientCollapse.md)
-- [Greeting](Greeting.md)
 - [Image](Image.md)
 - [InfoCard](InfoCard.md)
 - [Logo](Logo.md)
@@ -96,8 +89,11 @@ Below we have a README for each component of this project that explains how to u
 - [Search Bar](SearchBar.md)
 - [Share](Share.md)
 - [Shipping Simulator](ShippingSimulator.md)
-- [Slider](Slider.md)
 - [Notification](Notification.md)
+
+
+> :warning: **The following blocks have been deprecated:** `Animation`, `Categories Highlights`, `Collection Badges`, `Container`, `Discount Badge`, `Gradient Collapse`, `Greeting`, `Slide`. 
+> Despite this, support for them is still granted.
 
 ## Creating a new component
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,7 @@ Below we have a README for each component of this project that explains how to u
 - [Notification](Notification.md)
 
 
-> :warning: **The following blocks have been deprecated:** `Animation`, `Categories Highlights`, `Collection Badges`, `Container`, `Discount Badge`, `Gradient Collapse`, `Greeting`, `Slide`. 
+> :warning: **The following blocks have been deprecated:** `Animation`, `Categories Highlights`, `Collection Badges`, `Container`, `Discount Badge`, `Gradient Collapse`, `Greeting`, `Slider`. 
 > Despite this, support for them is still granted.
 
 ## Creating a new component


### PR DESCRIPTION
#### What problem is this solving?

According to the [CHANGELOG.md](https://github.com/vtex-apps/store-components/blob/master/CHANGELOG.md#31323---2020-12-01), the following components were deprecated: `Animation`, `Categories Highlights`, `Collection Badges`, `Container`, `Discount Badge`, `Gradient Collapse`, `Greeting`, `Slider` and apparently they do not longer have a repo on Github.

My suggestion is to have a callout on README.md pointing this change.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
The links for `Animation`, `Categories Highlights`, `Collection Badges`, `Container`, `Discount Badge`, `Gradient Collapse`, `Greeting`, `Slider` are broken: 
[Store Components](https://github.com/vtex-apps/store-components#components-specs)

These also reflect on Developer Portal
[Store Components - Developer Portal](https://developers.vtex.com/vtex-developer-docs/docs/vtex-store-components#components-specs)


#### Describe alternatives you've considered, if any.

1. Have a callout on README.md pointing the deprecated components
2. See if we have other alternatives for the deprecated components and make sure to direct users to them.


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/fm4WhPMzu9hRK/giphy.gif)
