### PR TITLE
Dispatch set_loading_item if skuid is different

### DIFF
--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -291,6 +291,8 @@ const SKUSelectorContainer: FC<Props> = ({
 
   const dispatch = useProductDispatch()
 
+  const getSkuId = () => query?.skuId
+
   const onSelectItem = useCallback(
     ({
       name: variationName,
@@ -299,13 +301,18 @@ const SKUSelectorContainer: FC<Props> = ({
       isMainAndImpossible,
       possibleItems,
     }) => {
-      dispatch({
-        type: 'SET_LOADING_ITEM',
-        args: { loadingItem: true },
-      })
+      const querySkuId = getSkuId()
+
+      if (querySkuId !== skuId) {
+        dispatch({
+          type: 'SET_LOADING_ITEM',
+          args: { loadingItem: true },
+        })
+      }
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const isRemoving = selectedVariations![variationName] === variationValue
+
       const newSelectedVariation = !isMainAndImpossible
         ? {
             ...selectedVariations,


### PR DESCRIPTION
#### What problem is this solving?
Prevent dispatch of the set_loading_item if SKU id is equal to the query. This avoids disabling the add-to-cart-button.
Related to https://github.com/vtex-apps/add-to-cart-button/pull/92 https://github.com/vtex-apps/product-context/pull/61

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace-alss](https://brasprod--alssports.myvtex.com/peakre-food-mountain-berry-granola/p)
[workspace-melisseiras](https://brasileiro--melisseiras.myvtex.com/melissa-sun-rodeo-vermelho-33530/p)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
