### PR TITLE
PromoView event for Info-Card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `analyticsProperties` prop to `Info-Card` that shows analytics informations about this component when active.
 ## [3.149.0] - 2021-07-15
 ### Added
 - `disableUnavailableSelectOptions` prop to `SKUSelector` in order to disable unavailable items when `displayMode` is set to `select`.

--- a/docs/InfoCard.md
+++ b/docs/InfoCard.md
@@ -51,6 +51,7 @@ The `infoCard` block allows you to **display content combining image and text** 
 | `blockClass` | `String` | Adds an extra class name to ease styling. | `null` |
 | `htmlId` | `String` | Adds an ID to the container element. | `null` |
 | `linkTarget` | `LinkTargetEnum` | Where to display the linked URL when `info-card` block is clicked. | `"_self"` |
+| `analyticsProperties` | `String` | An option to show analytics informations in this component when active | `none` |
 
 - Possible values of `TextPositionEnum`:
 

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,8 @@
     "vtex.store-icons": "0.x",
     "vtex.store-image": "0.x",
     "vtex.store-resources": "0.x",
-    "vtex.styleguide": "9.x"
+    "vtex.styleguide": "9.x",
+    "vtex.on-view": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -126,6 +126,12 @@
   "admin/editor.info-card.callAction.link": "Name of enum value to make CTA a link",
   "admin/editor.info-card.imageActionUrl.title": "Name of imageActionUrl property",
   "admin/editor.info-card.imageActionUrl.description": "Name of imageActionUrl description",
+  "admin/editor.info-card.analytics.title": "Analytics event",
+  "admin/editor.info-card.analytics.none": "No",
+  "admin/editor.info-card.analytics.provide": "Yes",
+  "admin/editor.info-card.analytics.promotionId": "Promotion ID",
+  "admin/editor.info-card.analytics.promotionName": "Promotion Name",
+  "admin/editor.info-card.analytics.promotionPosition": "Creative position",
   "store/user-address.pickup": "Pickup at <address>",
   "store/user-address.order": "Order to <address>",
   "store/user-address.change": "Change address button label",
@@ -191,9 +197,5 @@
   "admin/editor.product-description.title-prop.title": "Title",
   "admin/editor.search-bar.title": "Search bar",
   "admin/editor.search-bar.placeholder.title": "Placeholder",
-  "store/back-to-top.label": "Back to top",
-  "admin/editor.analyticsProperties.title": "admin/editor.analyticsProperties.title",
-  "admin/editor.promotionId.title": "admin/editor.promotionId.title",
-  "admin/editor.promotionName.title": "admin/editor.promotionName.title",
-  "admin/editor.promotionPosition.title": "admin/editor.promotionPosition.title"
+  "store/back-to-top.label": "Back to top"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -191,5 +191,9 @@
   "admin/editor.product-description.title-prop.title": "Title",
   "admin/editor.search-bar.title": "Search bar",
   "admin/editor.search-bar.placeholder.title": "Placeholder",
-  "store/back-to-top.label": "Back to top"
+  "store/back-to-top.label": "Back to top",
+  "admin/editor.analyticsProperties.title": "admin/editor.analyticsProperties.title",
+  "admin/editor.promotionId.title": "admin/editor.promotionId.title",
+  "admin/editor.promotionName.title": "admin/editor.promotionName.title",
+  "admin/editor.promotionPosition.title": "admin/editor.promotionPosition.title"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -126,6 +126,12 @@
   "admin/editor.info-card.callAction.link": "Link",
   "admin/editor.info-card.imageActionUrl.title": "Image Action URL",
   "admin/editor.info-card.imageActionUrl.description": "Pass URL to make image a link and able to redirect user",
+  "admin/editor.info-card.analytics.title": "Analytics event",
+  "admin/editor.info-card.analytics.none": "No",
+  "admin/editor.info-card.analytics.provide": "Yes",
+  "admin/editor.info-card.analytics.promotionId": "Promotion ID",
+  "admin/editor.info-card.analytics.promotionName": "Promotion Name",
+  "admin/editor.info-card.analytics.promotionPosition": "Creative position",
   "store/user-address.pickup": "Pick up at {name}",
   "store/user-address.order": "Order to",
   "store/user-address.change": "Change",
@@ -195,9 +201,5 @@
   "admin/editor.toTop.title": "Back to top button",
   "admin/editor.toTop.description": "When clicked it takes the page to the top",
   "admin/editor.toTop.topPixel.title": "Number of pixels",
-  "admin/editor.toTop.topPixel.description": "When exceeding the defined pixel value, the button to return to the top will appear",
-  "admin/editor.analyticsProperties.title": "Analytics Properties",
-  "admin/editor.promotionId.title": "Promotion ID",
-  "admin/editor.promotionName.title": "Promotion Name",
-  "admin/editor.promotionPosition.title": "Promotion Position"
+  "admin/editor.toTop.topPixel.description": "When exceeding the defined pixel value, the button to return to the top will appear"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -195,5 +195,9 @@
   "admin/editor.toTop.title": "Back to top button",
   "admin/editor.toTop.description": "When clicked it takes the page to the top",
   "admin/editor.toTop.topPixel.title": "Number of pixels",
-  "admin/editor.toTop.topPixel.description": "When exceeding the defined pixel value, the button to return to the top will appear"
+  "admin/editor.toTop.topPixel.description": "When exceeding the defined pixel value, the button to return to the top will appear",
+  "admin/editor.analyticsProperties.title": "Analytics Properties",
+  "admin/editor.promotionId.title": "Promotion ID",
+  "admin/editor.promotionName.title": "Promotion Name",
+  "admin/editor.promotionPosition.title": "Promotion Position"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -126,6 +126,12 @@
   "admin/editor.info-card.callAction.link": "Link",
   "admin/editor.info-card.imageActionUrl.title": "URL de acción de la imagen",
   "admin/editor.info-card.imageActionUrl.description": "Pase la URL para hacer de la imagen un enlace y poder redirigir al usuario",
+  "admin/editor.info-card.analytics.title": "Evento do Analytics",
+  "admin/editor.info-card.analytics.none": "No",
+  "admin/editor.info-card.analytics.provide": "Si",
+  "admin/editor.info-card.analytics.promotionId": "ID de promoción",
+  "admin/editor.info-card.analytics.promotionName": "Nombre de la promoción",
+  "admin/editor.info-card.analytics.promotionPosition": "Posición de la creatividad",
   "store/user-address.pickup": "Recoger en {name}",
   "store/user-address.order": "Orden a",
   "store/user-address.change": "Cambiar",
@@ -195,9 +201,5 @@
   "admin/editor.toTop.title": "Back to top button",
   "admin/editor.toTop.description": "Al hacer clic, lleva la página a la parte superior",
   "admin/editor.toTop.topPixel.title": "Número de píxeles",
-  "admin/editor.toTop.topPixel.description": "Al exceder el valor de píxel definido, aparecerá el botón para volver a la parte superior.",
-  "admin/editor.analyticsProperties.title": "Analytics Properties",
-  "admin/editor.promotionId.title": "Promotion ID",
-  "admin/editor.promotionName.title": "Promotion Name",
-  "admin/editor.promotionPosition.title": "Promotion Position"
+  "admin/editor.toTop.topPixel.description": "Al exceder el valor de píxel definido, aparecerá el botón para volver a la parte superior."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -195,5 +195,9 @@
   "admin/editor.toTop.title": "Back to top button",
   "admin/editor.toTop.description": "Al hacer clic, lleva la página a la parte superior",
   "admin/editor.toTop.topPixel.title": "Número de píxeles",
-  "admin/editor.toTop.topPixel.description": "Al exceder el valor de píxel definido, aparecerá el botón para volver a la parte superior."
+  "admin/editor.toTop.topPixel.description": "Al exceder el valor de píxel definido, aparecerá el botón para volver a la parte superior.",
+  "admin/editor.analyticsProperties.title": "Analytics Properties",
+  "admin/editor.promotionId.title": "Promotion ID",
+  "admin/editor.promotionName.title": "Promotion Name",
+  "admin/editor.promotionPosition.title": "Promotion Position"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -195,5 +195,9 @@
   "admin/editor.toTop.title": "Botão Voltar ao topo",
   "admin/editor.toTop.description": "Quando clicado, leva a página ao topo",
   "admin/editor.toTop.topPixel.title": "Número de pixels",
-  "admin/editor.toTop.topPixel.description": "Ao exceder o valor de pixel definido, o botão para retornar ao topo aparecerá"
+  "admin/editor.toTop.topPixel.description": "Ao exceder o valor de pixel definido, o botão para retornar ao topo aparecerá",
+  "admin/editor.analyticsProperties.title": "Analytics Properties",
+  "admin/editor.promotionId.title": "Promotion ID",
+  "admin/editor.promotionName.title": "Promotion Name",
+  "admin/editor.promotionPosition.title": "Promotion Position"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -126,6 +126,12 @@
   "admin/editor.info-card.callAction.link": "Link",
   "admin/editor.info-card.imageActionUrl.title": "URL de Ação da Imagem",
   "admin/editor.info-card.imageActionUrl.description": "Passe a URL para tornar a imagem um link e capaz de redirecionar o usuário",
+  "admin/editor.info-card.analytics.title": "Evento do Analytics",
+  "admin/editor.info-card.analytics.none": "Não",
+  "admin/editor.info-card.analytics.provide": "Sim",
+  "admin/editor.info-card.analytics.promotionId": "Id da promoção",
+  "admin/editor.info-card.analytics.promotionName": "Nome da promoção",
+  "admin/editor.info-card.analytics.promotionPosition": "Posição do criativo",
   "store/user-address.pickup": "Retirar em {name}",
   "store/user-address.order": "Enviar para",
   "store/user-address.change": "Alterar",
@@ -195,9 +201,5 @@
   "admin/editor.toTop.title": "Botão Voltar ao topo",
   "admin/editor.toTop.description": "Quando clicado, leva a página ao topo",
   "admin/editor.toTop.topPixel.title": "Número de pixels",
-  "admin/editor.toTop.topPixel.description": "Ao exceder o valor de pixel definido, o botão para retornar ao topo aparecerá",
-  "admin/editor.analyticsProperties.title": "Analytics Properties",
-  "admin/editor.promotionId.title": "Promotion ID",
-  "admin/editor.promotionName.title": "Promotion Name",
-  "admin/editor.promotionPosition.title": "Promotion Position"
+  "admin/editor.toTop.topPixel.description": "Ao exceder o valor de pixel definido, o botão para retornar ao topo aparecerá"
 }

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -10,7 +10,10 @@ import {
 import { formatIOMessage } from 'vtex.native-types'
 import { useCssHandles } from 'vtex.css-handles'
 import { useOnView } from 'vtex.on-view'
+
 import RichText from 'vtex.rich-text/index'
+import { usePixel } from 'vtex.pixel-manager'
+
 
 import CallToAction from './CallToAction'
 import LinkWrapper from './LinkWrapper'
@@ -173,20 +176,21 @@ const InfoCard = ({
 
   const subheadClasses = `${handles.infoCardSubhead} t-body mt6 c-on-base ${alignToken} mw-100`
 
+  const infoCardRef = useRef(null)
+  
+  const { push } = usePixel()
+
   const promotionEventData =
     analyticsProperties === 'provide'
       ? {
           id: promotionId,
           name: promotionName,
-          creative: formattedSrc,
           position: promotionPosition,
         }
       : undefined
    
-  const imageRef = useRef(null)
-
   useOnView({
-    ref: imageRef,
+    ref: infoCardRef,
     onView: () => {
       if (analyticsProperties === 'none') return
 
@@ -209,6 +213,7 @@ const InfoCard = ({
         style={containerStyle}
         data-testid="container"
         id={htmlId}
+        ref={infoCardRef}
         {...containerAttributes}
       >
         <div className={textContainerClasses}>
@@ -285,10 +290,6 @@ MemoizedInfoCard.propTypes = {
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
   linkTarget: oneOf(['_self', '_blank', '_parent', '_top']),
   callToActionLinkTarget: oneOf(['_self', '_blank', '_parent', '_top']),
-  analyticsProperties: bool,
-  promotionId: string,
-  promotionName: string,
-  promotionPosition: string,
 }
 
 MemoizedInfoCard.defaultProps = {
@@ -305,10 +306,6 @@ MemoizedInfoCard.defaultProps = {
   textMode: textModeTypes.TEXT_MODE_HTML.value,
   linkTarget: '_self',
   callToActionLinkTarget: '_self',
-  analyticsProperties: false,
-  promotionId: '',
-  promotionName: '',
-  promotionPosition: '',
 }
 
 MemoizedInfoCard.schema = {
@@ -365,26 +362,6 @@ MemoizedInfoCard.schema = {
       type: 'string',
       isLayout: true,
     },
-    analyticsProperties: {
-      title: 'admin/editor.analyticsProperties.title',
-      type: 'bool',
-      default: false,
-    },
-    promotionId: {
-      title: 'admin/editor.promotionId.title',
-      type: 'string',
-      default: "",
-    },
-    promotionName: {
-      title: 'admin/editor.promotionName.title',
-      type: 'string',
-      default: "",
-    },
-    promotionPosition: {
-      title: 'admin/editor.promotionPosition.title',
-      type: 'string',
-      default: "",
-    }
   },
 }
 

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes, { bool, string, oneOf } from 'prop-types'
-import React, { memo } from 'react'
+import React, { memo, useRef } from 'react'
 import { values } from 'ramda'
 import { injectIntl } from 'react-intl'
 import {
@@ -9,6 +9,7 @@ import {
 } from 'vtex.render-runtime'
 import { formatIOMessage } from 'vtex.native-types'
 import { useCssHandles } from 'vtex.css-handles'
+import { useOnView } from 'vtex.on-view'
 import RichText from 'vtex.rich-text/index'
 
 import CallToAction from './CallToAction'
@@ -95,6 +96,10 @@ const InfoCard = ({
   htmlId,
   textMode,
   linkTarget,
+  analyticsProperties = 'none',
+  promotionId,
+  promotionName,
+  promotionPosition,
 }) => {
   const {
     hints: { mobile },
@@ -167,6 +172,31 @@ const InfoCard = ({
   const headlineClasses = `${handles.infoCardHeadline} t-heading-2 mt6 ${alignToken} c-on-base mw-100`
 
   const subheadClasses = `${handles.infoCardSubhead} t-body mt6 c-on-base ${alignToken} mw-100`
+
+  const promotionEventData =
+    analyticsProperties === 'provide'
+      ? {
+          id: promotionId,
+          name: promotionName,
+          creative: formattedSrc,
+          position: promotionPosition,
+        }
+      : undefined
+   
+  const imageRef = useRef(null)
+
+  useOnView({
+    ref: imageRef,
+    onView: () => {
+      if (analyticsProperties === 'none') return
+
+      push({
+        event: 'promoView',
+        promotions: [promotionEventData],
+      })
+    },
+    once: true,
+  })
 
   return (
     <LinkWrapper
@@ -255,6 +285,10 @@ MemoizedInfoCard.propTypes = {
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
   linkTarget: oneOf(['_self', '_blank', '_parent', '_top']),
   callToActionLinkTarget: oneOf(['_self', '_blank', '_parent', '_top']),
+  analyticsProperties: bool,
+  promotionId: string,
+  promotionName: string,
+  promotionPosition: string,
 }
 
 MemoizedInfoCard.defaultProps = {
@@ -271,6 +305,10 @@ MemoizedInfoCard.defaultProps = {
   textMode: textModeTypes.TEXT_MODE_HTML.value,
   linkTarget: '_self',
   callToActionLinkTarget: '_self',
+  analyticsProperties: false,
+  promotionId: '',
+  promotionName: '',
+  promotionPosition: '',
 }
 
 MemoizedInfoCard.schema = {
@@ -327,6 +365,26 @@ MemoizedInfoCard.schema = {
       type: 'string',
       isLayout: true,
     },
+    analyticsProperties: {
+      title: 'admin/editor.analyticsProperties.title',
+      type: 'bool',
+      default: false,
+    },
+    promotionId: {
+      title: 'admin/editor.promotionId.title',
+      type: 'string',
+      default: "",
+    },
+    promotionName: {
+      title: 'admin/editor.promotionName.title',
+      type: 'string',
+      default: "",
+    },
+    promotionPosition: {
+      title: 'admin/editor.promotionPosition.title',
+      type: 'string',
+      default: "",
+    }
   },
 }
 

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -65,28 +65,13 @@
           "description": "admin/editor.info-card.analytics.description",
           "enum": ["none", "provide"],
           "enumNames": [
-            "admin/editor.image.analytics.none",
-            "admin/editor.image.analytics.provide"
+            "admin/editor.info-card.analytics.none",
+            "admin/editor.info-card.analytics.provide"
           ],
           "widget": {
             "ui:widget": "radio"
           },
           "default": "none"
-        },
-        "promotionId": {
-          "title": "admin/editor.info-card.analytics.promotionId",
-          "type": "string",
-          "default": ""
-        },
-        "promotionName": {
-          "title": "admin/editor.info-card.analytics.promotionName",
-          "type": "string",
-          "default": ""
-        },
-        "promotionPosition": {
-          "title": "admin/editor.info-card.analytics.promotionPosition",
-          "type": "string",
-          "default": ""
         }
       },
       "dependencies": {

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -59,6 +59,69 @@
           "description": "admin/editor.info-card.imageActionUrl.description",
           "$ref": "app:vtex.native-types#/definitions/url",
           "default": ""
+        },
+        "analyticsProperties": {
+          "title": "admin/editor.info-card.analytics.title",
+          "description": "admin/editor.info-card.analytics.description",
+          "enum": ["none", "provide"],
+          "enumNames": [
+            "admin/editor.image.analytics.none",
+            "admin/editor.image.analytics.provide"
+          ],
+          "widget": {
+            "ui:widget": "radio"
+          },
+          "default": "none"
+        },
+        "promotionId": {
+          "title": "admin/editor.info-card.analytics.promotionId",
+          "type": "string",
+          "default": ""
+        },
+        "promotionName": {
+          "title": "admin/editor.info-card.analytics.promotionName",
+          "type": "string",
+          "default": ""
+        },
+        "promotionPosition": {
+          "title": "admin/editor.info-card.analytics.promotionPosition",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "dependencies": {
+        "analyticsProperties": {
+          "oneOf": [
+            {
+              "properties": {
+                "analyticsProperties": {
+                  "enum": ["provide"]
+                },
+                "promotionId": {
+                  "title": "admin/editor.info-card.analytics.promotionId",
+                  "type": "string",
+                  "default": ""
+                },
+                "promotionName": {
+                  "title": "admin/editor.info-card.analytics.promotionName",
+                  "type": "string",
+                  "default": ""
+                },
+                "promotionPosition": {
+                  "title": "admin/editor.info-card.analytics.promotionPosition",
+                  "type": "string",
+                  "default": ""
+                }
+              }
+            },
+            {
+              "properties": {
+                "analyticsProperties": {
+                  "enum": ["none"]
+                }
+              }
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
#### What problem is this solving?

A new feature in Info-Card component that shows analytics informations about it. This feature was implemented from store-image component and changed as needed. 

#### How to test it?

Check the page and visualizate the Info-Card component, then you could execute the dataLayer function in your own console to see their informations. Also you can configurate the analytics informations in /admin/cms/site-editor Info Card.

[Workspace](https://newinfocard--acctglobal.myvtex.com)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/62369374/128743971-f2517dfd-d9bf-427b-abc9-8f9c3fa66de5.png)
![image](https://user-images.githubusercontent.com/62369374/128744025-0a0499a8-4a71-4c83-a53b-9a762749fdc0.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3o6Mbjc28C0NP08xAA/source.gif)
