### PR TITLE
Add new content to info-card schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add more content to `info-card` schema.
+
 ## [3.151.2] - 2021-08-26
 
 ## [3.151.1] - 2021-08-26 [YANKED]

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -59,6 +59,19 @@
           "description": "admin/editor.info-card.imageActionUrl.description",
           "$ref": "app:vtex.native-types#/definitions/url",
           "default": ""
+        },
+        "textMode": {
+          "title": "admin/editor.info-card.textMode.title",
+          "description": "admin/editor.info-card.textMode.description",
+          "type": "string",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": ""
+        },
+        "isFullModeStyle": {
+          "title": "admin/editor.info-card.isFullModeStyle.title",
+          "description": "admin/editor.info-card.isFullModeStyle.description",
+          "type": "boolean",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
#### What problem is this solving?
When you use the `info-card-list-context` without any default props and create content by the `site-editor` the info-card component came with default props, I've added new ones to make possible more customization.

#### How to test it?

Access this workspace and go to site-editor, notice that the `info-card-list-context` component displays more props to `info-cards`

[Workspace](https://marcos--pivotree.myvtex.com/admin/cms/site-editor)

#### Screenshots or example usage:

https://i.imgur.com/BIjsu5z.png