### PR TITLE
feat/sku-variation-color-props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `isImage` props for SKU color variation.
+
 ## [3.152.0] - 2021-09-20
 ### Added
 - Added social media identifier class to SocialButton

--- a/docs/SKUSelector.md
+++ b/docs/SKUSelector.md
@@ -55,6 +55,7 @@ The SKU Selector is a product details page block responsible for displaying ever
 | `imageHeight`  | `number` | `object` | Height (in `px`) of the product thumbnail image. You can declare an object as its value in case you want to define a height for each device (`desktop` and `mobile`). | `undefined` |
 | `imageWidth` | `number` | `object` | Width (in `px`) of the product thumbnail image. You can declare an object as its value in case you want to define a width for each device (`desktop` and `mobile`).  | `undefined`  |
 | `initialSelection` | `enum`  | Controls the user initial selection for available variations when product page is fully loaded. Possible values are: `complete` (selects the first available SKU's variation values), `image` (selects the first available image variation) or `empty` (no variations will be selected when the page is loaded).  | `complete` |
+| `isImage` | `boolean`  | Controls the color variation images. Possible values are: `true` (render color variations with Images), `false` (render variations labels)  | `true` |.
 | `classes` | `CustomCSSClasses` | Used to override default CSS handles. To better understand how this prop works, we recommend reading about it [here](https://github.com/vtex-apps/css-handles#usecustomclasses). Note that this is only useful if you're using this block as a React component. | `undefined` |
 
 - **`visibleVariations` array**

--- a/react/components/SKUSelector/Wrapper.tsx
+++ b/react/components/SKUSelector/Wrapper.tsx
@@ -169,6 +169,7 @@ interface Props {
   sliderDisplayThreshold?: number
   sliderArrowSize?: number
   sliderItemsPerPage?: ResponsiveValuesTypes.ResponsiveValue<number>
+  isImage?: boolean
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof SKU_SELECTOR_CSS_HANDLES>
 }
@@ -260,6 +261,7 @@ function SKUSelectorWrapper(props: Props) {
         sliderItemsPerPage={props.sliderItemsPerPage}
         sliderArrowSize={props.sliderArrowSize}
         sliderDisplayThreshold={props.sliderDisplayThreshold}
+        isImage={props.isImage}
       />
     </SKUSelectorCssHandlesProvider>
   )

--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -67,6 +67,7 @@ interface Props {
   sliderDisplayThreshold: number
   sliderArrowSize: number
   sliderItemsPerPage: ResponsiveValuesTypes.ResponsiveValue<number>
+  isImage: boolean
 }
 
 function isSkuAvailable(item?: SelectorProductItem) {
@@ -297,6 +298,7 @@ function SKUSelector({
   sliderDisplayThreshold,
   sliderArrowSize,
   sliderItemsPerPage,
+  isImage
 }: Props) {
   const { handles } = useSKUSelectorCssHandles()
   const variationsSpacing = getValidMarginBottom(marginBottomProp)
@@ -382,6 +384,7 @@ function SKUSelector({
             sliderDisplayThreshold={sliderDisplayThreshold}
             sliderArrowSize={sliderArrowSize}
             sliderItemsPerPage={sliderItemsPerPage}
+            isImage={isImage}
           />
         )
       })}

--- a/react/components/SKUSelector/components/Variation.tsx
+++ b/react/components/SKUSelector/components/Variation.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useState, Fragment, useCallback } from 'react'
+import React, { FC, memo, useState, Fragment, useCallback, useEffect } from 'react'
 import { Button } from 'vtex.styleguide'
 import { IOMessage } from 'vtex.native-types'
 import { SliderLayout } from 'vtex.slider-layout'
@@ -33,6 +33,7 @@ interface Props {
   sliderDisplayThreshold: number
   sliderArrowSize: number
   sliderItemsPerPage: ResponsiveValuesTypes.ResponsiveValue<number>
+  isImage: boolean
 }
 
 const ITEMS_VISIBLE_THRESHOLD = 2
@@ -60,6 +61,7 @@ const Variation: FC<Props> = ({
   sliderArrowSize,
   sliderDisplayThreshold,
   sliderItemsPerPage,
+  isImage
 }) => {
   const { originalName, name, options } = variation
 
@@ -76,6 +78,16 @@ const Variation: FC<Props> = ({
       clicked: false,
     },
   } = useProduct()
+  
+  const [customDisplayImage, setCustomDisplayImage] = useState(isImage)
+
+  // SKU Color variation accessibility
+  useEffect(() => {
+    setCustomDisplayImage(false)
+    if (isColor(originalName) === true) {  
+      setCustomDisplayImage(isImage)
+    }
+  }, [isImage])
 
   const displayImage = isColor(originalName)
 
@@ -127,7 +139,7 @@ const Variation: FC<Props> = ({
         isAvailable={option.available}
         maxPrice={maxSkuPrice}
         onClick={option.impossible ? noop : option.onSelectItem}
-        isImage={displayImage}
+        isImage={customDisplayImage}
         variationValue={option.label}
         variationValueOriginalName={option.originalName}
         imageHeight={imageHeight}

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -186,6 +186,7 @@ interface Props {
   sliderDisplayThreshold?: number
   sliderArrowSize?: number
   sliderItemsPerPage?: ResponsiveValuesTypes.ResponsiveValue<number>
+  isImage?: boolean
 }
 
 const getNewSelectedVariations = (
@@ -252,6 +253,7 @@ const SKUSelectorContainer: FC<Props> = ({
     tablet: 2,
     phone: 1,
   },
+  isImage = true
 }) => {
   const variationsCount = keyCount(variations)
   const { query } = useRuntime()
@@ -409,6 +411,7 @@ const SKUSelectorContainer: FC<Props> = ({
       sliderDisplayThreshold={sliderDisplayThreshold}
       sliderArrowSize={sliderArrowSize}
       sliderItemsPerPage={sliderItemsPerPage}
+      isImage={isImage}
     />
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

The context of the change was basically because SKU Color Variation always display a button with a image inside and don't have a props to change that behavior. In this project, we had this particular design for Color variation. So, I made it possible to control this particular variation with a boolean value.

#### How to test it?

1- Open the Workspace.
2- Use ReactDevTools to change props between true or false. (https://prnt.sc/1t4qy5u)

[Workspace](https://tt209pr--tatauyqadev.myvtex.com/playstation-5/p)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

### Before ( Normal SKU-Selector as Store-Theme)

### After:

`isImage: true`

- https://prnt.sc/1t4knn5
- https://prnt.sc/1t4kpdq

<!----->

`isImage: false`

- https://prnt.sc/1t4ktoq
- https://prnt.sc/1t4kslf


#### How does this PR make you feel? [:link:](http://giphy.com/)

![Smile](https://media.giphy.com/media/tliXLSkzfq2C4/giphy.gif?cid=ecf05e476tmgwlj946m5qi7jv7ihl4aiw8oia1e1o0whd287&rid=giphy.gif&ct=g)
