### PR TITLE
update shipping simulator on change seller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Added key on `BaseShippingSimulatorWrapper` to recreate component and load current shipping address when change seller.
+
 ## [3.153.0] - 2021-09-24
 
 ### Added

--- a/react/components/ShippingSimulator/Wrapper.js
+++ b/react/components/ShippingSimulator/Wrapper.js
@@ -160,6 +160,7 @@ const ShippingSimulatorWithOrderForm = ({
 
   return (
     <BaseShippingSimulatorWrapper
+      key={seller}
       skuId={skuId}
       seller={seller}
       country={country}
@@ -217,6 +218,7 @@ const ShippingSimulatorWrapper = props => {
   ) {
     return (
       <BaseShippingSimulatorWrapper
+        key={sellerId}
         country={country}
         skuId={skuId}
         seller={sellerId}


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
The shipping simulator have a behavior to control when need to update the `ShippingTable` results. You can see this here: https://github.com/vtex-apps/store-components/blob/efebaee9e9e981849018d1f3d224f948ab7a521b/react/components/ShippingSimulator/Wrapper.js#L116

The problem was because the `isMountedRef.current` did not update when the product context was changed. 
You can see the problem below:
![busca-frete-buybox](https://user-images.githubusercontent.com/17439470/135152695-b1c717de-911f-44c6-a2fb-ba2cdf35300d.gif)

With this implementation, when the prop `key` changes, the `ShippingSimulator` is updated and set `isMountedRef.current` to `false`, as when the product page is started, and follow the normal flow of page. As shown below:
![busca-frete-buybox-funcionando](https://user-images.githubusercontent.com/17439470/135153430-3947c9ce-0cc8-44e9-ab7d-b1dd59ea9637.gif)

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
Access product page using [buybox-context](https://github.com/vtex-apps/buybox-context) configured and use shipping simulator.

[Workspace](https://buyboxdemo--pedrocruzio.myvtex.com/luxury-purple-ballon/p)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/PdpT9kNlBtV3Nqlmbg/giphy.gif)
