### PR TITLE
Written property to order the means of shipment by the estimated time.

### DIFF
--- a/docs/ShippingSimulator.md
+++ b/docs/ShippingSimulator.md
@@ -36,12 +36,13 @@ The Shipping Simulator block **estimates the shipping fee** based on a zip code 
   },
 ```
 
-| Prop name               | Type      | Description                                                                                   | Default value |
-| ----------------------- | --------- | --------------------------------------------------------------------------------------------- | ------------- |
-| `skuId`                 | `String`  | ID of the current product SKU                                                                 | -             |
-| `seller`                | `String`  | ID of the product seller                                                                      | -             |
-| `pricingMode`           | `enum`    | If the product has gifts or attachments, for example, you can choose whether the shipping information will be grouped (`grouped`) by shipping type or showing the shipping prices for each of the items individually (`individualItems`). | `individualItems`       |
-| `shouldUpdateOrderForm` | `Boolean` | Whether interacting with the simulator should update the shopper's address in their orderForm | `true`        |
+| Prop name                | Type      | Description                                                                                   | Default value |
+| -----------------------  | --------- | --------------------------------------------------------------------------------------------- | ------------- |
+| `skuId`                  | `String`  | ID of the current product SKU                                                                 | -             |
+| `seller`                 | `String`  | ID of the product seller                                                                      | -             |
+| `pricingMode`            | `enum`    | If the product has gifts or attachments, for example, you can choose whether the shipping information will be grouped (`grouped`) by shipping type or showing the shipping prices for each of the items individually (`individualItems`). | `individualItems`       |
+| `shouldUpdateOrderForm`  | `Boolean` | Whether interacting with the simulator should update the shopper's address in their orderForm | `true`        |
+| `orderByShippingEstimate`| `Boolean` | Sorts the presentation of shipping types by the estimated date for a pickup or delivery.      | `false`       |
 
 ## Customization
 

--- a/react/components/ShippingSimulator/Wrapper.js
+++ b/react/components/ShippingSimulator/Wrapper.js
@@ -51,6 +51,7 @@ const BaseShippingSimulatorWrapper = ({
   shouldUpdateOrderForm,
   pricingMode,
   selectedQuantity,
+  orderByShippingEstimate
 }) => {
   const [shipping, setShipping] = useState(null)
   const [loading, setLoading] = useState(false)
@@ -131,7 +132,6 @@ const BaseShippingSimulatorWrapper = ({
 
     handleCalculateShipping()
   }, [handleCalculateShipping, address, isValid])
-
   return (
     <ShippingSimulator
       skuId={skuId}
@@ -146,6 +146,7 @@ const BaseShippingSimulatorWrapper = ({
       selectedQuantity={selectedQuantity}
       onAddressChange={updateAddress}
       onCalculateShipping={handleCalculateShipping}
+      orderByShippingEstimate={orderByShippingEstimate}
     />
   )
 }
@@ -158,6 +159,7 @@ const ShippingSimulatorWithOrderForm = ({
   shouldUpdateOrderForm,
   pricingMode,
   selectedQuantity,
+  orderByShippingEstimate,
 }) => {
   const { updateSelectedAddress } = useOrderShipping()
   const { orderForm } = useOrderForm()
@@ -179,6 +181,7 @@ const ShippingSimulatorWithOrderForm = ({
       shouldUpdateOrderForm={shouldUpdateOrderForm}
       pricingMode={pricingMode}
       selectedQuantity={selectedQuantity}
+      orderByShippingEstimate={orderByShippingEstimate}
     />
   )
 }
@@ -200,6 +203,7 @@ const ShippingSimulatorWrapper = props => {
   const country = props.country || culture.country
   const skuId = props.skuId || productContext?.selectedItem?.itemId
   const selectedQuantity = productContext?.selectedQuantity?.toString()
+  const orderByShippingEstimate = props.orderByShippingEstimate || false;
 
   const { pricingMode } = props
 
@@ -229,6 +233,7 @@ const ShippingSimulatorWrapper = props => {
         pricingMode={pricingMode}
         selectedQuantity={selectedQuantity}
         loaderStyles={props.loaderStyles}
+        orderByShippingEstimate={orderByShippingEstimate}
       />
     )
   }
@@ -244,6 +249,7 @@ const ShippingSimulatorWrapper = props => {
           pricingMode={pricingMode}
           selectedQuantity={selectedQuantity}
           shouldUpdateOrderForm={shouldUpdateOrderForm}
+          orderByShippingEstimate={orderByShippingEstimate}
         />
       </OrderFormLoader>
     </OrderShippingProvider>

--- a/react/components/ShippingSimulator/components/ShippingTable.js
+++ b/react/components/ShippingSimulator/components/ShippingTable.js
@@ -6,12 +6,12 @@ import { GROUPED } from '../constants/PricingMode'
 import ShippingTableRow from './ShippingTableRow'
 import styles from '../shippingSimulator.css'
 
-const ShippingTable = ({ shipping, pricingMode }) => {
+const ShippingTable = ({ shipping, pricingMode, orderByShippingEstimate }) => {
   if ((shipping?.logisticsInfo?.length ?? 0) === 0) {
     return null
   }
 
-  const slaList = shipping.logisticsInfo.reduce(
+  let slaList = shipping.logisticsInfo.reduce(
     (slas, info) => [...slas, ...info.slas],
     []
   )
@@ -41,6 +41,40 @@ const ShippingTable = ({ shipping, pricingMode }) => {
         )}
       </FormattedMessage>
     )
+  }
+
+  //Sort the list by estimated time
+  if(orderByShippingEstimate) {
+    function OrderByShippingEst(a, b, replaceType) {
+      let aInt = 0;
+      let bInt = 0;
+      try {
+        aInt = parseInt(a.shippingEstimate.toString().replace(replaceType, "").replace("bd", ""));
+        bInt = parseInt(b.shippingEstimate.toString().replace(replaceType, "").replace("bd", ""));
+      }
+      catch {
+        return 0;
+      }
+  
+      if (aInt < bInt) {
+        return -1;
+      }
+      if (aInt > bInt ) {
+        return 1;
+      }
+      return 0;
+    }
+
+    const listMin = slaList.filter((x) => x.shippingEstimate.includes("m")).sort(function (a, b) {
+      return OrderByShippingEst(a, b, "m");
+    });
+
+    const listDay = slaList.filter((x) => x.shippingEstimate.includes("bd")).sort(function (a, b) {
+      return OrderByShippingEst(a, b, "bd");
+    });  
+
+    const newList = listMin.concat(listDay);
+    slaList = newList;
   }
 
   return (

--- a/react/components/ShippingSimulator/index.js
+++ b/react/components/ShippingSimulator/index.js
@@ -26,6 +26,7 @@ const ShippingSimulator = ({
   onCalculateShipping,
   shipping,
   pricingMode,
+  orderByShippingEstimate
   /* eslint-enable react/prop-types */
 }) => {
   const intl = useIntl()
@@ -60,7 +61,7 @@ const ShippingSimulator = ({
           {intl.formatMessage({ id: 'store/shipping.label' })}
         </Button>
       </div>
-      <ShippingTable shipping={shipping} pricingMode={pricingMode} />
+      <ShippingTable shipping={shipping} pricingMode={pricingMode} orderByShippingEstimate={orderByShippingEstimate} />
     </Fragment>
   )
 }
@@ -72,10 +73,12 @@ ShippingSimulator.propTypes = {
   country: PropTypes.string.isRequired,
   /** Component and content loader styles */
   styles: PropTypes.object,
+  orderByShippingEstimate: PropTypes.bool,
 }
 
 ShippingSimulator.defaultProps = {
   pricingMode: 'individualItems',
+  orderByShippingEstimate: false
 }
 
 export default ShippingSimulator


### PR DESCRIPTION
#### What problem is this solving?

It will be possible to have the ShippingSimulator table sorted by the estimated time for delivery or withdrawal.
New functionality that was requested by the company pay less, thus needing to be adding it to the ShippingSimulator component.

#### How to test it?

Testing within the paymenus workspace
https://pm650--paguemenos.myvtex.com/cetaphil-hidratante-locao-473ml/p

Preferably use zip code 04662-001 for tests

#### Screenshots or example usage:

before
![image](https://user-images.githubusercontent.com/87080892/140164777-9b91b270-4224-4c23-bdb2-5e3aef177588.png)

after
![image](https://user-images.githubusercontent.com/87080892/140164869-dbfdf737-2c38-4a24-862a-135fb8a41a1c.png)

#### Describe alternatives you've considered, if any.

Directly change any code as it was done, or create a new query.
