### PR TITLE
SKUSelector infinite loop fix

### DIFF
--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -6,7 +6,7 @@ import React, {
   useCallback,
   FC,
 } from 'react'
-import { filter, head, isEmpty, compose, keys, length } from 'ramda'
+import { filter, head, isEmpty, compose, keys, length, equals } from 'ramda'
 import { useRuntime } from 'vtex.render-runtime'
 import {
   useResponsiveValue,
@@ -151,7 +151,7 @@ const useAllSelectedEvent = (
   const dispatch = useProductDispatch()
 
   useEffect(() => {
-    if (dispatch && selectedVariations) {
+    if (dispatch && selectedVariations) {    
       dispatch({
         type: 'SKU_SELECTOR_SET_VARIATIONS_SELECTED',
         args: {
@@ -257,6 +257,7 @@ const SKUSelectorContainer: FC<Props> = ({
   const { query } = useRuntime()
   const responsiveDisplayMode = useResponsiveValue(displayMode)
 
+  const [prevVariations, setPrevVariations] = useState({} as Variations)
   const parsedItems = useMemo(() => skuItems.map(parseSku), [skuItems])
   const { setQuery } = useRuntime()
   const redirectToSku = (skuId: string) => {
@@ -273,9 +274,12 @@ const SKUSelectorContainer: FC<Props> = ({
   useAllSelectedEvent(selectedVariations, variationsCount)
 
   useEffectSkipMount(() => {
-    setSelectedVariations(
-      getNewSelectedVariations(query, skuSelected, variations, initialSelection)
-    )
+    if (!equals(variations, prevVariations)) {
+      setPrevVariations(variations)
+      setSelectedVariations(
+        getNewSelectedVariations(query, skuSelected, variations, initialSelection)
+      )
+    }
   }, [variations])
 
   // This is used to selected an SKU when initialSelection is not 'empty'.

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -151,7 +151,7 @@ const useAllSelectedEvent = (
   const dispatch = useProductDispatch()
 
   useEffect(() => {
-    if (dispatch && selectedVariations) {    
+    if (dispatch && selectedVariations) { 
       dispatch({
         type: 'SKU_SELECTOR_SET_VARIATIONS_SELECTED',
         args: {

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -151,7 +151,7 @@ const useAllSelectedEvent = (
   const dispatch = useProductDispatch()
 
   useEffect(() => {
-    if (dispatch && selectedVariations) { 
+    if (dispatch && selectedVariations) {
       dispatch({
         type: 'SKU_SELECTOR_SET_VARIATIONS_SELECTED',
         args: {


### PR DESCRIPTION
#### What problem is this solving?

There is an app called wishlist-io that uses the SKUSelector. When adding the prop "visibleVariations" to that SKUSelector, an infinite loop will occur breaking the functionality (the SKUSelector wont update, it will keep the default selection that is coming from the product-context).

One of the reason for the problem seems to be this useEffectSkipMount, that uses an object as a dependency. Even if the fields of the object stay the same, the reference change, so the useEffect will be executed, and the state of selectedVariation will change, causing a re-render.

This ramda deep compare that I added, just checks if the variation really changed.

#### How to test it?

In order to test, I created 1 workspace that illustrates the behaviour after the change.

[ workspace - tibidev; account - miniprix ]( https://tibidev--miniprix.myvtex.com )

#### Screenshots or example usage:

Here is a gif of how the selector acts before
![Dec-06-2021 16-45-53](https://user-images.githubusercontent.com/94540115/144866647-ae146254-1a09-4ad4-ab85-6811e8f88b08.gif)

It's not seen in the gif, but for a moment the selection changed, but then it is back to the default one from the product-context, this can be seen in the photo below.
![Screenshot 2021-11-23 at 17 27 15](https://user-images.githubusercontent.com/94540115/144866925-e5fd177f-8c0a-4fe6-a1a5-4a6afd52735a.png)

Here is a gif of how the selector acts after
![Dec-06-2021 16-42-48](https://user-images.githubusercontent.com/94540115/144866738-63e0089a-b843-41f6-8ef0-586adf998c77.gif)

#### Describe alternatives you've considered, if any.

I tried to dive even deeper and see why the variation change reference in the first place, but I had no results after a while.

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![https://media.giphy.com/media/l7fdqmHQ1jCg2HzQlx/giphy.gif](put .gif link here - can be found under "advanced" on giphy)