### PR TITLE
added keyboard control module for carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added keyboard control module to carousel
 
 ## [3.155.8] - 2022-01-03
 

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { path, equals } from 'ramda'
 import { IconCaret } from 'vtex.store-icons'
 import { withCssHandles } from 'vtex.css-handles'
-import SwiperCore, { Thumbs, Navigation, Pagination } from 'swiper'
+import SwiperCore, { Thumbs, Navigation, Pagination, Keyboard } from 'swiper'
 import { Swiper, SwiperSlide } from 'swiper/react'
 
 import Video, { getThumbUrl } from '../Video'
@@ -27,7 +27,7 @@ const CARET_CLASSNAME =
   'pv8 absolute top-50 translate--50y z-2 pointer c-action-primary'
 
 // install Swiper's Thumbs component
-SwiperCore.use([Thumbs, Navigation, Pagination])
+SwiperCore.use([Thumbs, Navigation, Pagination, Keyboard])
 
 const CSS_HANDLES = [
   'carouselContainer',
@@ -190,6 +190,8 @@ class Carousel extends Component {
     const { handles, slides = [], showPaginationDots = true } = this.props
 
     const params = {}
+
+    params.keyboard = { enabled: true }
 
     if (slides.length > 1 && showPaginationDots) {
       params.pagination = {


### PR DESCRIPTION
#### What problem is this solving?

Added keyboard control module for swiper js in order to be able to use the right and left arrows keys to swipe between images.
the reason why i did not add a prop in order to enable this module was that i believe this to be a default behavior (a nice addition) to swiping images.

#### How to test it?

Link this PR on a workspace and use the block product-images in order to test the keyboard module.
