### PR TITLE
added new CSS handle to handle the impossible items

### DIFF
--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -44,6 +44,7 @@ export const CSS_HANDLES = [
   'skuSelectorInternalBox',
   'skuSelectorItemTextValue',
   'skuSelectorItemImageValue',
+  'skuSelectorItemImpossible'
 ] as const
 
 /**
@@ -80,7 +81,7 @@ function SelectorItem({
         'relative di pointer flex items-center outline-0 ma2',
         {
           [`${handles.skuSelectorItemImage}`]: isImage,
-          'o-20': isImpossible,
+          [`o-20 ${handles.skuSelectorItemImpossible}`]: isImpossible,
         }
       ),
     [


### PR DESCRIPTION
#### What problem is this solving?

When we use the "hideImpossibleCombinations" props as false, to show all sku variants, we don't have a specific class to deal with that, so I am adding a simple CSS handle to have a class to deal with this options

#### How to test it?

[Workspace](https://devvitor--corebizio.myvtex.com/calcado-feminino-0101-preto-rosa/p!)

#### Screenshots or example usage:

![Screenshot from 2022-02-01 21-32-23](https://user-images.githubusercontent.com/11010539/152074250-4c6ed905-83fd-4fc9-9834-336b4d1c3636.png)
![Screenshot from 2022-02-01 21-32-29](https://user-images.githubusercontent.com/11010539/152074254-2ae7f3af-cd55-4293-8135-0195d6215620.png)


#### Describe alternatives you've considered, if any.

None

#### Related to / Depends on

None

#### How does this PR make you feel? [:link:](http://giphy.com/)

Awesome!

![](put .gif link here - can be found under "advanced" on giphy)
