### PR TITLE
fix: SearchBar when inputValue has blank space at the beginning or at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `srcSet` typo in the Image documentation.
+- `SearchBar`'s `handleGoToPage` when `inputValue` has blank space at the beginning or at the end.
 
 ## [3.155.8] - 2022-01-03
 

--- a/react/SearchBar.tsx
+++ b/react/SearchBar.tsx
@@ -115,7 +115,7 @@ function SearchBarContainer(props: Props) {
   }, [])
 
   const handleGoToSearchPage = useCallback(() => {
-    const search = encodeURIComponent(inputValue)
+    const search = encodeURIComponent(inputValue.trim())
 
     if (attemptPageTypeSearch) {
       window.location.href = `/${search}`


### PR DESCRIPTION
#### What problem is this solving?
When the user tries to search with terms that include blank spaces at the beginning or at the end, the client-side navigation breaks.

#### How to test it?
[fixed workspace with brand page](https://brasileiro--txboot.myvtex.com/): `Search for "Olathe "` with blank space
[broken workspace with brand page](https://txboot.myvtex.com/): `Search for "Olathe "` with blank space

[fixed workspace with custom page](https://brasileiro--minisomx.myvtex.com/): `Search for "Navidad "` with blank space
[broken workspace with custom page](https://minisomx.myvtex.com/): `Search for "Navidad "` with blank space

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
