### PR TITLE
[sku-selector] Always trigger the `SET_LOADING_ITEM` action when users change the current selected SKU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Always trigger the `SET_LOADING_ITEM` action from Product Context when users change the current selected SKU.
 
 ## [3.158.0] - 2022-03-23
 

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -12,7 +12,7 @@ import {
   useResponsiveValue,
   ResponsiveValuesTypes,
 } from 'vtex.responsive-values'
-import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
+import { useProduct, useProductDispatch } from 'vtex.product-context'
 
 import SKUSelector, {
   ShowValueForVariation,
@@ -253,6 +253,9 @@ const SKUSelectorContainer: FC<Props> = ({
     phone: 1,
   },
 }) => {
+  const productContext = useProduct()
+  const selectedItem = productContext?.selectedItem
+
   const variationsCount = keyCount(variations)
   const { query } = useRuntime()
   const responsiveDisplayMode = useResponsiveValue(displayMode)
@@ -263,12 +266,10 @@ const SKUSelectorContainer: FC<Props> = ({
     setQuery({ skuId }, { replace: true })
   }
 
-  const [
-    selectedVariations,
-    setSelectedVariations,
-  ] = useState<SelectedVariations>(() =>
-    getNewSelectedVariations(query, skuSelected, variations, initialSelection)
-  )
+  const [selectedVariations, setSelectedVariations] =
+    useState<SelectedVariations>(() =>
+      getNewSelectedVariations(query, skuSelected, variations, initialSelection)
+    )
 
   useAllSelectedEvent(selectedVariations, variationsCount)
 
@@ -314,6 +315,14 @@ const SKUSelectorContainer: FC<Props> = ({
 
       // Set here for a better response to user
       setSelectedVariations(newSelectedVariation)
+
+      if (selectedItem && selectedItem.itemId !== skuId) {
+        dispatch({
+          type: 'SET_LOADING_ITEM',
+          args: { loadingItem: true },
+        })
+      }
+
       const uniqueOptions = isRemoving
         ? {}
         : uniqueOptionToSelect(
@@ -375,12 +384,6 @@ const SKUSelectorContainer: FC<Props> = ({
       // If its just removing, no need to redirect
       if (!isRemoving && (allSelected || isColor(variationName))) {
         redirectToSku(skuIdToRedirect)
-        if (skuSelected && skuSelected.itemId !== skuId) {
-          dispatch({
-            type: 'SET_LOADING_ITEM',
-            args: { loadingItem: true },
-          })
-        }
       }
     },
     // Adding selectedVariations, variationsCount and onSKUSelected causes an infinite loop


### PR DESCRIPTION
#### What problem is this solving?

This makes sure that every time a user selects a different SKU using the SKU Selector, the action `SET_LOADING_ITEM` is fired to update the nearest Product Context.

This should prevent issues with incorrect SKUs being added into the user's cart due to the delay between the user selecting a different SKU and the actual Product Context being updated. Now on a page that contains the `add-to-cart-button` for example, users will see a loading state as long as there's a mismatch between the SKU Selector and the Product Context.

#### How to test it?

Go to any product page on this [Workspace](https://victormirandaprod--miniprix.myvtex.com/), and try out the SKU Selector. You should notice no visible changes, apart from the loading state on the `add-to-cart-button` (much easier to see when simulating a `low-end mobile` device).

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/xT5LMEcHRXKXpIHCCI/giphy.gif)
