### PR TITLE
Update component to hide hide asterics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New prop to `UserAddress` showIfMasked to remove entire string if asterics are present
+
 ## [3.158.0] - 2022-03-23
 
 ### Added

--- a/react/UserAddress.tsx
+++ b/react/UserAddress.tsx
@@ -28,6 +28,8 @@ type Props = {
   showPrefix?: boolean
   /** Define if component should render if address is empty */
   showIfEmpty?: boolean
+  /** Define if component should render if ZipCode contains asterics */
+  showIfMasked?: boolean
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof USER_ADDRESS_CSS_HANDLES>
 }
@@ -39,6 +41,7 @@ function UserAddress({
   showPostalCode = false,
   showPrefix = true,
   showIfEmpty = false,
+  showIfMasked = false,
   classes,
 }: Props) {
   const { handles, withModifiers } = useCssHandles(USER_ADDRESS_CSS_HANDLES, {
@@ -84,6 +87,7 @@ function UserAddress({
           showPostalCode={showPostalCode}
           showPrefix={showPrefix}
           showIfEmpty={showIfEmpty}
+          showIfMasked={showIfMasked}
         />
       </UserAddressCssHandlesProvider>
     )

--- a/react/components/UserAddress/AddressInfo.tsx
+++ b/react/components/UserAddress/AddressInfo.tsx
@@ -13,6 +13,7 @@ type Props = {
   showStreet: boolean
   showCityAndState: boolean
   showPostalCode: boolean
+  showIfMasked: boolean
   showPrefix: boolean
   showIfEmpty: boolean
 }
@@ -33,6 +34,7 @@ const AddressInfo = ({
   showStreet,
   showCityAndState,
   showPostalCode,
+  showIfMasked,
   showPrefix,
   showIfEmpty,
 }: Props) => {
@@ -41,7 +43,11 @@ const AddressInfo = ({
   const { handles } = useUserAddressCssHandles()
   const intl = useIntl()
 
-  if (!shippingData || !shippingData.address) {
+  if (
+    !shippingData ||
+    !shippingData.address ||
+    (!showIfMasked && shippingData.address.postalCode.includes('*'))
+  ) {
     if (!showIfEmpty) {
       return null
     }
@@ -84,15 +90,8 @@ const AddressInfo = ({
     )
   }
 
-  const {
-    street,
-    number,
-    complement,
-    addressType,
-    city,
-    state,
-    postalCode,
-  } = shippingData.address
+  const { street, number, complement, addressType, city, state, postalCode } =
+    shippingData.address
 
   let displayStreet = number ? `${street}, ${number}` : street
 

--- a/react/components/UserAddress/AddressInfo.tsx
+++ b/react/components/UserAddress/AddressInfo.tsx
@@ -103,10 +103,10 @@ const AddressInfo = ({
   const displayAddress = `${showStreet ? displayStreet || '' : ''}${
     showStreet && (showCityAndState || showPostalCode) ? ', ' : ''
   }${showCityAndState ? displayCityAndState : ''}${
-    showCityAndState && showPostalCode
+    showCityAndState && showPostalCode && !postalCode.includes('*')
       ? `${displayCityAndState ? ', ' : ''}`
       : ''
-  }${showPostalCode ? postalCode : ''}`
+  }${showPostalCode && !postalCode.includes('*') ? postalCode : ''}`
 
   const isPickup = addressType === 'pickup'
   const friendlyName = orderForm?.pickupPointCheckedIn?.friendlyName ?? ''


### PR DESCRIPTION
#### What problem is this solving?
- Asterics in the `UserAddres` is always shown. The user should have the option to disable this.

<!--- What is the motivation and context for this change? -->
- A client is requesting us to remove the asteriscs from the `UserAddress` component. 
- I added a new prop to hide this from the component.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

This feature can be tested [here](https://beto--sandboxusdev.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![Image 2022-03-24 at 3 14 01 p m](https://user-images.githubusercontent.com/11176519/160011350-4797719d-d4ae-4fe0-a372-aedb37a92260.jpg)

