### PR TITLE
docs(search-bar): added missing classnames

### DIFF
--- a/docs/SearchBar.md
+++ b/docs/SearchBar.md
@@ -72,15 +72,19 @@ To apply CSS customizations in this and other blocks, follow the [Using CSS hand
 
 | CSS Handles                       | 
 | --------------------------------  | 
+| `autoCompleteOuterContainer`      | 
 | `compactMode`                     | 
 | `externalSearchButtonWrapper`     |
 | `paddingInput`                    |
 | `searchBarContainer`              |
+| `searchBarInnerContainer`         |
 | `searchBarInnerContainer--opened` |
 | `searchBarInnerContainer--filled` | 
 | `searchBarIcon`                   |
+| `searchBarClearIcon`              |
+| `searchBarSearchIcon`             |
 | `searchBarIcon--clear`            | 
 | `searchBarIcon--external-search`  | 
 | `searchBarIcon--prefix`           | 
 | `searchBarIcon--search`           | 
-| `suffixWrapper`                  |
+| `suffixWrapper`                   |


### PR DESCRIPTION
Added classes that were not documented in the CSS Handle table

**What problem is this solving?**
Documentation

**How to test it?**
Looking for the changes