### PR TITLE
Fix/product context infinite loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent `SET_LOADING_ITEM` action from Product Context from being fired when users unselect a certain property in the SKU Selector.
 
 ## [3.159.0] - 2022-03-28
 ### Fixed

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -316,7 +316,7 @@ const SKUSelectorContainer: FC<Props> = ({
       // Set here for a better response to user
       setSelectedVariations(newSelectedVariation)
 
-      if (selectedItem && selectedItem.itemId !== skuId) {
+      if (selectedItem && selectedItem.itemId !== skuId && !isRemoving) {
         dispatch({
           type: 'SET_LOADING_ITEM',
           args: { loadingItem: true },


### PR DESCRIPTION
#### What problem is this solving?

This will prevent the `SET_LOADING_ITEM` action from being fired to the Product Context when an SKU is unselected. Always firing this action could cause an infinite loading state in some cases where the users unselected a certain property that didn't trigger navigation in the browser.

Here's a demonstration of the issue: https://share.vidyard.com/watch/kThnmE3tgGij1yeBpRy3o9.

#### How to test it?

Go to this [Workspace](https://victormiranda--underarmourcl.myvtex.com/zapatillas-para-correr-ua-charged-vantage-2-de-mujer-3024884/p?property__Color=GREY%20(102)) and try unselecting the size and color.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/FxlsMhC9t82jCJKfgY/giphy.gif)
