### PR TITLE
Update ProductContext when sku change doesn't trigger navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Infinite loading state caused by never sending the `SET_LOADING_ITEM` action with a value of `false` in the SKU Selector.
 
 ## [3.159.1] - 2022-03-31
 ### Fixed

--- a/react/components/SKUSelector/index.tsx
+++ b/react/components/SKUSelector/index.tsx
@@ -321,6 +321,11 @@ const SKUSelectorContainer: FC<Props> = ({
           type: 'SET_LOADING_ITEM',
           args: { loadingItem: true },
         })
+      } else if (selectedItem?.itemId === skuId) {
+        dispatch({
+          type: 'SET_LOADING_ITEM',
+          args: { loadingItem: false },
+        })
       }
 
       const uniqueOptions = isRemoving
@@ -373,6 +378,11 @@ const SKUSelectorContainer: FC<Props> = ({
       // only redirect to a specific sku id if every variation was defined
       if (allSelected === false) {
         skuIdToRedirect = null
+
+        dispatch({
+          type: 'SET_LOADING_ITEM',
+          args: { loadingItem: false },
+        })
       }
 
       if (onSKUSelected) {


### PR DESCRIPTION
#### What problem is this solving?

When removing a certain selected variation from the SKU Selector, the query string in the current URL might not be changed, so the `ProductContext` and the `SKU Seletor` components are not remounted. In this case, the value for `ProductContext.loadingItem` is not reset to `false`, causing an infinite loading state.

This PR should fix this, enabling the SKU Selector to set `loadingItem` to `false`.

#### How to test it?

Go to this [Workspace](https://victormiranda--underarmourcl.myvtex.com/zapatillas-para-correr-unisex-ua-hovr--phantom-2-intelliknit-slip-3024917/p?property__Color=BLACK%20(001)&skuId=4756427) and play with the SKU Selector. Try selecting and unselecting variations, you should see no strange behavior.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/dZEoQE2qlzwx3IP98G/giphy.gif)
