### PR TITLE
inclusao da tag alt images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+inclusao da tag alt images nos infocard
 
 ## [3.159.5] - 2022-06-08
 

--- a/react/__tests__/components/__snapshots__/InfoCard.test.js.snap
+++ b/react/__tests__/components/__snapshots__/InfoCard.test.js.snap
@@ -16,7 +16,7 @@ exports[`<InfoCard /> should insert span with class on headline 1`] = `
         <div
           style="display: contents;"
         >
-          HEADLINE 
+          HEADLINE
           <span
             class="my-custom-class"
           >
@@ -55,7 +55,7 @@ exports[`<InfoCard /> should not render subhead 1`] = `
         <div
           style="display: contents;"
         >
-          HEADLINE 
+          HEADLINE
           <span
             class="my-custom-class"
           >
@@ -173,7 +173,7 @@ exports[`<InfoCard /> should render with image and text side by side 1`] = `
       class="infoCardImageContainer w-50-ns"
     >
       <img
-        alt=""
+        alt="CLIQUE HERE"
         class="infoCardImage"
         data-testid="half-image"
         src="my-image.com/image.png"
@@ -252,7 +252,7 @@ exports[`<InfoCard /> should wrap half image in a link with imageActionUrl 1`] =
         href="dummy"
       >
         <img
-          alt=""
+          alt="CLIQUE HERE"
           class="infoCardImage"
           data-testid="half-image"
           src="my-image.com/image.png"

--- a/react/__tests__/components/__snapshots__/InfoCard.test.js.snap
+++ b/react/__tests__/components/__snapshots__/InfoCard.test.js.snap
@@ -173,7 +173,7 @@ exports[`<InfoCard /> should render with image and text side by side 1`] = `
       class="infoCardImageContainer w-50-ns"
     >
       <img
-        alt="CLIQUE HERE"
+        alt="CLICK HERE"
         class="infoCardImage"
         data-testid="half-image"
         src="my-image.com/image.png"
@@ -252,7 +252,7 @@ exports[`<InfoCard /> should wrap half image in a link with imageActionUrl 1`] =
         href="dummy"
       >
         <img
-          alt="CLIQUE HERE"
+          alt="CLICK HERE"
           class="infoCardImage"
           data-testid="half-image"
           src="my-image.com/image.png"

--- a/react/__tests__/components/__snapshots__/InfoCard.test.js.snap
+++ b/react/__tests__/components/__snapshots__/InfoCard.test.js.snap
@@ -16,7 +16,7 @@ exports[`<InfoCard /> should insert span with class on headline 1`] = `
         <div
           style="display: contents;"
         >
-          HEADLINE
+          HEADLINE 
           <span
             class="my-custom-class"
           >
@@ -55,7 +55,7 @@ exports[`<InfoCard /> should not render subhead 1`] = `
         <div
           style="display: contents;"
         >
-          HEADLINE
+          HEADLINE 
           <span
             class="my-custom-class"
           >

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -223,7 +223,7 @@ const InfoCard = ({
                 className={handles.infoCardImage}
                 src={finalImageUrl}
                 style={{ objectFit: 'cover' }}
-                alt=""
+                alt={formatIOMessage({ id: callToActionText, intl })}
                 data-testid="half-image"
               />
             </LinkWrapper>


### PR DESCRIPTION
#### What problem is this solving?

A Tag Alt das Imagens não estavam aparecendo nos infocards.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://fixaltimages--carrefourbr.myvtex.com)

#### Screenshots or example usage:

![carrefour-alt-2](https://user-images.githubusercontent.com/95489973/172658457-da429057-5ad0-4bb8-916f-ada596b2cc0d.png)
![carrefour-alt-1](https://user-images.githubusercontent.com/95489973/172658499-fe770309-c96b-4893-87c4-e2a72c847b8e.png)



