### PR TITLE
Fix/slugified SKU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added ` (grave accent) and ’ (apostrophe) to be replaced by - when SKU slugified
+- Added ` (grave accent) and ’ (apostrophe) to be removed when SKU slugified
 
 ## [3.160.0] - 2022-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added ` (grave accent) and ’ (apostrophe) to be replaced by - when SKU slugified
 
 ## [3.160.0] - 2022-06-21
-
 
 ### Added
 - Added color definition for Bulgarian

--- a/react/components/SKUSelector/utils/index.ts
+++ b/react/components/SKUSelector/utils/index.ts
@@ -1,8 +1,8 @@
 import { clone, filter, prop, reject } from 'ramda'
 import slugify from 'slugify'
+
 import { getDefaultSeller } from '../../../utils/sellers'
 import { SelectedVariations, SelectorProductItem } from '../types'
-
 
 /**
  * Return the maximum sku price
@@ -177,7 +177,7 @@ export const uniqueOptionToSelect = (
 
 export function slug(str: string) {
   // eslint-disable-next-line no-useless-escape
-  const replaced = str?.replace(/[*+~.()'"!:@&\[\]]/g, '') || ''
+  const replaced = str?.replace(/[*+~.()'`’"!:@&\[\]]/g, '') || ''
   const slugified = slugify(replaced, { lower: true }) || ''
 
   return slugified


### PR DESCRIPTION
#### What problem is this solving?

Slugify can't replace special characters.

Nowadays we are not removing the special characters (` and ’) of the SKU variation, and then, we are facing problems to slugify it


#### How to test it?

With the fix:

[Workspace](https://testerns--kissnewyork.myvtex.com/paleta-de-blush-ruby-kisses/p?skuId=367)

<img width="960" alt="image" src="https://user-images.githubusercontent.com/13649073/175371210-a17ce660-b6f6-41ba-95cc-be78d382f1e4.png">

Without the fix:

[Workspace](https://withoutfix--kissnewyork.myvtex.com/paleta-de-blush-ruby-kisses/p?skuId=367)

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/13649073/175373201-200be2f2-b842-4365-b71b-ae6d3dbc0650.png">

#### Related to / Depends on

Zendesk #593195

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3oEduVObV0nnnTSDCg/giphy.gif)
