### PR TITLE
feat: added call to action button to be managed on site editor for infoCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added Call To Action mode on contentSchema
 
 ## [3.160.1] - 2022-06-23
 ### Added

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -30,6 +30,17 @@
           "$ref": "app:vtex.native-types#/definitions/text",
           "default": ""
         },
+        "callToActionMode": {
+          "default": "button",
+          "type": "string",
+          "title": "admin/editor.info-card.callToActionMode.title",
+          "enum": ["none", "button", "link"],
+          "enumNames": [
+            "admin/editor.info-card.callAction.none",
+            "admin/editor.info-card.callAction.button",
+            "admin/editor.info-card.callAction.link"
+          ]
+        },
         "callToActionText": {
           "title": "admin/editor.info-card.callToActionText.title",
           "description": "admin/editor.info-card.callToActionText.description",


### PR DESCRIPTION
#### What problem is this solving?

The customer is not allowed to change the infoCardButton on Site Editor

#### How to test it?

Select the Infocard and click on call to action mode

[Workspace](https://iespinoza6--storecomponents.myvtex.com/admin/cms/site-editor)

#### Screenshots or example usage:
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/13649073/177222801-9ffe0303-92f0-44c5-bf82-d68664b5e5c9.png">

#### Related to / Depends on

Zendesk 606198

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/3o6nUOtr1Fj1YKwX84/giphy.gif)
