### PR TITLE
Chore/update test tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated @vtex/test-tools dependency
+
+### Added
+- Resolutions yarn field
 
 ## [3.161.21] - 2022-07-14
 

--- a/react/package.json
+++ b/react/package.json
@@ -74,6 +74,9 @@
     "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.83.0/public/@types/vtex.store-resources",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide"
   },
+  "resolutions": {
+    "json-schema": "^0.4.0"
+  },
   "vtexTestTools": {
     "defaultLocale": "en"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -42,7 +42,7 @@
     "@types/react": "^16.9.2",
     "@types/react-content-loader": "3",
     "@types/react-dom": "^16.9.0",
-    "@vtex/test-tools": "^3.1.0",
+    "@vtex/test-tools": "^3.4.3",
     "@vtex/tsconfig": "^0.5.5",
     "apollo-cache-inmemory": "^1.4.3",
     "babel-eslint": "^10.1.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3759,10 +3759,10 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.2.3, json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1379,13 +1379,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/graphql@^14.5.0":
-  version "14.5.0"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.5.0.tgz#a545fb3bc8013a3547cf2f07f5e13a33642b75d6"
-  integrity sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==
-  dependencies:
-    graphql "*"
-
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -1558,10 +1551,10 @@
     assignment "2.0.0"
     he "0.5.0"
 
-"@vtex/test-tools@^3.1.0":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-3.3.2.tgz#b131653d85f381c82efea12a13d08fc9b1f65c85"
-  integrity sha512-rs0yHIpSlJc5zM6nYSFxWRMyS7k1w4JYyWmD5flNOtMIHiuUkOFrQh84tBAPtz6nxFf9993fv/Zfip5KKdpVmA==
+"@vtex/test-tools@^3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-3.4.3.tgz#d0cc34c445410050b9b56f804236c7c07a242489"
+  integrity sha512-sBGnr9lIv2dFiZnkUWBdiuiE/GRcu7jSKYqcYQ7fD1o0VlacMIMxHQmz8Gv1NIic37QRgntbSBDrvUUNo94Iwg==
   dependencies:
     "@babel/core" "^7.11.1"
     "@babel/plugin-proposal-class-properties" "^7.10.4"
@@ -1572,7 +1565,6 @@
     "@testing-library/jest-dom" "^5.11.2"
     "@testing-library/react" "^10.4.7"
     "@testing-library/react-hooks" "^3.4.1"
-    "@types/graphql" "^14.5.0"
     "@types/jest" "^26.0.8"
     "@types/node" "^14.0.27"
     "@types/react" "^16.9.44"
@@ -2846,11 +2838,6 @@ graphql-tag@~2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.8.0.tgz#52cdea07a842154ec11a2e840c11b977f9b835ce"
   integrity sha1-Us3qB6hCFU7BGi6EDBG5d/m4Nc4=
-
-graphql@*:
-  version "15.4.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
-  integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==
 
 graphql@^14.0.0:
   version "14.7.0"


### PR DESCRIPTION
#### What problem is this solving?

We are updating dependencies to solve some security issues alerted by `dependabot`. 
[One](https://github.com/vtex-apps/store-components/security/dependabot/20) of these issues is regarding `json-schema`, but dependabot couldn't update it automatically. 

We noticed that `@vtex/test-tools` wasn't updated, so I took the opportunity to update it. It wasn't the only thing necessary for this issue to be fixed - the fixed version of `json-schema` wasn't being installed because of the other dependencies that use it. 

Therefore, I used the [resolutions](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/) field to tell yarn which version to install. In the next 2 PRs I'll also be using this `resolutions` field, I'm separating those changes in different PRs so we can keep track in case some update breaks something.

#### How to test it?

Nothing should've changed: [workspace](https://laricia1--storecomponents.myvtex.com/)
