### PR TITLE
Added analytics push event on description show-more/show-less click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Added gtm event when a use clicks on show-more/show-less product description's button (vtex:productDescription)
 ## [3.162.0] - 2022-08-01
 
 ## [3.161.28] - 2022-07-28

--- a/react/ProductDescription.tsx
+++ b/react/ProductDescription.tsx
@@ -82,7 +82,7 @@ function ProductDescription(props: PropsWithChildren<Props>) {
 
       <div className={`${handles.productDescriptionText} c-muted-1`}>
         {collapseContent ? (
-          <GradientCollapse collapseHeight={220}>
+          <GradientCollapse collapseHeight={220} product={product}>
             <SanitizedHTML
               content={description}
               allowedTags={allowedTags}

--- a/react/components/GradientCollapse/index.js
+++ b/react/components/GradientCollapse/index.js
@@ -5,6 +5,7 @@ import debounce from 'debounce'
 import { FormattedMessage } from 'react-intl'
 import classNames from 'classnames'
 import { useCssHandles } from 'vtex.css-handles'
+import { usePixel } from 'vtex.pixel-manager'
 
 import styles from './styles.css'
 
@@ -36,8 +37,10 @@ function GradientCollapse(props) {
     collapseHeight,
     onCollapsedChange,
     collapsed: collapsedProp,
+    product
   } = props
 
+  const { push } = usePixel()
   const { handles } = useCssHandles(CSS_HANDLES)
   const [collapsed, setCollapsed] = useState(collapsedProp)
   const [prevCollapsedProp, setPrevCollapsedProp] = useState(collapsedProp)
@@ -65,8 +68,10 @@ function GradientCollapse(props) {
   }
 
   const handleCollapsedChange = (e, newValue) => {
+
     setCollapsed(newValue)
     setPrevCollapsedProp(collapsedProp)
+    push({event: 'productDescription', product, action: newValue ? 'show-less' : 'show-more' })
 
     if (onCollapsedChange) {
       onCollapsedChange(e, newValue)


### PR DESCRIPTION
#### What problem is this solving?

By now, no analytics event is pushed when the user click on the show-more/show-less product description button.

#### How to test it?

You can test here or in any other product that have a long description in the site: [Workspace](https://descriptionpr--itwhirlpool.myvtex.com/lavastoviglie-da-incasso-whirlpool-colore-argento-grande-capienza-wic-3c33-f-869991604360/p)

#### Screenshots or example usage:

For testing you can reach the workspace link and then press the **show-more** button:

![image](https://user-images.githubusercontent.com/81118704/182559005-12755e4a-301b-4dac-bd04-f54591b758bb.png)

Then if you look at the developer console and type **dataLayer** you can see that the event is correctly triggered:

![image](https://user-images.githubusercontent.com/81118704/182559402-6115affa-c211-4ae2-8e81-384d04c46a3c.png)

You can also have a look at **enhancedEcommerceEvents.ts** file:

![image](https://user-images.githubusercontent.com/81118704/182559729-478083b6-7cd2-404c-87f8-7d1dab9fcd6c.png)


#### Describe alternatives you've considered, if any.

Obviously the event is fired both for **show-more** clicks and **show-less** ones and distinguished by the field ```action``` (```push({event: 'productDescription', product, action: newValue ? 'show-less' : 'show-more' })```) that can be **show-more** or **show-less**.

#### Related to / Depends on

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/UEggOy3De1CHeben5N/giphy.gif)
