### PR TITLE
Fix: Reset swiper when changing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Reset selected image on PDP when changing the product.
 
 ## [3.162.0] - 2022-08-01
 

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -107,7 +107,6 @@ class Carousel extends Component {
         ...initialState,
       })
 
-
       return
     }
 

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -98,11 +98,15 @@ class Carousel extends Component {
     if (!equals(prevProps.slides, this.props.slides)) {
       this.setInitialVariablesState()
 
-      const newInitialState = { ...initialState }
-
       if (!this.props.slides) return
 
-      this.setState(newInitialState)
+      this.state.gallerySwiper?.slideTo(initialState.activeIndex)
+      this.state.thumbSwiper?.slideTo(initialState.activeIndex)
+
+      this.setState({
+        ...initialState,
+      })
+
 
       return
     }


### PR DESCRIPTION
#### What problem is this solving?

Based on a Known Issue (KI):

**Summary**
When selecting any image on the PDP of a product, if you move from this PDP directly to another PDP, the position of the image won't be erased - if you were seeing the third image, you will see directly the third image on the new PDP.

**Simulation**
Go to a PDP and select any image that's not the first one (ex: image number 2). Now search for a product and select it on the suggestions of the searchBar (do not go to the PLP of this search). You will notice that the image that will be selected on this new PDP will be in the same position (image number 2), even though it's a different PDP.


https://user-images.githubusercontent.com/11325562/186799147-492a1ce2-13c0-43d1-9556-a43508827964.mov

Using `storecomponents` account.
|Before|After|
|-|-|
|![fQied4CgNB](https://user-images.githubusercontent.com/11325562/186800343-225f91fb-c828-4930-9193-9b70b072b55e.gif)|![HiewExs1Ln](https://user-images.githubusercontent.com/11325562/186799976-cd3ca1f0-82c0-4d30-b747-e1346d3aa1cd.gif)|

#### How to test it?

- I used the `storecomponents` account with a brand new workspace.
- After applying this PR changes, try to simulate again the behavior.

#### Describe alternatives you've considered, if any.

Well, I noticed while testing that this king of navigation, that uses the back or next browser button or even using the `search` component didn't mount a brand new `Carousel` component. So I tried hard to rerender a brand new component using the updated initial index to reset the `Swiper` component. After some tries that fails like:
- set the initial state with the initial index;
- update the swipers using the [Swiper api](https://swiperjs.com/swiper-api);

I find a solution by making the swiper slide to the initial index when `componentDidUpdate` (old version of react) and the page changed ([when slides change](https://github.com/vtex-apps/store-components/blob/a2d844f629453bd00b7d0d2214a770ae3e13fa1a/react/components/ProductImages/components/Carousel/index.js#L98) means the page change).


#### How does this PR make you feel?

looking for the correct screw to tighten

![](https://media.giphy.com/media/3oEhmNef89Yv0hhZUQ/giphy-downsized-large.gif)
