### PR TITLE
fix ProductPrice Wrapper

### DIFF
--- a/react/components/ProductPrice/Wrapper.js
+++ b/react/components/ProductPrice/Wrapper.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import { ProductContext } from 'vtex.product-context'
 import { path, isEmpty, has } from 'ramda'
+import { getDefaultSeller } from '../../utils/sellers'
 
 import ProductPrice from './index'
 
@@ -86,11 +87,9 @@ const ProductPriceWrapper = ({
       }
     }
 
-    const { selectedItem } = valuesFromContext
-    const commertialOffer = path(
-      ['sellers', 0, 'commertialOffer'],
-      selectedItem
-    )
+    const { selectedItem: { sellers } } = valuesFromContext
+
+    const { commertialOffer } = getDefaultSeller(sellers)
 
     return {
       ...props,


### PR DESCRIPTION
Signed-off-by: Arthur Andrade <arthurfelandrade@gmail.com>

#### What problem is this solving?

When showing the price in PDP, the component ignores Default Seller, considering the first seller which was registered.

#### How to test it?

The `ProductPrice`is used in suggest components, like the Top Classy Sunglasses

![Screen Shot 2022-09-14 at 10 41 38](https://user-images.githubusercontent.com/51174217/190170299-133b191b-1b43-4112-8a6f-7b5d027be9ca.png)

[Workspace](https://arthurspace--storecomponents.myvtex.com/fashion-eyeglasses/p)

To make the tests easy was created a new workspace, where more sellers were added and logs are shown on console.

#### Screenshots or example usage:

![Screen Shot 2022-09-14 at 11 21 20](https://user-images.githubusercontent.com/51174217/190180762-024ea0e2-4698-402d-b169-d9b416d3ed44.png)

