### PR TITLE
Fix/swiper destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Check if the swiper is not destroyed before changing initial state, which could cause the whole product UI to crash
+
 ## [3.163.2] - 2022-11-03
 ### Fixed
 - Update Info Card doc.

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -107,10 +107,8 @@ const ThumbnailSwiper = props => {
       'swiper-thumbnails-caret-next',
       thumbCaretClassName,
       {
-        [`bottom-0 pt7 left-0 justify-center w-100 ${styles.gradientBaseBottom}`]:
-          isThumbsVertical,
-        [`right-0 top-0 items-center h-100 pl6 ${styles.gradientBaseRight}`]:
-          !isThumbsVertical,
+        [`bottom-0 pt7 left-0 justify-center w-100 ${styles.gradientBaseBottom}`]: isThumbsVertical,
+        [`right-0 top-0 items-center h-100 pl6 ${styles.gradientBaseRight}`]: !isThumbsVertical,
       }
     )
 
@@ -155,6 +153,7 @@ const ThumbnailSwiper = props => {
          * so that clicking on next/prev will scroll more than
          * one thumbnail */
         slidesPerGroup={displayThumbnailsArrows ? 4 : 1}
+        slidesPerGroupSkip={0}
         freeMode={false}
         mousewheel={false}
         zoom={false}

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -153,7 +153,6 @@ const ThumbnailSwiper = props => {
          * so that clicking on next/prev will scroll more than
          * one thumbnail */
         slidesPerGroup={displayThumbnailsArrows ? 4 : 1}
-        slidesPerGroupSkip={0}
         freeMode={false}
         mousewheel={false}
         zoom={false}

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -108,9 +108,9 @@ const ThumbnailSwiper = props => {
       thumbCaretClassName,
       {
         [`bottom-0 pt7 left-0 justify-center w-100 ${styles.gradientBaseBottom}`]:
-         isThumbsVertical,
+          isThumbsVertical,
         [`right-0 top-0 items-center h-100 pl6 ${styles.gradientBaseRight}`]:
-         !isThumbsVertical,
+          !isThumbsVertical,
       }
     )
 

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -107,8 +107,10 @@ const ThumbnailSwiper = props => {
       'swiper-thumbnails-caret-next',
       thumbCaretClassName,
       {
-        [`bottom-0 pt7 left-0 justify-center w-100 ${styles.gradientBaseBottom}`]: isThumbsVertical,
-        [`right-0 top-0 items-center h-100 pl6 ${styles.gradientBaseRight}`]: !isThumbsVertical,
+        [`bottom-0 pt7 left-0 justify-center w-100 ${styles.gradientBaseBottom}`]:
+         isThumbsVertical,
+        [`right-0 top-0 items-center h-100 pl6 ${styles.gradientBaseRight}`]:
+         !isThumbsVertical,
       }
     )
 

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -98,7 +98,13 @@ class Carousel extends Component {
     if (!equals(prevProps.slides, this.props.slides)) {
       this.setInitialVariablesState()
 
-      if (!this.props.slides) return
+      if (
+        !this.props.slides ||
+        this.state.gallerySwiper?.destroyed ||
+        this.state.thumbSwiper?.destroyed
+      ) {
+        return
+      }
 
       this.state.gallerySwiper?.slideTo(initialState.activeIndex)
       this.state.thumbSwiper?.slideTo(initialState.activeIndex)

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -130,6 +130,10 @@ const ProductImages = ({
     )
   }
 
+  if (!slides) {
+    return
+  }
+
   return (
     <div className={containerClass}>
       <Carousel


### PR DESCRIPTION
#### What problem is this solving?

When changing the product context through the shelf and using productImage carousel, Swiper sometimes is destroyed due new render of the page, and then, when changing its context it breaks the page because Swiper is not mounted yet

#### How to test it?

Keep changing the shelf below the product image, after a while, the page is going to crash

[before](https://supportproduct--yoyojeans.myvtex.com/blusa-tiras-para-ni%C3%B1as-junior-con-nido-de-abeja-negro-32030209/p?skuId=20174)

[after](https://carolteste--yoyojeans.myvtex.com/camiseta-para-ninas-estampada-en-frente-amarillopastel-33055153/p?skuId=11787 )

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/13649073/200915333-b730c4f1-ada4-4f97-8433-f2db1f69b4d3.png)

#### Related to / Depends on

Zendesk #682994
#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/l2JebJIKQmRwbjp5e/giphy.gif)
