### PR TITLE
docs: include all html attributes to image

### DIFF
--- a/docs/Image.md
+++ b/docs/Image.md
@@ -41,6 +41,8 @@ The `image` block renders images in the storefront.
 | `srcSet`      | `string`   | URL of the image to use in different situations.              | - |
 | `title` | `string` | Image title displayed on hover | - |
 
+> All image HTML attributes are also valid props.
+
 - **`link` props:**
 
 | Prop name     | Type       | Description                                                                | Default value | 


### PR DESCRIPTION
#### What problem is this solving?

Recently I made a [PR](https://github.com/vtex-apps/store-image/pull/77) spreading all remaining props of an image. Here I am simply documenting it.

#### Related to / Depends on

Depends on https://github.com/vtex-apps/store-image/pull/77
