### PR TITLE
bug: validation in shipping simulator

### DIFF
--- a/react/components/ShippingSimulator/Wrapper.js
+++ b/react/components/ShippingSimulator/Wrapper.js
@@ -35,7 +35,8 @@ const useAddressState = (country, postalCode) => {
     }
 
     setAddress(updatedAddress)
-    setIsValid(updatedAddress.postalCode.valid)
+    
+    setIsValid(updatedAddress.city.value && updateAddress.state.value ? true : false)
   }
 
   return { address, updateAddress, isValid }


### PR DESCRIPTION
#### What problem is this solving?

when the zip code is not valid, it still inserts the zip code and leaves the orderform completely reset. You can test with zip code: 00000-000

This zip code undergoes zip code validation, but there is no city or state, street or anything. That's why everything is zero

#### How to test it?

Insert zip 00000-000

https://fieldcep--lojaduratex.myvtex.com/chuveiro-com-desviador-e-ducha-manual-acqua-plus-1990-c-std-kit/p

#### Screenshots or example usage:

<img width="282" alt="Captura de Tela 2023-03-14 às 01 21 39" src="https://user-images.githubusercontent.com/39968896/224892589-921f2ea9-1dab-4157-8f11-9773cfa57040.png">

<img width="362" alt="Captura de Tela 2023-03-14 às 01 18 25" src="https://user-images.githubusercontent.com/39968896/224892606-88a6f1bc-893f-4311-be30-04f4680b94c8.png">

<img width="602" alt="Captura de Tela 2023-03-14 às 01 16 20" src="https://user-images.githubusercontent.com/39968896/224892619-6d9b79f3-b34a-4f46-affb-1e6c41e1ff7f.png">

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

I would love to have a PR, this would be my first contribution to VTEX
