### PR TITLE
Feature: render image label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `showImageLabel` prop to `ProductImages` which if set to `true` will result in each image's label text being rendered above the image
+
 ## [3.167.2] - 2023-04-20
 ### Fixed
 - Updated readme.md according to task LOC-10534.

--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -1,4 +1,4 @@
->📢 **Disclaimer** Don't fork this project. Use it, [contribute](https://github.com/vtex-apps/store-components) to it or open issues through [Store Discussion](https://github.com/vtex-apps/store-discussion) to help us evolve it. 
+> 📢 **Disclaimer** Don't fork this project. Use it, [contribute](https://github.com/vtex-apps/store-components) to it or open issues through [Store Discussion](https://github.com/vtex-apps/store-discussion) to help us evolve it.
 
 # Product Images
 
@@ -43,26 +43,27 @@ The `product-images` block is responsible for rendering a product image or video
 
 ### Props
 
-| Prop name                 | Type      | Description                                                                                                 | Default Value |
-| ------------------------- | --------- | ----------------------------------------------------------------------------------------------------------- | ------------- |
-| `aspectRatio`             | `string`                                   | Sets the aspect ratio of the image, that is, whether the image should be square, portrait, landscape, etc. The value should follow the [common aspect ratio notation](https://en.wikipedia.org/wiki/Aspect_ratio_(image)) i.e. two numbers separated by a colon such as `1:1` for square, `3:4` for upright portrait, or `1920:1080` for even large values) | `"auto"`          |
-| `contentOrder`   | `'videos-first'` &#124; `'images-first'`    | Controls the order in which the images and videos are displayed.                                 | `'images-first'`    | 
-| `contentType` | `enum` | Controls the type of content that will be displayed in the block. Possible values are: `images`, `videos`, or `all`. | `all` |
-| `displayMode` | `enum` | Defines how the product media should be displayed. Possible values are `carousel` (displays the product images and videos in a carousel), `list` (displays only the product images inline, with no extra markup) and `first-image` (displays only the first image available). *Caution*: The `list` and `first-image` values do not display product videos and are only compatible with the `maxHeight`, `hiddenImages`, `zoomFactor`, `aspectRatio`,`ModalZoomElement`, and `zoomMode` props. | `carousel` |
-| `displayThumbnailsArrows` | `boolean` | Displays navigation arrows on the thumbnails media (if there are enough thumbnails for them to scroll)              | `false`       |
-| `hiddenImages`       | `string`  | Hides images whose labels match the values listed in this prop. Intended to be used along with the `product-summary-sku-selector` block. You can have more information at the [SKU Selector](https://developers.vtex.com/docs/apps/vtex.store-components/skuselector) documentation | `skuvariation` |
-| `maxHeight`             | `number`                                   | Maximum height for individual product images (in pixels). | `600`          |
-| `ModalZoom` | `block` | Opens a modal for product image zooming. This prop's value must match the name of the block responsible for triggering the modal containing the product image for zooming (e.g. `modal-layout` from [Modal layout](https://developers.vtex.com/docs/apps/vtex.modal-layout) app). Notice that the `ModalZoom` prop will work only if the `zoomMode` prop is set as `open-modal`. To learn more, check out the [Advanced Configuration section](#Advanced-Configuration). | `undefined` |
-| `placeholder` | `string` | Sets the URL for a placeholder image to be used in case there is no available image or video of the product. | `undefined`       |
-| `position`                | `Enum`    | Set the position of the thumbnails (`left` or `right`). Only used when `thumbnailsOrientation` is `vertical` | `left`        |
-| `showNavigationArrows`             | `boolean`                                   | Controls if the navigation arrows should appear | `true`          |
-| `showPaginationDots`             | `boolean`                                   | Controls if the pagination dots should appear | `true`          |
-| `thumbnailVisibility`             | `visible` or `hidden`                                   | Controls if the thumbnails should appear in `carousel` displayMode | `visible`          |
-| `thumbnailAspectRatio`             | `string`                                   | Sets the aspect ratio of the thumbnail image; For more information about aspect ratio, check the `aspectRatio` prop | `"auto"`          |
-| `thumbnailMaxHeight`             | `number`                                   | Maximum height for the thumbnail image (in pixels). | `150`          |
-| `thumbnailsOrientation`   | `Enum`    | Choose the orientation of the thumbnails. Can be set to `vertical` or `horizontal`                                 | `vertical`    | 
-| `zoomFactor` | `number` | Sets how much the zoom increases the image size (e.g. `2` will make the zoomed-in image twice as large) | 2 |
-| `zoomMode` | `enum` | Defines the image zoom behavior. Possible values are: `disabled` (zoom is disabled), `in-place-click`(zoom will be triggered when the image is clicked on), `in-place-hover`(zoom will be triggered when the image is hovered on)  or `open-modal` (image is zoommed using a modal). | `in-place-click` |
+| Prop name                 | Type                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Default Value    |
+| ------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `aspectRatio`             | `string`                                 | Sets the aspect ratio of the image, that is, whether the image should be square, portrait, landscape, etc. The value should follow the [common aspect ratio notation](<https://en.wikipedia.org/wiki/Aspect_ratio_(image)>) i.e. two numbers separated by a colon such as `1:1` for square, `3:4` for upright portrait, or `1920:1080` for even large values)                                                                                                                                  | `"auto"`         |
+| `contentOrder`            | `'videos-first'` &#124; `'images-first'` | Controls the order in which the images and videos are displayed.                                                                                                                                                                                                                                                                                                                                                                                                                               | `'images-first'` |
+| `contentType`             | `enum`                                   | Controls the type of content that will be displayed in the block. Possible values are: `images`, `videos`, or `all`.                                                                                                                                                                                                                                                                                                                                                                           | `all`            |
+| `displayMode`             | `enum`                                   | Defines how the product media should be displayed. Possible values are `carousel` (displays the product images and videos in a carousel), `list` (displays only the product images inline, with no extra markup) and `first-image` (displays only the first image available). _Caution_: The `list` and `first-image` values do not display product videos and are only compatible with the `maxHeight`, `hiddenImages`, `zoomFactor`, `aspectRatio`,`ModalZoomElement`, and `zoomMode` props. | `carousel`       |
+| `displayThumbnailsArrows` | `boolean`                                | Displays navigation arrows on the thumbnails media (if there are enough thumbnails for them to scroll)                                                                                                                                                                                                                                                                                                                                                                                         | `false`          |
+| `hiddenImages`            | `string`                                 | Hides images whose labels match the values listed in this prop. Intended to be used along with the `product-summary-sku-selector` block. You can have more information at the [SKU Selector](https://developers.vtex.com/docs/apps/vtex.store-components/skuselector) documentation                                                                                                                                                                                                            | `skuvariation`   |
+| `maxHeight`               | `number`                                 | Maximum height for individual product images (in pixels).                                                                                                                                                                                                                                                                                                                                                                                                                                      | `600`            |
+| `ModalZoom`               | `block`                                  | Opens a modal for product image zooming. This prop's value must match the name of the block responsible for triggering the modal containing the product image for zooming (e.g. `modal-layout` from [Modal layout](https://developers.vtex.com/docs/apps/vtex.modal-layout) app). Notice that the `ModalZoom` prop will work only if the `zoomMode` prop is set as `open-modal`. To learn more, check out the [Advanced Configuration section](#Advanced-Configuration).                       | `undefined`      |
+| `placeholder`             | `string`                                 | Sets the URL for a placeholder image to be used in case there is no available image or video of the product.                                                                                                                                                                                                                                                                                                                                                                                   | `undefined`      |
+| `position`                | `Enum`                                   | Set the position of the thumbnails (`left` or `right`). Only used when `thumbnailsOrientation` is `vertical`                                                                                                                                                                                                                                                                                                                                                                                   | `left`           |
+| `showNavigationArrows`    | `boolean`                                | Controls if the navigation arrows should appear                                                                                                                                                                                                                                                                                                                                                                                                                                                | `true`           |
+| `showPaginationDots`      | `boolean`                                | Controls if the pagination dots should appear                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `true`           |
+| `showImageLabel`          | `boolean`                                | Controls if the image label text should be rendered above each image                                                                                                                                                                                                                                                                                                                                                                                                                           | `false`          |
+| `thumbnailVisibility`     | `visible` or `hidden`                    | Controls if the thumbnails should appear in `carousel` displayMode                                                                                                                                                                                                                                                                                                                                                                                                                             | `visible`        |
+| `thumbnailAspectRatio`    | `string`                                 | Sets the aspect ratio of the thumbnail image; For more information about aspect ratio, check the `aspectRatio` prop                                                                                                                                                                                                                                                                                                                                                                            | `"auto"`         |
+| `thumbnailMaxHeight`      | `number`                                 | Maximum height for the thumbnail image (in pixels).                                                                                                                                                                                                                                                                                                                                                                                                                                            | `150`            |
+| `thumbnailsOrientation`   | `Enum`                                   | Choose the orientation of the thumbnails. Can be set to `vertical` or `horizontal`                                                                                                                                                                                                                                                                                                                                                                                                             | `vertical`       |
+| `zoomFactor`              | `number`                                 | Sets how much the zoom increases the image size (e.g. `2` will make the zoomed-in image twice as large)                                                                                                                                                                                                                                                                                                                                                                                        | 2                |
+| `zoomMode`                | `enum`                                   | Defines the image zoom behavior. Possible values are: `disabled` (zoom is disabled), `in-place-click`(zoom will be triggered when the image is clicked on), `in-place-hover`(zoom will be triggered when the image is hovered on) or `open-modal` (image is zoommed using a modal).                                                                                                                                                                                                            | `in-place-click` |
 
 ### Advanced configuration
 
@@ -72,7 +73,7 @@ When configured as stated previously, the `zoomMode` prop will allow the trigger
 
 Once both props are correctly configured, you must declare the `modal-layout` block and the `product-images.high-quality-image` block as its child.
 
-The `modal-layout` block is the one responsible for building the Modal component and triggering the image zooming in a popup box. The `product-images.high-quality-image` block, in turn, is a *special* block, only meant to render the `product-image` block inside the modal. 
+The `modal-layout` block is the one responsible for building the Modal component and triggering the image zooming in a popup box. The `product-images.high-quality-image` block, in turn, is a _special_ block, only meant to render the `product-image` block inside the modal.
 
 Check out the following example:
 
@@ -110,56 +111,57 @@ Notice that the `product-images.high-quality-image` block must be declared as a 
 
 The following table shows the props allowed by `product-images.high-quality-image`:
 
-| Prop name | Type | Description | Default Value |
-| --- | --- | --- | --- |
-| `aspectRatio` | `string` | Sets the aspect ratio of the image, that is, whether the image should be square, portrait, landscape, etc. The value should follow the [common aspect ratio notation](https://en.wikipedia.org/wiki/Aspect_ratio_(image) i.e. two numbers separated by a colon such as `1:1` for square, `3:4` for upright portrait, or `1920:1080` for even large values).| `auto` |
-| `defaultSize` | `number` |  Image default size (in `px`). | `1200` | 
-| `imageSizes` | `[number]` | Image size(s) (in `px`) to be used in the image's [`srcset` HTML attribute](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). If no value is passed to this prop, the `srcset` will use the image original size.  | `undefined` |
-| `maxSize` | `number` | Image maximum size (in `px`) for rendering regardless of the screen size. Notice that this prop only works if you also declare the `imageSizes` prop. | `4096` |
-| `zoomFactor` | `number` | Sets how much the zoom increases the image size (e.g. `2` will make the zoomed-in image twice as large). | `2` |
-| `zoomMode` | `enum` | Defines the zoom behavior for the `product-images.high-quality-image` block. Possible values are: `disabled` (zoom is disabled), `in-place-click`(zoom will be triggered when the image is clicked on), or `in-place-hover`(zoom will be triggered when the image is hovered on). Different from the `store-images` prop, this one doesn't accept `open-modal` value. | `disabled` |
+| Prop name     | Type       | Description                                                                                                                                                                                                                                                                                                                                                           | Default Value |
+| ------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `aspectRatio` | `string`   | Sets the aspect ratio of the image, that is, whether the image should be square, portrait, landscape, etc. The value should follow the [common aspect ratio notation](https://en.wikipedia.org/wiki/Aspect_ratio_(image) i.e. two numbers separated by a colon such as `1:1` for square, `3:4` for upright portrait, or `1920:1080` for even large values).           | `auto`        |
+| `defaultSize` | `number`   | Image default size (in `px`).                                                                                                                                                                                                                                                                                                                                         | `1200`        |
+| `imageSizes`  | `[number]` | Image size(s) (in `px`) to be used in the image's [`srcset` HTML attribute](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). If no value is passed to this prop, the `srcset` will use the image original size.                                                                                                       | `undefined`   |
+| `maxSize`     | `number`   | Image maximum size (in `px`) for rendering regardless of the screen size. Notice that this prop only works if you also declare the `imageSizes` prop.                                                                                                                                                                                                                 | `4096`        |
+| `zoomFactor`  | `number`   | Sets how much the zoom increases the image size (e.g. `2` will make the zoomed-in image twice as large).                                                                                                                                                                                                                                                              | `2`           |
+| `zoomMode`    | `enum`     | Defines the zoom behavior for the `product-images.high-quality-image` block. Possible values are: `disabled` (zoom is disabled), `in-place-click`(zoom will be triggered when the image is clicked on), or `in-place-hover`(zoom will be triggered when the image is hovered on). Different from the `store-images` prop, this one doesn't accept `open-modal` value. | `disabled`    |
 
 ## Customization
 
 To apply CSS customizations in this and other blocks, follow the [Using CSS handles for store customization](https://developers.vtex.com/docs/guides/vtex-io-documentation-using-css-handles-for-store-customization) guide.
 
-| CSS Handles |
-| --- |
-| `carouselContainer` |
-| `carouselCursorDefault` |
-| `carouselGaleryCursor` |
-| `carouselGaleryThumbs` |
-| `carouselIconCaretLeft` |
-| `carouselIconCaretRight` |
-| `carouselImagePlaceholder` |
-| `carouselInconCaretRight` |
-| `carouselThumbBorder` |
-| `figure` |
-| `figure--video` |
-| `highQualityContainer` |
-| `image` |
-| `imgZoom` |
+| CSS Handles                                        |
+| -------------------------------------------------- |
+| `carouselContainer`                                |
+| `carouselCursorDefault`                            |
+| `carouselGaleryCursor`                             |
+| `carouselGaleryThumbs`                             |
+| `carouselIconCaretLeft`                            |
+| `carouselIconCaretRight`                           |
+| `carouselImagePlaceholder`                         |
+| `carouselInconCaretRight`                          |
+| `carouselThumbBorder`                              |
+| `figure`                                           |
+| `figure--video`                                    |
+| `highQualityContainer`                             |
+| `image`                                            |
+| `imgZoom`                                          |
 | `productImagesContainer` (`content` is deprecated) |
-| `productImagesContainer--carousel`|
-| `productImagesContainer--list`|
-| `productImagesGallerySlide` |
-| `productImagesGallerySwiperContainer` |
-| `productImagesThumb` |
-| `productImagesThumbActive` |
-| `productImagesThumbCaret` |
-| `productImagesThumbsSwiperContainer` |
-| `productImageTag--main`|
-| `productImageTag--zoon`|
-| `productImageTag`|
-| `productVideo` |
-| `swiper-pagination` |
-| `swiperBullet--active` |
-| `swiperBullet` |
-| `swiperCaret` |
-| `swiperCaretNext` |
-| `swiperCaretPrev` |
-| `thumbImg` |
-| `thumbImg--video` |
-| `video` |
-| `video`|
-| `videoContainer` |
+| `productImagesContainer--carousel`                 |
+| `productImagesContainer--list`                     |
+| `productImagesGallerySlide`                        |
+| `productImagesGallerySwiperContainer`              |
+| `productImagesThumb`                               |
+| `productImagesThumbActive`                         |
+| `productImagesThumbCaret`                          |
+| `productImagesThumbsSwiperContainer`               |
+| `productImageTag--main`                            |
+| `productImageTag--zoon`                            |
+| `productImageTag`                                  |
+| `productImageLabel`                                |
+| `productVideo`                                     |
+| `swiper-pagination`                                |
+| `swiperBullet--active`                             |
+| `swiperBullet`                                     |
+| `swiperCaret`                                      |
+| `swiperCaretNext`                                  |
+| `swiperCaretPrev`                                  |
+| `thumbImg`                                         |
+| `thumbImg--video`                                  |
+| `video`                                            |
+| `video`                                            |
+| `videoContainer`                                   |

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -172,6 +172,7 @@ class Carousel extends Component {
             index={i}
             src={slide.url}
             alt={slide.alt}
+            imageLabel={slide.imageLabel}
             maxHeight={maxHeight}
             zoomFactor={zoomFactor}
             aspectRatio={aspectRatio}

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -16,6 +16,7 @@ interface Props {
   index: number
   src: string
   alt: string
+  imageLabel?: string
   zoomMode: ZoomMode
   zoomFactor: number
   aspectRatio?: AspectRatio
@@ -25,12 +26,13 @@ interface Props {
 
 type AspectRatio = string | number
 
-const CSS_HANDLES = ['productImage', 'productImageTag']
+const CSS_HANDLES = ['productImage', 'productImageTag', 'productImageLabel']
 
 const ProductImage: FC<Props> = ({
   index,
   src,
   alt,
+  imageLabel,
   zoomFactor = 2,
   maxHeight = 600,
   ModalZoomElement,
@@ -59,6 +61,9 @@ const ProductImage: FC<Props> = ({
   return (
     <ProductImageContext.Provider value={imageContext}>
       <div className={handles.productImage}>
+        {imageLabel && (
+          <div className={`tc ${handles.productImageLabel}`}>{imageLabel}</div>
+        )}
         <Zoomable
           mode={zoomMode}
           factor={zoomFactor}

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -28,6 +28,7 @@ const ProductImages = ({
   thumbnailMaxHeight,
   showNavigationArrows,
   showPaginationDots,
+  showImageLabel = false,
   thumbnailVisibility,
   contentOrder = 'images-first',
   zoomMode,
@@ -66,9 +67,10 @@ const ProductImages = ({
             url: image.imageUrls ? image.imageUrls[0] : image.imageUrl,
             alt: image.imageText,
             thumbUrl: image.thumbnailUrl || image.imageUrl,
+            ...(showImageLabel && { imageLabel: image.imageLabel }),
           }))
       : []
-  }, [allImages, contentType, excludeImageRegexes])
+  }, [allImages, contentType, excludeImageRegexes, showImageLabel])
 
   const videos = useMemo(() => {
     const shouldIncludeVideos = contentType !== 'images'
@@ -96,11 +98,12 @@ const ProductImages = ({
   if (displayMode === DISPLAY_MODE.LIST) {
     return (
       <div className={containerClass}>
-        {images.map(({ url, alt }, index) => (
+        {images.map(({ url, alt, imageLabel }, index) => (
           <ProductImage
             key={index}
             src={url}
             alt={alt}
+            imageLabel={imageLabel}
             maxHeight={maxHeight}
             zoomFactor={zoomFactor}
             aspectRatio={aspectRatio}
@@ -113,13 +116,14 @@ const ProductImages = ({
   }
 
   if (displayMode === DISPLAY_MODE.FIRST_IMAGE && images?.length) {
-    const { url, alt } = images?.[0]
+    const { url, alt, imageLabel } = images?.[0] ?? {}
 
     return (
       <div className={containerClass}>
         <ProductImage
           src={url}
           alt={alt}
+          imageLabel={imageLabel}
           maxHeight={maxHeight}
           zoomFactor={zoomFactor}
           aspectRatio={aspectRatio}
@@ -203,6 +207,7 @@ ProductImages.propTypes = {
   thumbnailMaxHeight: PropTypes.number,
   showNavigationArrows: PropTypes.bool,
   showPaginationDots: PropTypes.bool,
+  showImageLabel: PropTypes.bool,
   thumbnailVisibility: PropTypes.oneOf([
     THUMBS_VISIBILITY.VISIBLE,
     THUMBS_VISIBILITY.HIDDEN,


### PR DESCRIPTION
#### What problem is this solving?

A client wishes to render the image label text above the product image on the PDP. This PR adds a `showImageLabel` boolean prop to the `ProductImages` component that, if set to `true`, will have the desired effect.

#### How to test it?

Linked here: https://cosmotest--cosmo.myvtex.com/art---lutherie-roadhouse-acoustic-guitar---tennessee-red/p
(select the fifth image to see the rendered label)

#### Screenshots or example usage:

<img width="997" alt="image" src="https://user-images.githubusercontent.com/6306265/233726769-5c29b955-b07d-47cc-9ed1-a0fa60a1b0d1.png">

Or with custom styling:

![image](https://user-images.githubusercontent.com/6306265/233726800-f8fd1dd7-9794-4b13-8c90-6fbff701cefd.png)
