### PR TITLE
Fix: openShareDialogClick on click is true except when it is emailShareButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Modal not displaing in email share at `SocialButton`
 ## [3.169.3] - 2023-05-12
 
 ## [3.169.2] - 2023-05-12

--- a/react/components/Share/components/SocialButton.js
+++ b/react/components/Share/components/SocialButton.js
@@ -89,7 +89,7 @@ export default class SocialButton extends Component {
         )}
         media={imageUrl}
         onClick={() => this.props.sendShareEvent(socialEnum)}
-        openShareDialogOnClick={true}
+        openShareDialogOnClick
         {...additionalProps}
       >
         {icon}

--- a/react/components/Share/components/SocialButton.js
+++ b/react/components/Share/components/SocialButton.js
@@ -89,6 +89,7 @@ export default class SocialButton extends Component {
         )}
         media={imageUrl}
         onClick={() => this.props.sendShareEvent(socialEnum)}
+        openShareDialogOnClick={true}
         {...additionalProps}
       >
         {icon}


### PR DESCRIPTION
#### What problem is this solving?

The modal on the email share button is not being opened when clicked. 

Ref: https://www.npmjs.com/package/react-share 

> OpenShareDialogOnClick (boolean): Open dialog on click. Defaults to true except on EmailShareButton

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[before](https://dexco.myvtex.com/valvula-de-escoamento-para-lavatorio-cuba-e-bide-cromado-1602-c/p)
![image](https://github.com/vtex-apps/store-components/assets/95254650/5987fe5d-dd5b-4591-96a6-5493bb0f2d03)
Click on the email option and nothing happens

[after](https://ccanelas--dexco.myvtex.com/valvula-de-escoamento-para-lavatorio-cuba-e-bide-cromado-1602-c/p )
![image](https://github.com/vtex-apps/store-components/assets/95254650/1b3a28d3-abe2-41d9-bb98-69315911d950)
Click on the email option and the expected modal opens

#### Related to / Depends on

Zendesk: #879384

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/aOften89vRbG/giphy.gif)
