### PR TITLE
collapseHeight prop at ProductDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `collapseHeight` prop at `ProductDescription` to define the content minimum height in pixels when `collapseContent` prop is `true` (default: 200)
+- `collapseHeight` prop at `ProductDescription` to define the content minimum height in pixels when `collapseContent` prop is `true` (default: 220)
 
 ## [3.169.5] - 2023-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `collapseHeight` prop at `ProductDescription` to define the content minimum height in pixels when `collapseContent` prop is `true` (default: 200)
+
 ## [3.169.5] - 2023-10-05
 
 

--- a/docs/ProductDescription.md
+++ b/docs/ProductDescription.md
@@ -38,7 +38,7 @@ The `product-description` block displays the description of a product. This Comp
 | ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
 | `classes` | `CustomCSSClasses` | Overrides default CSS handles. To better understand how this prop works, check [this document](https://github.com/vtex-apps/css-handles#usecustomclasses). Note that this is only helpful if you're using this block as a React component.| `undefined` |
 | `collapseContent` | `boolean` | If `true`, whenever the product description is too big, it will collapse and show a "Show More" button. When false, it will never collapse and will always show the whole description. | `true` |
-| `collapseHeight` | `number` | Define the content minimum height in pixels when `collapseContent` prop is `true`. | `200` |
+| `collapseHeight` | `number` | Define the content minimum height in pixels when `collapseContent` prop is `true`. | `220` |
 | `showTitle`           | `boolean`  | Define whether or not to show the title. | `true` |
 | `title`           | `string`  | Defines a custom title for the description section. | `undefined` |
 

--- a/docs/ProductDescription.md
+++ b/docs/ProductDescription.md
@@ -37,7 +37,8 @@ The `product-description` block displays the description of a product. This Comp
 | Prop name         | Type      | Description                                                                                                                                                                          | Default     |
 | ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
 | `classes` | `CustomCSSClasses` | Overrides default CSS handles. To better understand how this prop works, check [this document](https://github.com/vtex-apps/css-handles#usecustomclasses). Note that this is only helpful if you're using this block as a React component.| `undefined` |
-| `collapseContent` | `Boolean` | If `true`, whenever the product description is too big, it will collapse and show a "Show More" button. When false, it will never collapse and will always show the whole description. | `true` |
+| `collapseContent` | `boolean` | If `true`, whenever the product description is too big, it will collapse and show a "Show More" button. When false, it will never collapse and will always show the whole description. | `true` |
+| `collapseHeight` | `number` | Define the content minimum height in pixels when `collapseContent` prop is `true`. | `200` |
 | `showTitle`           | `boolean`  | Define whether or not to show the title. | `true` |
 | `title`           | `string`  | Defines a custom title for the description section. | `undefined` |
 

--- a/react/ProductDescription.tsx
+++ b/react/ProductDescription.tsx
@@ -24,6 +24,8 @@ type Props = {
   showTitle?: boolean
   /** Define if content should start collapsed or not */
   collapseContent?: boolean
+  /** Define the content minimum height in pixels when collapseContent is true (default: 200) */
+  collapseHeight?: number
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
 }
@@ -64,7 +66,12 @@ function ProductDescription(props: PropsWithChildren<Props>) {
     return null
   }
 
-  const { collapseContent = true, showTitle = true, title } = props
+  const {
+    collapseContent = true,
+    collapseHeight = 200,
+    showTitle = true,
+    title,
+  } = props
 
   return (
     <div className={handles.productDescriptionContainer}>
@@ -82,7 +89,7 @@ function ProductDescription(props: PropsWithChildren<Props>) {
 
       <div className={`${handles.productDescriptionText} c-muted-1`}>
         {collapseContent ? (
-          <GradientCollapse collapseHeight={220}>
+          <GradientCollapse collapseHeight={collapseHeight}>
             <SanitizedHTML
               content={description}
               allowedTags={allowedTags}

--- a/react/ProductDescription.tsx
+++ b/react/ProductDescription.tsx
@@ -24,7 +24,7 @@ type Props = {
   showTitle?: boolean
   /** Define if content should start collapsed or not */
   collapseContent?: boolean
-  /** Define the content minimum height in pixels when collapseContent is true (default: 200) */
+  /** Define the content minimum height in pixels when collapseContent is true (default: 220) */
   collapseHeight?: number
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
@@ -68,7 +68,7 @@ function ProductDescription(props: PropsWithChildren<Props>) {
 
   const {
     collapseContent = true,
-    collapseHeight = 200,
+    collapseHeight = 220,
     showTitle = true,
     title,
   } = props


### PR DESCRIPTION
#### What problem is this solving?

Currently the height of 220px is explicitly defined in the code. This PR creates a `collapseHeight` prop at `ProductDescription` that defines the content minimum height in pixels when `collapseContent` prop is `true` (default: 220 for compatibility with current version).

#### How to test it?

```json
"product-description": {
  "props": {
    "collapseHeight": 117
  }
}
```

[Workspace](https://titantools.vtexdemostores.com/starrett-electronic-caliper/p?workspace=dev)

#### Screenshots or example usage:
<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

Before:
![before](https://github.com/vtex-apps/store-components/assets/921910/e936f5f1-5aec-4189-9f2d-1fd518506d34)

After:
![after](https://github.com/vtex-apps/store-components/assets/921910/575bc0a0-0217-4c84-af8a-3a03ec0b2543)
