### PR TITLE
Feat added unavailable class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Class name to 'unavailable' in order to unavailable items in sku selector so they can be hidden by CSS. 
+- CSS Handle for unavailable products. 
 
 
 ## [3.171.0] - 2024-01-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Class name to 'unavailable' to unavailable items in sku selector so they can be hidden by CSS. 
+
+
 ## [3.171.0] - 2024-01-09
 
 ## [3.170.0] - 2023-11-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- CSS Handle for unavailable products. 
+- CSS Handle for unavailable products update. 
 
 
 ## [3.171.0] - 2024-01-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Class name to 'unavailableSkuSelectorPDP' to unavailable items in sku selector so they can be hidden by CSS. 
+- Class name to 'unavailable' in order to unavailable items in sku selector so they can be hidden by CSS. 
 
 
 ## [3.171.0] - 2024-01-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Class name to 'unavailable' to unavailable items in sku selector so they can be hidden by CSS. 
+- Class name to 'unavailableSkuSelectorPDP' to unavailable items in sku selector so they can be hidden by CSS. 
 
 
 ## [3.171.0] - 2024-01-09

--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -83,7 +83,7 @@ function SelectorItem({
           'o-20': isImpossible,
         },
         'valueWrapper',
-        !isAvailable ? 'unavailableSkuSelectorPDP' : 'disableItem'
+        !isAvailable ? 'unavailable' : 'disableItem'
       ),
     [
       isImage,

--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -83,7 +83,7 @@ function SelectorItem({
           'o-20': isImpossible,
         },
         'valueWrapper',
-        !isAvailable ? 'unavailable' : 'disableItem'
+        !isAvailable ? 'unavailableSkuSelectorPDP' : 'disableItem'
       ),
     [
       isImage,

--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -81,10 +81,13 @@ function SelectorItem({
         {
           [`${handles.skuSelectorItemImage}`]: isImage,
           'o-20': isImpossible,
-        }
+        },
+        'valueWrapper',
+        !isAvailable ? 'unavailable' : 'disableItem'
       ),
     [
       isImage,
+      isAvailable,
       isSelected,
       isImpossible,
       variationValueOriginalName,

--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -38,6 +38,7 @@ export const CSS_HANDLES = [
   'frameAround',
   'valueWrapper',
   'diagonalCross',
+  'unavailable',
   'skuSelectorItem',
   'skuSelectorBadge',
   'skuSelectorItemImage',
@@ -83,7 +84,7 @@ function SelectorItem({
           'o-20': isImpossible,
         },
         'valueWrapper',
-        !isAvailable ? 'unavailable' : 'disableItem'
+        !isAvailable ? `${handles.unavailable}` : 'disableItem'
       ),
     [
       isImage,
@@ -93,6 +94,7 @@ function SelectorItem({
       variationValueOriginalName,
       withModifiers,
       handles.skuSelectorItemImage,
+      handles.unavailable,
     ]
   )
 

--- a/react/components/SKUSelector/components/SelectorItem.tsx
+++ b/react/components/SKUSelector/components/SelectorItem.tsx
@@ -84,7 +84,7 @@ function SelectorItem({
           'o-20': isImpossible,
         },
         'valueWrapper',
-        !isAvailable ? `${handles.unavailable}` : 'disableItem'
+        !isAvailable ? `${handles.unavailable}` : ''
       ),
     [
       isImage,


### PR DESCRIPTION
#### What problem is this solving?

PDP Sku selector shows unavailable items crossed out. Some clients require to hide these items via CSS with a CSS HANDLE 

#### How to test it?

Go to the workspace and use css to hide class unavailable

[Workspace](https://jorge--esikaperu.myvtex.com/labial-liquido-hidracolor-mate/p?skuId=200103718)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/store-components/assets/94565086/56ec8d85-ee45-4855-b66d-259f834090ad)

![image](https://github.com/vtex-apps/store-components/assets/94565086/12c07b5e-af76-4468-b537-fcc16396afb1)


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
