### PR TITLE
Performance TBT improvement rendering videos only it's selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Performance TBT improvement rendering videos only it's selected  
+
 ## [3.172.1] - 2024-02-13
 
 ### Fixed

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -190,7 +190,7 @@ class Carousel extends Component {
             id={i}
           />
         ) : (
-          <></>
+          <div />
         )
 
       default:

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -182,15 +182,15 @@ class Carousel extends Component {
         )
 
       case 'video':
-        return (
-          i === this.state.activeIndex && (
-            <Video
-              url={slide.src}
-              setThumb={this.setVideoThumb(i)}
-              playing={i === this.state.activeIndex}
-              id={i}
-            />
-          )
+        return i === this.state.activeIndex ? (
+          <Video
+            url={slide.src}
+            setThumb={this.setVideoThumb(i)}
+            playing={i === this.state.activeIndex}
+            id={i}
+          />
+        ) : (
+          <></>
         )
 
       default:

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -183,12 +183,14 @@ class Carousel extends Component {
 
       case 'video':
         return (
-          <Video
-            url={slide.src}
-            setThumb={this.setVideoThumb(i)}
-            playing={i === this.state.activeIndex}
-            id={i}
-          />
+          i === this.state.activeIndex && (
+            <Video
+              url={slide.src}
+              setThumb={this.setVideoThumb(i)}
+              playing={i === this.state.activeIndex}
+              id={i}
+            />
+          )
         )
 
       default:


### PR DESCRIPTION
#### What problem is this solving?

TBT when there are videos from Youtube or Vimeo.

Solution:

Only the target video is selected, and then it's rendered.

#### How to test it?

https://www.raamdecoratievantuiss.nl/cavendish-warme-steen-vouwgordijn-20258/p?workspace=labprod3