### PR TITLE
feat: new body text field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `bodyText` property added, this property allows adding a body text below the subtitle.
+
 ## [3.173.0] - 2024-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `bodyText` property added, this property allows adding a body text below the subtitle.
+- Added `bodyText` property to `info-card` component. This property allows adding a body text below the subtitle.
 
 ## [3.173.0] - 2024-05-28
 

--- a/docs/InfoCard.md
+++ b/docs/InfoCard.md
@@ -52,6 +52,7 @@ The `info-card` component groups information on a single topic. It often include
 | `linkTarget`             | `LinkTargetEnum`    | Where to display the linked URL when the Info Card component is clicked.                                                   | `"_self"`     |
 | `mobileImageUrl`         | `string`            | Path to the image used on mobile devices. If empty, the desktop image is used.                                             | `null`        |
 | `subhead`                | `string`            | Text to be displayed underneath the headline. If not provided, it will not be rendered.                                    | `null`        |
+| `bodyText`                | `string`            | Text to be displayed underneath the subhead. If not provided, it will not be rendered.                                    | `null`        |
 | `textAlignment`          | `TextAlignmentEnum` | Text alignment inside the component: `left`, `center` or `right`. This prop is ignored if `isFullModeStyle` is true.       | `"left"`      |
 | `textMode`               | `TextModeEnum`      | Text mode used to process the text from `headline` and `subhead` props.                                                    | `"html"`      |
 | `textPosition`           | `TextPositionEnum`  | Position of the text component: `left`, `center` or `right`.                                                               | `"left"`      |
@@ -104,4 +105,5 @@ To apply CSS customizations to this and other blocks, please see the [Using CSS 
 | `infoCardImageContainer`      |
 | `infoCardImageLinkWrapper`    |
 | `infoCardSubhead`             |
+| `infoCardBodyText`            |
 | `infoCardTextContainer`       |

--- a/messages/context.json
+++ b/messages/context.json
@@ -95,6 +95,8 @@
   "admin/editor.info-card.headline.description": "Description of headline property",
   "admin/editor.info-card.subhead.title": "Title of subhead property",
   "admin/editor.info-card.subhead.description": "Description of subhead property",
+  "admin/editor.info-card.body-text.title": "Title of body text property",
+  "admin/editor.info-card.body-text.description": "Description of body text property",
   "admin/editor.info-card.callToActionMode.title": "Title of callToActionMode property",
   "admin/editor.info-card.callToActionMode.description": "Description of callToActionMode property",
   "admin/editor.info-card.callToActionText.title": "Title of callToActionText property",

--- a/messages/en.json
+++ b/messages/en.json
@@ -97,6 +97,8 @@
   "admin/editor.info-card.headline.description": "Headline text inside component",
   "admin/editor.info-card.subhead.title": "Subheader",
   "admin/editor.info-card.subhead.description": "Text below headline inside component",
+  "admin/editor.info-card.body-text.title": "Body text",
+  "admin/editor.info-card.body-text.description": "Text below subhead inside component",
   "admin/editor.info-card.callToActionMode.title": "Call to action mode",
   "admin/editor.info-card.callToActionMode.description": "Controls how your call to action is displayed",
   "admin/editor.info-card.callToActionText.title": "Call to action text",

--- a/messages/es.json
+++ b/messages/es.json
@@ -97,6 +97,8 @@
   "admin/editor.info-card.headline.description": "Texto presentado de forma destacada",
   "admin/editor.info-card.subhead.title": "Subtítulo",
   "admin/editor.info-card.subhead.description": "Texto que aparece debajo del título",
+  "admin/editor.info-card.body-text.title": "Texto del cuerpo",
+  "admin/editor.info-card.body-text.description": "Texto que aparece debajo del subtítulo",
   "admin/editor.info-card.callToActionMode.title": "Modo call to action",
   "admin/editor.info-card.callToActionMode.description": "Controla cómo se muestra tu componente de call to action",
   "admin/editor.info-card.callToActionText.title": "Texto de call to action",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -97,6 +97,8 @@
   "admin/editor.info-card.headline.description": "Texto apresentado com destaque",
   "admin/editor.info-card.subhead.title": "Subtítulo",
   "admin/editor.info-card.subhead.description": "Texto apresentado abaixo do título",
+  "admin/editor.info-card.body-text.title": "Corpo do texto",
+  "admin/editor.info-card.body-text.description": "Texto abaixo do subtítulo no componente",
   "admin/editor.info-card.callToActionMode.title": "Modo do call to action",
   "admin/editor.info-card.callToActionMode.description": "Controla o modo de exibição do seu componente de call to action",
   "admin/editor.info-card.callToActionText.title": "Texto do call to action",

--- a/react/__tests__/components/InfoCard.test.js
+++ b/react/__tests__/components/InfoCard.test.js
@@ -109,4 +109,34 @@ describe('<InfoCard />', () => {
     expect(asFragment()).toBeDefined()
     expect(asFragment()).toMatchSnapshot()
   })
+  it('should not render bodyText', () => {
+    const { asFragment } = renderComponent({
+      isFullModeStyle: true,
+      callToActionMode: 'none',
+      textAlignment: 'right',
+      textPosition: 'center',
+      headline:
+        'HEADLINE <span class="my-custom-class">THIS IS BOOOLD AND BLUE</span> HEADLINE STILL',
+      subhead: '',
+      bodyText: '',
+    })
+
+    expect(asFragment()).toBeDefined()
+    expect(asFragment()).toMatchSnapshot()
+  })
+  it("should render bodyText, subhead and headline using the RichText component when textMode is set to 'rich-text'", () => {
+    const { asFragment } = renderComponent({
+      isFullModeStyle: true,
+      callToActionMode: 'none',
+      textAlignment: 'right',
+      textPosition: 'center',
+      textMode: 'rich-text',
+      headline: 'This is a headline, and should be inside a rich-text.',
+      subhead: 'This is a subhead, and should be inside a rich-text.',
+      bodyText: 'This is a bodyText, and should be inside a rich-text.',
+    })
+
+    expect(asFragment()).toBeDefined()
+    expect(asFragment()).toMatchSnapshot()
+  })
 })

--- a/react/__tests__/components/__snapshots__/InfoCard.test.js.snap
+++ b/react/__tests__/components/__snapshots__/InfoCard.test.js.snap
@@ -39,6 +39,36 @@ exports[`<InfoCard /> should insert span with class on headline 1`] = `
 </DocumentFragment>
 `;
 
+exports[`<InfoCard /> should not render bodyText 1`] = `
+<DocumentFragment>
+  <div
+    class="infoCardContainer items-center bg-center bb b--muted-4 flex justify-center"
+    data-testid="container"
+    style="background-image: url(my-image.com/image.png); background-size: cover;"
+  >
+    <div
+      class="infoCardTextContainer flex flex-column mw-100 mh8-ns mh4-s w-40-ns items-center"
+    >
+      <div
+        class="infoCardHeadline t-heading-2 mt6 tc c-on-base mw-100"
+      >
+        <div
+          style="display: contents;"
+        >
+          HEADLINE 
+          <span
+            class="my-custom-class"
+          >
+            THIS IS BOOOLD AND BLUE
+          </span>
+           HEADLINE STILL
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`<InfoCard /> should not render subhead 1`] = `
 <DocumentFragment>
   <div
@@ -63,6 +93,36 @@ exports[`<InfoCard /> should not render subhead 1`] = `
           </span>
            HEADLINE STILL
         </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<InfoCard /> should render bodyText, subhead and headline using the RichText component when textMode is set to 'rich-text' 1`] = `
+<DocumentFragment>
+  <div
+    class="infoCardContainer items-center bg-center bb b--muted-4 flex justify-center"
+    data-testid="container"
+    style="background-image: url(my-image.com/image.png); background-size: cover;"
+  >
+    <div
+      class="infoCardTextContainer flex flex-column mw-100 mh8-ns mh4-s w-40-ns items-center"
+    >
+      <div
+        data-testid="rich-text"
+      >
+        This is a headline, and should be inside a rich-text.
+      </div>
+      <div
+        data-testid="rich-text"
+      >
+        This is a subhead, and should be inside a rich-text.
+      </div>
+      <div
+        data-testid="rich-text"
+      >
+        This is a bodyText, and should be inside a rich-text.
       </div>
     </div>
   </div>

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -74,6 +74,7 @@ const CSS_HANDLES = [
   'infoCardTextContainer',
   'infoCardHeadline',
   'infoCardSubhead',
+  'infoCardBodyText',
   'infoCardImageContainer',
   'infoCardImage',
 ]
@@ -82,6 +83,7 @@ const InfoCard = ({
   isFullModeStyle,
   headline,
   subhead,
+  bodyText,
   callToActionMode,
   callToActionText,
   callToActionUrl,
@@ -169,6 +171,8 @@ const InfoCard = ({
 
   const subheadClasses = `${handles.infoCardSubhead} t-body mt6 c-on-base ${alignToken} mw-100`
 
+  const bodyTextClasses = `${handles.infoCardBodyText} t-body mt6 c-on-base ${alignToken} mw-100`
+
   return (
     <LinkWrapper
       imageActionUrl={formatIOMessage({ id: imageActionUrl, intl })}
@@ -207,6 +211,18 @@ const InfoCard = ({
             ) : (
               <RichText className={subheadClasses} text={subhead} />
             ))}
+            {bodyText &&
+            (textMode === 'html' ? (
+              <div className={bodyTextClasses}>
+                <SanitizedHTML
+                  content={formatIOMessage({ id: bodyText, intl })}
+                  allowedTags={ALLOWED_TAGS}
+                  allowedAttributes={ALLOWED_ATTRS}
+                />
+              </div>
+            ) : (
+              <RichText className={bodyTextClasses} text={bodyText} />
+            ))}
           <CallToAction
             mode={callToActionMode}
             text={formatIOMessage({ id: callToActionText, intl })}
@@ -243,6 +259,7 @@ MemoizedInfoCard.propTypes = {
   textPosition: oneOf(getEnumValues(textPositionTypes)),
   headline: string,
   subhead: string,
+  bodyText: string,
   callToActionMode: oneOf(getEnumValues(callToActionModeTypes)),
   callToActionText: string,
   callToActionUrl: string,
@@ -263,6 +280,7 @@ MemoizedInfoCard.defaultProps = {
   textPosition: textPositionTypes.TEXT_POSITION_LEFT.value,
   headline: '',
   subhead: '',
+  bodyText: '',
   callToActionMode: callToActionModeTypes.CALL_ACTION_BUTTON.value,
   callToActionText: '',
   callToActionUrl: '',

--- a/react/components/InfoCard/index.js
+++ b/react/components/InfoCard/index.js
@@ -211,7 +211,7 @@ const InfoCard = ({
             ) : (
               <RichText className={subheadClasses} text={subhead} />
             ))}
-            {bodyText &&
+          {bodyText &&
             (textMode === 'html' ? (
               <div className={bodyTextClasses}>
                 <SanitizedHTML

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -30,6 +30,12 @@
           "$ref": "app:vtex.native-types#/definitions/text",
           "default": ""
         },
+        "bodyText": {
+          "title": "admin/editor.info-card.body-text.title",
+          "description": "admin/editor.info-card.body-text.description",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": ""
+        },
         "callToActionMode": {
           "default": "button",
           "type": "string",


### PR DESCRIPTION
#### What problem is this solving?

A new text field is added to the infocard called “bodyText”.

#### How to test it?

https://infocard--eobando.myvtex.com/

#### Screenshots or example usage:

<img width="1440" alt="Captura de pantalla 2024-06-06 a la(s) 1 24 17 p  m" src="https://github.com/vtex-apps/store-components/assets/26680887/e8070a59-4e1f-4cd1-bec6-8e1ac333fb62">

```json
{
        "info-card#home": {
            "props": {
                  "id": "info-card-home",
                  "isFullModeStyle": false,
                  "textPosition": "left",
                  "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/banner-infocard2.png",
                  "headline": "Clearance Sale",
                  "subhead": "Clearance Sale subhead",
                  "bodyText": "Clearance Sale bodyText",
                  "callToActionText": "DISCOVER",
                  "callToActionUrl": "/sale/d",
                  "blockClass": "info-card-home",
                  "textAlignment": "center"
            }
      }
}
```

#### How does this PR make you feel? 

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmV2a2FlYXI3Ynp1cnRsY3Y1Z3dhNjFjY2JvMTl3ZGpkb2g0cWM5cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5qZEZ0rTln9581K7Q5/giphy.gif)
