### PR TITLE
Fix: brand route on product brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Issue with brand link on `ProductBrand` component.
+
 ## [3.175.0] - 2024-08-15
 
 ### Added

--- a/react/components/ProductBrand/ProductBrandName.tsx
+++ b/react/components/ProductBrand/ProductBrandName.tsx
@@ -14,7 +14,7 @@ function ProductBrandName({ brandName, withLink, slug }: Props) {
   const { handles } = useProductBrandCssHandles()
 
   if (withLink && slug) {
-    const nameLink = `/${slug}/b`
+    const nameLink = `/${slug}`
 
     return (
       <a


### PR DESCRIPTION
#### What problem is this solving?

The `ProductBrand` component was returning a `brand` route with the `/b` suffix, which should no longer be used. This was providing users with access to a broken brand link. The solution was to remove the incorrect/deprecated suffix.

#### How to test it?

1. Access a PDP ([example PDP](https://vsseixaso--rougemaison.myvtex.com/vaso-la-majorelle-250-ml-h51131032/p))
2. Click on the brand displayed for the product (in this case, *Pip Studio*)
3. The brand's PLP should load correctly ([example PLP](https://vsseixaso--rougemaison.myvtex.com/pip-studio))

#### Screenshots or example usage:

[[*Before*]](https://rougemaison.myvtex.com/vaso-la-majorelle-250-ml-h51131032/p)

Brand link with `/b` on the PDP
![pdp-master](https://github.com/user-attachments/assets/066f8dc3-66f1-4e8a-87d5-eefe7f092d5b)

Brand PLP did not load correctly
![Screenshot 2024-09-10 at 4 01 28 PM](https://github.com/user-attachments/assets/15749874-4e52-4819-bfb8-6dc8a1b287fd)

[[*After*]](https://vsseixaso--rougemaison.myvtex.com/vaso-la-majorelle-250-ml-h51131032/p)

Brand link without `/b` on the PDP
![pdp-vsseixaso](https://github.com/user-attachments/assets/12299e47-209b-4212-bef3-a26a67e70224)

Brand PLP loaded correctly
![Screenshot 2024-09-10 at 4 05 32 PM](https://github.com/user-attachments/assets/6aafc4f8-eea9-48ae-ae5a-bfef117754bc)

#### Related to / Depends on

This PR is a fix related to the [Ticket](https://vtexhelp.zendesk.com/agent/tickets/1093817) on Zendesk.

#### How does this PR make you feel?

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmJkZDljMGNhOW1wYWR4eHJzYmNheG9hcHV5cDN6YWh2d3Bvazd2NCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WYyvz9PIhjLHgiyvR2/giphy.gif)