### PR TITLE
fix typo in portuguese message

### DIFF
--- a/messages/pt.json
+++ b/messages/pt.json
@@ -146,7 +146,7 @@
   "admin/editor.image.title.title": "Título da imagem",
   "admin/editor.image.title.description": "Título a ser mostrado ao passar o mouse pela imagem",
   "admin/editor.image.alt.title": "Texto alternativo",
-  "admin/editor.product-images.title": "Imagems do produto",
+  "admin/editor.product-images.title": "Imagens do produto",
   "admin/editor.product-images.description": "Componente que permite personalizar as propriedades das imagens do produto",
   "admin/editor.product-images.zoomOptions.title": "Opções de zoom",
   "admin/editor.product-images.zoomType.title": "Tipo de zoom",


### PR DESCRIPTION
#### What problem is this solving?

This PR fix a single typo on the Portuguese messages of the site editor/admin.

#### How to test it?
Select the product images block.
[Workspace](https://productimagesarrow--novaikesaki.myvtex.com/admin/cms/site-editor/nivea-locao-deo-hidratante-corporal-milk-hidratacao-profunda-400ml/p)

#### Screenshots or example usage:
### Before
![Captura de tela 2024-09-19 154624](https://github.com/user-attachments/assets/c3e4f3d2-8bfa-4ca5-9b02-4441f1ea241b)

### After
![Captura de tela 2024-09-19 155841](https://github.com/user-attachments/assets/bb853629-b28e-41ae-973a-6f071283f513)
