### PR TITLE
Feature/pdp fetch priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added `fetchpriority: 'high'` for the first product image to prioritize loading of the main image and improve page load performance.
+
 - Added the ability to configure the width and height for product thumbnails in the carousel component. Improved page performance and SEO by ensuring appropriate image sizes are used, reducing unnecessary data load.
 
 ## [3.175.1] - 2024-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added the ability to configure the width and height for product thumbnails in the carousel component. Improved page performance and SEO by ensuring appropriate image sizes are used, reducing unnecessary data load.
+
 ## [3.175.1] - 2024-09-11
 
 ### Fixed

--- a/react/components/ProductImages/Wrapper.js
+++ b/react/components/ProductImages/Wrapper.js
@@ -16,6 +16,8 @@ const ProductImagesWrapper = props => {
     showPaginationDots,
     contentOrder,
     placeholder,
+    thumbCustomWidth,
+    thumbCustomHeight,
   } = useResponsiveValues(
     pick(
       [
@@ -25,6 +27,8 @@ const ProductImagesWrapper = props => {
         'showPaginationDots',
         'contentOrder',
         'placeholder',
+        'thumbCustomWidth',
+        'thumbCustomHeight',
       ],
       props
     )
@@ -93,6 +97,8 @@ const ProductImagesWrapper = props => {
       ModalZoomElement={props.ModalZoom}
       contentType={props.contentType}
       showImageLabel={props.showImageLabel}
+      thumbCustomWidth={thumbCustomWidth}
+      thumbCustomHeight={thumbCustomHeight}
       // Deprecated
       zoomProps={props.zoomProps}
       displayMode={props.displayMode}

--- a/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
+++ b/react/components/ProductImages/components/Carousel/ThumbnailSwiper.js
@@ -22,7 +22,15 @@ const CSS_HANDLES = [
 ]
 
 const Thumbnail = props => {
-  const { alt, isVideo, thumbUrl, handles, aspectRatio = 'auto' } = props
+  const {
+    alt,
+    isVideo,
+    thumbUrl,
+    handles,
+    aspectRatio = 'auto',
+    thumbCustomWidth,
+    thumbCustomHeight,
+  } = props
 
   return (
     <>
@@ -39,7 +47,14 @@ const Thumbnail = props => {
           )} w-100 h-auto db`}
           itemProp="thumbnail"
           alt={alt}
-          src={imageUrl(thumbUrl, THUMB_SIZE, THUMB_MAX_SIZE, aspectRatio)}
+          src={imageUrl(
+            thumbUrl,
+            THUMB_SIZE,
+            THUMB_MAX_SIZE,
+            aspectRatio,
+            thumbCustomWidth,
+            thumbCustomHeight
+          )}
         />
       </figure>
       <div
@@ -67,6 +82,8 @@ const ThumbnailSwiper = props => {
     thumbnailAspectRatio,
     thumbnailMaxHeight,
     displayThumbnailsArrows,
+    thumbCustomWidth,
+    thumbCustomHeight,
     ...swiperProps
   } = props
 
@@ -151,9 +168,6 @@ const ThumbnailSwiper = props => {
         touchRatio={1}
         threshold={8}
         navigation={navigationConfig}
-        /* Slides are grouped when thumbnails arrows are enabled
-         * so that clicking on next/prev will scroll more than
-         * one thumbnail */
         slidesPerGroup={displayThumbnailsArrows ? 4 : 1}
         freeMode={false}
         mousewheel={false}
@@ -183,6 +197,8 @@ const ThumbnailSwiper = props => {
                 alt={slide.alt}
                 thumbUrl={slide.thumbUrl || thumbUrls[i]}
                 aspectRatio={thumbnailAspectRatio}
+                thumbCustomWidth={thumbCustomWidth}
+                thumbCustomHeight={thumbCustomHeight}
               />
             </SwiperSlide>
           )

--- a/react/components/ProductImages/components/Carousel/index.js
+++ b/react/components/ProductImages/components/Carousel/index.js
@@ -249,6 +249,8 @@ class Carousel extends Component {
       showNavigationArrows = true,
       thumbnailVisibility,
       displayThumbnailsArrows = false,
+      thumbCustomWidth,
+      thumbCustomHeight,
     } = this.props
 
     const hasSlides = slides && slides.length > 0
@@ -325,6 +327,8 @@ class Carousel extends Component {
         displayThumbnailsArrows={displayThumbnailsArrows}
         slides={slides}
         position={position}
+        thumbCustomWidth={thumbCustomWidth}
+        thumbCustomHeight={thumbCustomHeight}
       />
     )
 
@@ -414,6 +418,8 @@ Carousel.propTypes = {
     THUMBS_VISIBILITY.VISIBLE,
     THUMBS_VISIBILITY.HIDDEN,
   ]),
+  thumbCustomWidth: PropTypes.number,
+  thumbCustomHeight: PropTypes.number,
 }
 
 export default withCssHandles(CSS_HANDLES)(Carousel)

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -107,6 +107,7 @@ const ProductImage: FC<Props> = ({
             alt={alt}
             title={alt}
             loading={index === 0 ? 'eager' : 'lazy'}
+            {...((index === 0 ? { fetchpriority: 'high' } : {}) as any)}
             // WIP
             // The value of the "sizes" attribute means: if the window has at most 64.1rem of width,
             // the image will be of a width of 100vw. Otherwise, the

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -35,6 +35,8 @@ const ProductImages = ({
   zoomFactor,
   ModalZoomElement,
   contentType = 'all',
+  thumbCustomWidth,
+  thumbCustomHeight,
   // Deprecated
   zoomProps,
   displayMode,
@@ -152,6 +154,8 @@ const ProductImages = ({
         thumbnailsOrientation={thumbnailsOrientation}
         displayThumbnailsArrows={displayThumbnailsArrows}
         thumbnailVisibility={thumbnailVisibility}
+        thumbCustomWidth={thumbCustomWidth}
+        thumbCustomHeight={thumbCustomHeight}
         // Deprecated
         zoomProps={zoomProps}
       />

--- a/react/components/ProductImages/utils/aspectRatioUtil.tsx
+++ b/react/components/ProductImages/utils/aspectRatioUtil.tsx
@@ -44,30 +44,33 @@ export const imageUrl = (
   src: string,
   size: number,
   maxSize: number,
-  aspectRatio?: AspectRatio
+  aspectRatio?: AspectRatio,
+  customWidth?: number,
+  customHeight?: number
   // eslint-disable-next-line max-params
 ) => {
-  let width = size
-  let height: number | string = 'auto'
+  let width = customWidth || size
+  let height: number | string = customHeight || 'auto'
 
-  if (aspectRatio && aspectRatio !== 'auto') {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    height = size * (parseAspectRatio(aspectRatio) || 1)
+  if (!customWidth || !customHeight) {
+    if (aspectRatio && aspectRatio !== 'auto') {
+      height = size * (parseAspectRatio(aspectRatio) || 1)
 
-    if (width > maxSize) {
-      height /= width / maxSize
-      width = maxSize
+      if (width > maxSize) {
+        height /= width / maxSize
+        width = maxSize
+      }
+
+      if (height > maxSize) {
+        width /= height / maxSize
+        height = maxSize
+      }
+
+      width = Math.round(width)
+      height = Math.round(height)
+    } else {
+      width = Math.min(maxSize, width)
     }
-
-    if (height > maxSize) {
-      width /= height / maxSize
-      height = maxSize
-    }
-
-    width = Math.round(width)
-    height = Math.round(height)
-  } else {
-    width = Math.min(maxSize, width)
   }
 
   return changeImageUrlSize(src, width, height)


### PR DESCRIPTION
#### What problem is this solving?

This change improves page performance by ensuring the main product image is prioritized during loading. By setting the fetchpriority: 'high' for the first product image, we ensure that the most important image (usually the first one) is loaded first, enhancing user experience, especially for pages with multiple images.

#### How to test it?

You can test this change by visiting the following workspace where the branch is linked. Check the loading behavior of the first product image, ensuring it is loaded before others when opening a product page.

[[Workspace](https://pr1189--italiaonlineqa.myvtex.com)](Link goes here!)

#### Screenshots or example usage:

<img width="1490" alt="Screenshot 2024-10-16 alle 19 57 52" src="https://github.com/user-attachments/assets/89d4a6aa-c5e1-401a-a979-b145bb16f496">

#### Describe alternatives you've considered, if any.

No alternatives considered as fetchpriority: 'high' is a straightforward and effective solution for this problem.
