### PR TITLE
Fix sortVariationsByLabel logic

### DIFF
--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -282,8 +282,8 @@ const variationNameToDisplayVariation =
 
     if (sortVariationsByLabel) {
       const allNumbers = options.every(
-        (option: any) => !Number.isNaN(option.label)
-      )
+        (option: any) => !isNaN(Number(option.label))
+      );
 
       options.sort((a: any, b: any) => {
         if (allNumbers) {


### PR DESCRIPTION
Se option.label não é um número, Number.isNaN(option.label) retorna false, e o operador ! inverte isso para true. Portanto, qualquer valor não numérico ou válido será considerado "não-NaN" e fará o teste every retornar true indevidamente.

A lógica foi alterada para !isNaN(Number(option.label)

#### What problem is this solving?

A prop sortVariationsByLabel não estava funcional

#### How to test it?

Set the prop sortVariationsByLabel on sku-selector block to true

#### Screenshots or example usage:

Before
https://hanesdev--hanes.myvtex.com/0mhb005/p?skuId=180

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/3fe51f23-a309-4ed4-b5c8-576194a1cf77" />

After

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/69dc78be-db77-45a9-ba40-12b7c123f94c" />


#### How does this PR make you feel? [:link:](http://giphy.com/)

![https://giphy.com/gifs/dont-understand-rousseenragee-toutfeutoutcam-rHNCLQk0wDTjEUXRw0]
