### PR TITLE
[SFS-2085] refactor: sortVariationsByLabel logic when not numbers and redability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Fully refactor of `sortVariationsByLabel` property
+
 ## [3.176.1] - 2024-11-08
 
 ## [3.176.0] - 2024-11-06

--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -46,6 +46,7 @@ function getShowValueForVariation(
   )
 }
 
+
 interface Props {
   seeMoreLabel: string
   maxItems: number
@@ -82,6 +83,18 @@ function isSkuAvailable(item?: SelectorProductItem) {
   }
 
   return seller.commertialOffer?.AvailableQuantity > 0
+}
+
+function sortOptionsNumerically(options: DisplayOption[]) {
+  return options.slice().sort((a, b) => parseFloat(a.label) - parseFloat(b.label));
+}
+
+function sortOptionsAlphabetically(options: DisplayOption[]) {
+  return options.slice().sort((a, b) => {
+    if (a.label < b.label) return -1;
+    if (a.label > b.label) return 1;
+    return 0;
+  });
 }
 
 const showItemAsAvailable = ({
@@ -265,7 +278,7 @@ const variationNameToDisplayVariation =
   (variationName: string): DisplayVariation => {
     const name = variationName
     const { values, originalName } = variations[variationName]
-    const options = values
+    let options = values
       .map(
         parseOptionNameToDisplayOption({
           selectedVariations,
@@ -279,19 +292,20 @@ const variationNameToDisplayVariation =
         })
       )
       .filter(Boolean) as DisplayOption[]
+      
 
     if (sortVariationsByLabel) {
-      const allNumbers = options.every(
-        (option: any) => !Number.isNaN(option.label)
+
+      const areAllNumbers = options.every(
+        (option: DisplayOption) => !isNaN(Number(option.label))
       )
 
-      options.sort((a: any, b: any) => {
-        if (allNumbers) {
-          return a.label - b.label
-        }
+      const sortedOptions = areAllNumbers
+      ? sortOptionsNumerically({...options})
+      : sortOptionsAlphabetically({...options});
 
-        return a.label < b.label ? -1 : a.label > b.label ? 1 : 0
-      })
+      options = {...sortedOptions}
+
     }
 
     return { name, originalName, options }

--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -85,13 +85,11 @@ function isSkuAvailable(item?: SelectorProductItem) {
 }
 
 function sortOptionsNumerically(options: DisplayOption[]) {
-  return options
-    .slice()
-    .sort((a, b) => parseFloat(a.label) - parseFloat(b.label))
+  return options.sort((a, b) => parseFloat(a.label) - parseFloat(b.label))
 }
 
 function sortOptionsAlphabetically(options: DisplayOption[]) {
-  return options.slice().sort((a, b) => {
+  return options.sort((a, b) => {
     if (a.label < b.label) return -1
     if (a.label > b.label) return 1
 

--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -46,7 +46,6 @@ function getShowValueForVariation(
   )
 }
 
-
 interface Props {
   seeMoreLabel: string
   maxItems: number
@@ -86,15 +85,18 @@ function isSkuAvailable(item?: SelectorProductItem) {
 }
 
 function sortOptionsNumerically(options: DisplayOption[]) {
-  return options.slice().sort((a, b) => parseFloat(a.label) - parseFloat(b.label));
+  return options
+    .slice()
+    .sort((a, b) => parseFloat(a.label) - parseFloat(b.label))
 }
 
 function sortOptionsAlphabetically(options: DisplayOption[]) {
   return options.slice().sort((a, b) => {
-    if (a.label < b.label) return -1;
-    if (a.label > b.label) return 1;
-    return 0;
-  });
+    if (a.label < b.label) return -1
+    if (a.label > b.label) return 1
+
+    return 0
+  })
 }
 
 const showItemAsAvailable = ({
@@ -292,20 +294,17 @@ const variationNameToDisplayVariation =
         })
       )
       .filter(Boolean) as DisplayOption[]
-      
 
     if (sortVariationsByLabel) {
-
       const areAllNumbers = options.every(
-        (option: DisplayOption) => !isNaN(Number(option.label))
+        (option: DisplayOption) => !Number.isNaN(Number(option.label))
       )
 
       const sortedOptions = areAllNumbers
-      ? sortOptionsNumerically({...options})
-      : sortOptionsAlphabetically({...options});
+        ? sortOptionsNumerically({ ...options })
+        : sortOptionsAlphabetically({ ...options })
 
-      options = {...sortedOptions}
-
+      options = { ...sortedOptions }
     }
 
     return { name, originalName, options }

--- a/react/components/SKUSelector/components/SKUSelector.tsx
+++ b/react/components/SKUSelector/components/SKUSelector.tsx
@@ -299,10 +299,10 @@ const variationNameToDisplayVariation =
       )
 
       const sortedOptions = areAllNumbers
-        ? sortOptionsNumerically({ ...options })
-        : sortOptionsAlphabetically({ ...options })
+        ? sortOptionsNumerically([...options])
+        : sortOptionsAlphabetically([...options])
 
-      options = { ...sortedOptions }
+      options = [...sortedOptions]
     }
 
     return { name, originalName, options }


### PR DESCRIPTION
#### What problem is this solving?

Initially, the condition `!Number.isNaN(option.label)` was used to check if option.label is a number. However, this approach had a flaw. When `option.label` is not a number, `Number.isNaN(option.label)` returns false, and the ! operator inverts this to true. As a result, any non-numeric or invalid value would be incorrectly considered "non-NaN", causing the every test to return true falsely.

To address this issue, the logic was revised to [!Number.isNaN(Number(option.label))](https://github.com/airbnb/javascript#standard-library--isnan). This change ensures that only numeric values are considered valid, preventing incorrect results in the every test."

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Before](https://hanesdev--hanes.myvtex.com/0mhb005/p?skuId=180)

<img width="309" alt="image" src="https://github.com/user-attachments/assets/3cc29a20-c20f-4fb8-abd2-4704bc10b3c6" />

[After](https://iespinoza--hanes.myvtex.com/0mhb005/p?skuId=180)

<img width="309" alt="image" src="https://github.com/user-attachments/assets/0a6e6d41-b2d2-4055-b168-449c25b7498c" />


#### Related to / Depends on

It closes the PR: https://github.com/vtex-apps/store-components/pull/1127

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExNGd4aHYyejBwc2dmeGt0bWUzOWttMmJ6aGQ2bDRidnRxMnhscTl4MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0HlW67FubB1d2GJi/giphy.gif)
