### PR TITLE
[SFS-2196] update extractVideoID function to recognize url in shorts format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Youtube shorts as a valid format
+
 ## [3.176.2] - 2025-02-03
 
 ### Changed

--- a/react/components/ProductImages/components/Video/Youtube.js
+++ b/react/components/ProductImages/components/Video/Youtube.js
@@ -25,15 +25,15 @@ class Youtube extends Component {
 
   static extractVideoID = url => {
     const regExp =
-      /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/
-
+      /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?)|(shorts\/))\??v?=?([^#&?]*).*/
+  
     const match = url.match(regExp)
-
-    if (match && match[7].length === 11) return match[7]
-
+  
+    if (match && match[8].length === 11) return match[8]
+  
     return null
   }
-
+  
   executeCommand = command => () => {
     if (!this.frameReady) return
 

--- a/react/components/ProductImages/components/Video/Youtube.js
+++ b/react/components/ProductImages/components/Video/Youtube.js
@@ -26,14 +26,14 @@ class Youtube extends Component {
   static extractVideoID = url => {
     const regExp =
       /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?)|(shorts\/))\??v?=?([^#&?]*).*/
-  
+
     const match = url.match(regExp)
-  
+
     if (match && match[8].length === 11) return match[8]
-  
+
     return null
   }
-  
+
   executeCommand = command => () => {
     if (!this.frameReady) return
 


### PR DESCRIPTION
#### What problem is this solving?

Since this component's last update, YouTube has also started using videos in the shorts format. This PR aims to update the regEx of the extractVideoID function to recognize videos in this format as well.

#### How to test it?

Accessing a PDP in which the video was added to the catalog in shorts format, when analyzing the document it is seen that the video link is not created correctly

[https://video--gramplinebb.myvtex.com/tinta-para-pincel-quadro-branco-20ml-qb-20-6-frascos/p](https://video--gramplinebb.myvtex.com/tinta-para-pincel-quadro-branco-20ml-qb-20-6-frascos/p)

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/f97d74bd-c1cc-472f-ae03-cd2959d1e52e" />

#### Screenshots or example usage:

After regEx the update:

[https://juliabraz--gramplinebb.myvtex.com/tinta-para-pincel-quadro-branco-20ml-qb-20-6-frascos/p](https://juliabraz--gramplinebb.myvtex.com/tinta-para-pincel-quadro-branco-20ml-qb-20-6-frascos/p)

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/479f06a3-432e-44ae-abe3-53d3330b3557" />

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExazRvZTJ4bWZiczYzM2hoYzcxY3p6c2hpdG90a2EzNnVqYThjNXpsbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/U2RhNiWPNyhc8dtCeZ/giphy.gif)
