### PR TITLE
Fixed Product brand logo link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Product brand logo link
+
 ## [3.178.2] - 2025-07-22
 
 ### Added

--- a/react/ProductBrand.tsx
+++ b/react/ProductBrand.tsx
@@ -214,7 +214,7 @@ function ProductBrand({
   }
 
   const dpi = window?.devicePixelRatio ?? 1
-  const logoLink = `/${slug}/b`
+  const logoLink = `/${slug}`
 
   const logoImageSrc = changeImageUrlSize({
     imageUrl: `/arquivos/ids${imageUrl}`,


### PR DESCRIPTION
#### What problem is this solving?

When you have a Brand Logo with Link it goes to incorrect link `/${slug}/b` and lands in a 404 page. The correct link should be `/${slug}`

#### How to test it?

[Workspace Before](https://danielbrandbefore--fstudio.myvtex.com/sony-a7-iv-body-mirrorless/p)
[Workspace After](https://danielbrand--fstudio.myvtex.com/sony-a7-iv-body-mirrorless/p)

#### Screenshots or example usage:

Before Image

<img width="1179" height="1132" alt="image" src="https://github.com/user-attachments/assets/1051f058-4987-43b6-8695-b1ebc3286d43" />



After Image

<img width="1175" height="1127" alt="image" src="https://github.com/user-attachments/assets/f860efbd-02bc-440f-a669-722234122408" />


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)