### PR TITLE
improve the loading performance of the first product image on PDP

### DIFF
--- a/docs/ProductImages.md
+++ b/docs/ProductImages.md
@@ -121,6 +121,13 @@ The following table shows the props allowed by `product-images.high-quality-imag
 | `zoomFactor`  | `number`   | Sets how much the zoom increases the image size (for example, `2` will make the zoomed-in image twice as large).                                                                                                                                                                                                                                                | `2`           |
 | `zoomMode`    | `enum`     | Sets the zoom behavior for the `product-images.high-quality-image` block. Possible values are `disabled` (no zoom), `in-place-click` (zoom on click), and `in-place-hover` (zoom on hover). Unlike the `store-images` prop, this one doesn’t accept the `open-modal` value.   | `disabled`    |
 
+### Image preload for performance
+
+To improve the loading performance of the first product image on the Product Details Page, the `product-images` block includes a `<link rel="preload">` tag using [Helmet](https://www.npmjs.com/package/react-helmet), when the image has `index === 0`.
+
+This automatically adds the following tag to the page `<head>`:
+`in html: <link rel="preload" as="image" href="..." />`
+
 ## Customization
 
 To apply CSS customizations to this and other blocks, see the guide [Using CSS handles for store customization](https://developers.vtex.com/docs/guides/vtex-io-documentation-using-css-handles-for-store-customization).

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useMemo, useRef } from 'react'
 import { Modal } from 'vtex.modal-layout'
+import { Helmet } from 'vtex.render-runtime'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import Zoomable, { ZoomMode } from './Zoomable'
@@ -60,6 +61,11 @@ const ProductImage: FC<Props> = ({
 
   return (
     <ProductImageContext.Provider value={imageContext}>
+      <Helmet>
+        {index === 0 && (
+          <link rel="preload" as="image" href={imageUrl(src, DEFAULT_SIZE, MAX_SIZE, aspectRatio)} />
+        )}
+      </Helmet>
       <div className={handles.productImage}>
         {imageLabel && (
           <div className={`tc ${handles.productImageLabel}`}>{imageLabel}</div>


### PR DESCRIPTION
#### What problem is this solving?

This change improves the loading performance of product images by preloading the main product image via a <link rel="preload" as="image" /> tag in the ProductImage component. It ensures that the primary image is fetched earlier in the page load process, reducing time-to-visual-complete and enhancing user experience, particularly on slower connections.

#### How to test it?

You can test this by checking the network activity in the browser’s developer tools. The main product image should be listed as a preloaded resource, and the page should render the image faster compared to the previous behavior.

[Workspace](https://pr1189--italiaonlineqa.myvtex.com/outsunny-dondolo-da-giardino-3-posti-in-rattan-pe-e-metallo-con-tettuccio-e-cuscini-sfoderabili-198x124x179cm-marrone-22262/p)

#### Screenshots or example usage:
<img width="1485" alt="Screenshot 2024-10-17 alle 16 58 09" src="https://github.com/user-attachments/assets/ce930129-8817-44c2-8d95-1665c6e994a1">