### PR TITLE
fix: changed alt in ProductImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Changed alt attribute in `ProductImages` for SEO improvement
+
 ## [3.178.2] - 2025-07-22
 
 ### Added

--- a/react/components/ProductImages/index.js
+++ b/react/components/ProductImages/index.js
@@ -65,7 +65,7 @@ const ProductImages = ({
           .map(image => ({
             type: 'image',
             url: image.imageUrls ? image.imageUrls[0] : image.imageUrl,
-            alt: image.imageText,
+            alt: image.imageLabel,
             thumbUrl: image.thumbnailUrl || image.imageUrl,
             ...(showImageLabel && { imageLabel: image.imageLabel }),
           }))


### PR DESCRIPTION
#### What problem is this solving?

Adjusted alt and title attributes in the productImages component to improve SEO.

#### How to test it?

[Workspace](https://ombrec1422--lojaobramax.myvtex.com/martelete-perfurador-rompedor-sds-plus-800w-27j-hr2470-220v-makita-89221293/p)

#### Screenshots or example usage:

Before
<img width="1099" height="251" alt="image" src="https://github.com/user-attachments/assets/356a786d-c940-42d6-ba42-29fc8122de8c" />

After
<img width="985" height="212" alt="image" src="https://github.com/user-attachments/assets/f76c0b72-4f20-4094-a7f3-86a3fe9c01f1" />


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
