### PR TITLE
fix: Added fetchPriority and removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Added fetchPriority and removed `data-vtex-preload` attribute in the `ProductImage` component.
+
 ## [3.178.2] - 2025-07-22
 
 ### Added

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -106,7 +106,7 @@ const ProductImage: FC<Props> = ({
             alt={alt}
             title={alt}
             loading={index === 0 ? 'eager' : 'lazy'}
-            fetchPriority={index === 0 ? 'high' : undefined}
+            {...(index === 0 && { fetchPriority: 'high' })}
             // WIP
             // The value of the "sizes" attribute means: if the window has at most 64.1rem of width,
             // the image will be of a width of 100vw. Otherwise, the

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -94,7 +94,6 @@ const ProductImage: FC<Props> = ({
         >
           <img
             ref={imageRef}
-            data-vtex-preload={index === 0 ? 'true' : 'false'}
             className={`${applyModifiers(handles.productImageTag, 'main')}`}
             style={{
               width: '100%',
@@ -107,6 +106,7 @@ const ProductImage: FC<Props> = ({
             alt={alt}
             title={alt}
             loading={index === 0 ? 'eager' : 'lazy'}
+            fetchPriority={index === 0 ? 'high' : 'low'}
             // WIP
             // The value of the "sizes" attribute means: if the window has at most 64.1rem of width,
             // the image will be of a width of 100vw. Otherwise, the

--- a/react/components/ProductImages/components/ProductImage.tsx
+++ b/react/components/ProductImages/components/ProductImage.tsx
@@ -106,7 +106,7 @@ const ProductImage: FC<Props> = ({
             alt={alt}
             title={alt}
             loading={index === 0 ? 'eager' : 'lazy'}
-            fetchPriority={index === 0 ? 'high' : 'low'}
+            fetchPriority={index === 0 ? 'high' : undefined}
             // WIP
             // The value of the "sizes" attribute means: if the window has at most 64.1rem of width,
             // the image will be of a width of 100vw. Otherwise, the

--- a/react/typings/jsx.d.ts
+++ b/react/typings/jsx.d.ts
@@ -3,5 +3,6 @@ import 'react'
 declare module 'react' {
   interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
     loading?: 'lazy' | 'eager' | 'auto'
+    fetchPriority?: 'high' | 'low' | 'auto'
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Adds fetchPriority to ProductImage to improve LCP, as recommended by PageSpeed Insights.
Removes data-vtex-preload to ensure fetchPriority takes effect.

#### How to test it?

[Workspace](https://ombrec1447--lojaobramax.myvtex.com/cimento-cpii-e-32-50kg-campeao-89535684/p)

#### Screenshots or example usage:

### **Before**
<img width="550" height="550" alt="image" src="https://github.com/user-attachments/assets/2de3c936-eb9c-401f-a8bc-edc0946c3c5a" />

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/34053bf5-b7b4-48fd-8572-a045f9e08c3e" />


### **After**
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/296b18df-43e7-4795-b1dd-141e03892e89" />



#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
