### PR TITLE
fix(ProductBrand): Correctly display "&" in brand names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Correctly display "&" in brand names
+
 ### Chore
 
 - lint errors

--- a/react/ProductBrand.tsx
+++ b/react/ProductBrand.tsx
@@ -76,6 +76,8 @@ const shouldExcludeBrand = (
   return false
 }
 
+const normalizeBrandName = (name?: string) => name?.replace(/&amp;/g, '&')
+
 const useBrandInfoProps = (
   brandName: string | undefined,
   brandId: number | undefined
@@ -84,10 +86,10 @@ const useBrandInfoProps = (
   const product = productContext?.product
 
   if ((brandName && brandId) || !product) {
-    return { brandName, brandId }
+    return { brandName: normalizeBrandName(brandName), brandId }
   }
 
-  return { brandName: product.brand, brandId: Number(product.brandId) }
+  return { brandName: normalizeBrandName(product.brand), brandId: Number(product.brandId) }
 }
 
 /**

--- a/react/ProductBrand.tsx
+++ b/react/ProductBrand.tsx
@@ -89,7 +89,9 @@ const useBrandInfoProps = (
     return { brandName: normalizeBrandName(brandName), brandId }
   }
 
-  return { brandName: normalizeBrandName(product.brand), brandId: Number(product.brandId) }
+  return { 
+    brandName: normalizeBrandName(product.brand), 
+    brandId: Number(product.brandId) }
 }
 
 /**


### PR DESCRIPTION
#### What problem is this solving?

Currently, if a brand name is registered in the catalog containing the HTML entity for the ampersand character (i.e., &amp;), the ProductBrand component renders this entity literally (e.g., "Brand &amp; Test") instead of displaying the correct character (e.g., "Brand & Test").

This also breaks the excludeBrands prop logic. If a store administrator configures "Brand & Test" for exclusion, the comparison fails because the value coming from the product context is "Brand &amp; Test".

This PR normalizes the brand name to resolve both display and exclusion logic issues.

#### How to test it?

1. Link this component version in a test store.
2. Choose a product and, in the catalog, change its brand name to include &amp;. (e.g., My &amp; Brand).
3. Go to that product's page on the storefront.
4. Configure the ProductBrand component (either on the product page or in a shelf) to use displayMode="text".
5. Expected Result (Before): The name appears as "My &amp; Brand".
6. Expected Result (After): The name appears correctly as "My & Brand".

#### Screenshots or example usage:

Before:
<img width="1510" height="787" alt="image" src="https://github.com/user-attachments/assets/d190b5c7-c8ed-44f8-adb3-781ad0b3010d" />

After:
<img width="1511" height="790" alt="image" src="https://github.com/user-attachments/assets/d42b9fdb-1eab-4fe8-b64d-380c309c15c1" />
