### PR TITLE
chore: STR-969 catalog platform-flow-id (Shopper#1, Shopper#2, Shopper#4)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex-apps/store-components
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: Shopper#1,Shopper#2,Shopper#4
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: DDULY6N1
 spec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Chore
+### Changed
 
-- lint errors
-- tests fix
+- Update DK Catalog platform-flow-id
 
 ## [3.178.5] - 2025-10-13
 


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` to match the **Platform Flows (Dark Kitchen)** classification for this component (initiative STR-969).

## Change

| Annotation | Value |
|------------|-------|
| `vtex.com/platform-flow-id` | `Shopper#1,Shopper#2,Shopper#4` |

**Convention:** multiple DK IDs are **comma-separated with no spaces**.

## Classification context (source artifact)

The following summary is taken from the internal classification table (Portuguese) used for STR-969:

> **Biblioteca:** componentes shelf, buy button, newsletter, etc. **Decisão:** README/docs: superfícies de descoberta e compra → **Shopper#1**, **Shopper#2**; buy button aproxima do checkout (**Shopper#4**).

## Changelog

- `CHANGELOG.md` — **[Unreleased]** → **Changed**: Update DK Catalog platform-flow-id


---

Reviewers: @vmourac-vtex @iago1501
